### PR TITLE
[State] Backfill on-chain positions the agent didn't deploy during sync

### DIFF
--- a/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
+++ b/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
@@ -23,6 +23,7 @@ import {
   getTrackedPosition,
   minutesOutOfRange,
   syncOpenPositions,
+  reconcileTrackedPositions,
 } from "../../domain/state.js";
 import { recordPerformance } from "../../domain/lessons.js";
 import { isBaseMintOnCooldown, isPoolOnCooldown } from "../../domain/pool-memory.js";
@@ -1183,6 +1184,7 @@ export async function getMyPositions({ force = false, silent = false, wallet_add
         const rpcResult = await computePositions(walletAddress);
         if (useLocalWallet) {
           syncOpenPositions(rpcResult.positions.map((p: any) => p.position));
+          reconcileTrackedPositions(rpcResult.positions);
           _positionsCache = rpcResult;
           _positionsCacheAt = Date.now();
         }
@@ -1344,6 +1346,7 @@ export async function getMyPositions({ force = false, silent = false, wallet_add
     };
     if (useLocalWallet) {
       syncOpenPositions(positions.map(p => p.position));
+      reconcileTrackedPositions(positions);
       _positionsCache = result;
       _positionsCacheAt = Date.now();
     }

--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  reconcileTrackedPositions,
+  getTrackedPositions,
+  trackPosition,
+  syncOpenPositions,
+} from "./state.js";
+import { dataPath } from "../shared/constants.js";
+
+const STATE_FILE = dataPath("state.json");
+
+describe("reconcileTrackedPositions", () => {
+  beforeEach(() => {
+    if (fs.existsSync(STATE_FILE)) fs.unlinkSync(STATE_FILE);
+  });
+
+  it("imports an on-chain position the agent did not deploy", () => {
+    const added = reconcileTrackedPositions([
+      { position: "PosX", pool: "PoolA", pool_name: "TOKEN/SOL", lower_bin: 10, upper_bin: 20, fee_per_tvl_24h: 12.5, total_value_true_usd: 100 },
+    ]);
+    expect(added).toBe(1);
+    const tracked = getTrackedPositions(true);
+    expect(tracked).toHaveLength(1);
+    const pos = tracked[0]!;
+    expect(pos.position).toBe("PosX");
+    expect(pos.pool).toBe("PoolA");
+    expect(pos.strategy).toBe("imported");
+    expect(pos.bin_range).toEqual({ min: 10, max: 20 });
+    expect(pos.notes.join(" ")).toMatch(/Imported from on-chain/);
+  });
+
+  it("does not clobber an already-tracked position", () => {
+    trackPosition({
+      position: "PosY",
+      pool: "PoolB",
+      pool_name: "OTHER/SOL",
+      strategy: "bid_ask",
+      bin_range: { min: 1, max: 2 },
+      amount_sol: 0.1,
+      active_bin: 1,
+      bin_step: 100,
+      volatility: 1.2,
+      fee_tvl_ratio: 5,
+      organic_score: 80,
+      initial_value_usd: 50,
+    } as any);
+
+    const added = reconcileTrackedPositions([
+      { position: "PosY", pool: "PoolB", pool_name: "OTHER/SOL", lower_bin: 99, upper_bin: 99, fee_per_tvl_24h: 1 },
+    ]);
+    expect(added).toBe(0);
+    const tracked = getTrackedPositions(true);
+    expect(tracked).toHaveLength(1);
+    const pos = tracked[0]!;
+    expect(pos.strategy).toBe("bid_ask"); // original metadata preserved
+    expect(pos.bin_range).toEqual({ min: 1, max: 2 });
+  });
+
+  it("syncOpenPositions still closes positions missing on-chain", () => {
+    trackPosition({
+      position: "PosZ",
+      pool: "PoolC",
+      pool_name: "Z/SOL",
+      strategy: "bid_ask",
+      bin_range: { min: 1, max: 2 },
+      amount_sol: 0.1,
+      active_bin: 1,
+      bin_step: 100,
+      volatility: 1,
+      fee_tvl_ratio: 1,
+      organic_score: 70,
+      initial_value_usd: 50,
+    } as any);
+    // Older than SYNC_GRACE_MS so it is eligible for auto-close.
+    const state = JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+    state.positions.PosZ.deployed_at = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state));
+
+    syncOpenPositions(["PosY"]); // PosZ not in on-chain list
+    const tracked = getTrackedPositions(true);
+    expect(tracked.find((p) => p.position === "PosZ")).toBeUndefined();
+  });
+});

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -535,3 +535,69 @@ export function syncOpenPositions(active_addresses: string[]): void {
 
   if (changed) save(state);
 }
