### PR TITLE
[Core] Resolve REPO_ROOT to the pnpm workspace root

### DIFF
--- a/packages/core/src/shared/constants.test.ts
+++ b/packages/core/src/shared/constants.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { REPO_ROOT, configPath } from "./constants.js";
+
+describe("REPO_ROOT resolves to the pnpm workspace root", () => {
+  it("points at the directory containing pnpm-workspace.yaml", () => {
+    expect(fs.existsSync(path.join(REPO_ROOT, "pnpm-workspace.yaml"))).toBe(true);
+  });
+
+  it("configPath resolves to <root>/config, not packages/core/config", () => {
+    expect(configPath("user-config.json")).toBe(
+      path.join(REPO_ROOT, "config", "user-config.json"),
+    );
+    expect(configPath("user-config.json")).not.toContain("packages/core/config");
+  });
+});

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -1,10 +1,26 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-/** Absolute path to the repository root (one level above src/). */
-export const REPO_ROOT: string = path.resolve(
+/**
+ * Walk up from the given directory until we find the monorepo root,
+ * identified by the presence of pnpm-workspace.yaml. Falls back to the
+ * previous heuristic (two levels above this file) if no marker is found.
+ */
+function findRepoRoot(startDir: string): string {
+  let dir = startDir;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(startDir, "../..");
+}
+
+/** Absolute path to the repository root (the pnpm workspace root). */
+export const REPO_ROOT: string = findRepoRoot(
   path.dirname(fileURLToPath(import.meta.url)),
-  "../..",
 );
 
 /** Resolve a path relative to the repository root. */


### PR DESCRIPTION
## Summary

`REPO_ROOT` in `packages/core/src/shared/constants.ts` resolved to `packages/core` instead of the repo root, because the `../..` heuristic missed the `packages/core` monorepo nesting. Consequently `configPath` / `dataPath` / `logsDir` pointed at `packages/core/{config,data,logs}`, so the repo-root `config/user-config.json` was **never loaded** and orphaned `packages/core/*` dirs were created.

- `findRepoRoot()` now walks up from the module directory until it finds `pnpm-workspace.yaml` (falling back to the old `../..` heuristic if no marker is found). Works from both `src/` and `dist/`.
- Added a regression test asserting `REPO_ROOT` contains `pnpm-workspace.yaml` and `configPath("user-config.json")` resolves to `<root>/config/...`, not `packages/core/config/...`.

Closes #3

## Testing Plan

- [x] **Manual: path resolution** — `configPath("user-config.json")` resolves to the repo-root `config/user-config.json` (verified it exists there).
- [x] **Edge case: dist build** — walk-up logic is depth-independent, so it also resolves correctly from `packages/core/dist/...`.
- [x] **Edge case: no marker** — falls back to the previous `../..` heuristic.
- [x] **CI: TypeScript check** — `pnpm -r run typecheck` passes.
- [x] **CI: Tests** — `vitest run` green (constants.test.ts).

## Note

After merging, the orphaned `packages/core/{config,data,logs}` dirs (created by buggy runs) should be removed; they are no longer referenced. `data/` and `logs/` there are gitignored; `packages/core/config/` is not.