### PR TITLE
[Test] Isolate state regression test from real data/state.json

### DIFF
--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -1,19 +1,29 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   reconcileTrackedPositions,
   getTrackedPositions,
   trackPosition,
   syncOpenPositions,
+  __setStateFilePath,
 } from "./state.js";
-import { dataPath } from "../shared/constants.js";
 
-const STATE_FILE = dataPath("state.json");
+// Isolate the test from the real data/state.json via the test seam.
+const TMP_STATE = path.join(os.tmpdir(), `meridian-state-test-${process.pid}.json`);
 
 describe("reconcileTrackedPositions", () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
   beforeEach(() => {
-    if (fs.existsSync(STATE_FILE)) fs.unlinkSync(STATE_FILE);
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
   });
 
   it("imports an on-chain position the agent did not deploy", () => {
@@ -74,9 +84,9 @@ describe("reconcileTrackedPositions", () => {
       initial_value_usd: 50,
     } as any);
     // Older than SYNC_GRACE_MS so it is eligible for auto-close.
-    const state = JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+    const state = JSON.parse(fs.readFileSync(TMP_STATE, "utf8"));
     state.positions.PosZ.deployed_at = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-    fs.writeFileSync(STATE_FILE, JSON.stringify(state));
+    fs.writeFileSync(TMP_STATE, JSON.stringify(state));
 
     syncOpenPositions(["PosY"]); // PosZ not in on-chain list
     const tracked = getTrackedPositions(true);

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -32,7 +32,15 @@ import type {
 export type { PositionRecord } from "../shared/types.js";
 import type { AppConfig } from "../shared/types.js";
 
-const STATE_FILE = dataPath("state.json");
+let STATE_FILE = dataPath("state.json");
+
+/**
+ * Test-only seam: redirect the state file so tests don't read/write the real
+ * data/state.json. Production code always uses the default path.
+ */
+export function __setStateFilePath(path: string): void {
+  STATE_FILE = path;
+}
 
 interface StateData {
   positions: Record<string, PositionRecord>;


### PR DESCRIPTION
## Summary

`state.test.ts` used the real `data/state.json` because `state.ts` hardcoded `STATE_FILE = dataPath("state.json")` and the test never redirected it. Its `beforeEach` deleted that file, so a test run wiped the user's real tracked positions and left a fake `PosZ` placeholder (non-base58) in live state.

- Add a test-only seam `__setStateFilePath(path)` in `state.ts` (default path unchanged).
- Point the test at a temp file under `os.tmpdir()`, restored in `afterAll`. The real `data/state.json` is no longer touched.

Closes #9

## Testing Plan

- [x] **Manual: isolation** — after running the test, the real `data/state.json` is unchanged (verified it kept its pre-test content).
- [x] **CI: TypeScript check** — `tsc --noEmit` passes.
- [x] **CI: Tests** — `vitest run` green (3 tests in state.test.ts).