+
+/**
+ * Backfill state.json with on-chain positions the agent did not deploy itself
+ * (e.g. positions opened manually or via another tool). The sync command only
+ * prunes missing positions; this adds any live position not already tracked so
+ * the agent can monitor and manage it. Off-chain metadata (strategy, volatility,
+ * organic score, signal snapshot, entry market data) is unavailable for imported
+ * positions and is left as best-effort / null. Returns the number of positions added.
+ */
+export function reconcileTrackedPositions(livePositions: any[]): number {
+  if (!Array.isArray(livePositions) || livePositions.length === 0) return 0;
+  const state = load();
+  let added = 0;
+
+  for (const p of livePositions) {
+    const address = p?.position;
+    if (!address) continue;
+    // Already tracked (open or closed) — never clobber existing metadata.
+    if (state.positions[address]) continue;
+
+    state.positions[address] = {
+      position: address,
+      pool: p.pool || null,
+      pool_name: p.pool_name || null,
+      strategy: "imported",
+      bin_range: { min: p.lower_bin ?? null, max: p.upper_bin ?? null },
+      amount_sol: Number(p.amount_y ?? 0) || 0,
+      amount_x: Number(p.amount_x ?? 0) || 0,
+      active_bin_at_deploy: Number(p.active_bin) || 0,
+      bin_step: Number(p.bin_step) || 0,
+      volatility: 0,
+      fee_tvl_ratio: Number(p.fee_per_tvl_24h ?? 0) || 0,
+      initial_fee_tvl_24h: Number(p.fee_per_tvl_24h ?? 0) || 0,
+      organic_score: 0,
+      initial_value_usd: Number(p.total_value_true_usd ?? p.total_value_usd ?? 0) || 0,
+      entry_mcap: null,
+      entry_tvl: null,
+      entry_volume: null,
+      entry_holders: null,
+      signal_snapshot: null,
+      deployed_at: new Date().toISOString(),
+      out_of_range_since: null,
+      last_claim_at: null,
+      total_fees_claimed_usd: 0,
+      rebalance_count: 0,
+      closed: false,
+      closed_at: null,
+      notes: ["Imported from on-chain during sync (not deployed by agent)"],
+      peak_pnl_pct: 0,
+      pending_peak_pnl_pct: null,
+      pending_peak_confirm_count: 0,
+      pending_peak_started_at: null,
+      pending_exit_action: null,
+      pending_exit_count: 0,
+      pending_exit_started_at: null,
+      trailing_active: false,
+    };
+    added++;
+  }
+
+  if (added > 0) {
+    save(state);
+    log("state", `Reconciled ${added} imported position(s) into state.json`);
+  }
+  return added;
+}


### PR DESCRIPTION
## Summary

`state.json` only gained entries via `trackPosition()` (called inside `deployPosition()`), so positions opened manually / via another tool were never tracked and the agent never managed them. `syncOpenPositions()` only **closes** missing positions.

- Add `reconcileTrackedPositions(livePositions)` in `state.ts`: imports any on-chain position not already tracked into `state.json` with best-effort metadata (`strategy: "imported"`, a `notes` entry marking the origin). It never clobbers existing tracked metadata.
- Call it alongside `syncOpenPositions` in `getMyPositions()` for the local wallet, so "sync all active positions" makes the agent follow every live position.
- Add regression tests (import, no-clobber of existing metadata, auto-close of missing-on-chain).

Closes #7

## Testing Plan

- [x] **Manual: sync backfills** — an on-chain position not in `state.json` is imported with `strategy: "imported"` and a note.
- [x] **Edge: no clobber** — an already-tracked position keeps its original metadata.
- [x] **Edge: auto-close** — `syncOpenPositions` still closes positions missing on-chain (beyond grace period).
- [x] **CI: TypeScript check** — `tsc --noEmit` passes.
- [x] **CI: Tests** — `vitest run` green (state.test.ts).

## Deploy note
`dist/` was rebuilt (the daemon runs compiled code). After merging, restart the daemon (`pm2 delete meridian && npm run pm2:start`) so it loads the new build; the next position sync will import the untracked position into `state.json`.