### PR TITLE
[Deploy] Point pm2 entrypoint at packages/daemon/dist/Daemon.js

### DIFF
--- a/config/ecosystem.config.cjs
+++ b/config/ecosystem.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
   apps: [
     {
       name: "meridian",
-      script: path.join(repoRoot, "dist/interfaces/Daemon.js"),
+      script: path.join(repoRoot, "packages/daemon/dist/Daemon.js"),
       cwd: repoRoot,
       interpreter: "node",
       instances: 1,


### PR DESCRIPTION
## Summary

`config/ecosystem.config.cjs` ran `dist/interfaces/Daemon.js` at the repo root — a stale pre-monorepo-refactor build (timestamp Jul 12 12:32). After the `ccb0da3` workspace restructure the daemon compiles to `packages/daemon/dist/Daemon.js`, and `pnpm -r run build` only writes `packages/*/dist`.

Because pm2 executed the old build, `src/` fixes never reached the running service. Symptom reported: after restarting the service it recreated `packages/core/{config,data}` instead of using repo-root dirs — the stale binary still resolved `REPO_ROOT` to `packages/core`.

- Point `script` at `packages/daemon/dist/Daemon.js` (matches `package.json` `main`).
- Removed the orphaned root `dist/` (gitignored pre-refactor leftover).

Closes #5

## Testing Plan

- [x] **Manual: build output** — `packages/daemon/dist/Daemon.js` exists and `require("@meridian/core")` resolves into `packages/core/dist`, which contains the `REPO_ROOT` fix (`findRepoRoot` walk-up to `pnpm-workspace.yaml`).
- [x] **Manual: stale path removed** — root `dist/interfaces/Daemon.js` no longer exists.
- [x] **CI: TypeScript check** — `pnpm -r run typecheck` passes (only a deployment-config file changed).

## Deploy note

After merging, restart the daemon so pm2 re-reads the entrypoint:
`pm2 delete meridian && npm run pm2:start` (a plain `pm2 restart` keeps the old script path).