### PR TITLE
fix: persist logs under data directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ node_modules
 dist
 **/dist
 data
-logs
 coverage
 *.log
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ tsconfig.tsbuildinfo
 # Stray Claude Code worktrees
 .claude/worktrees/
 
-# Logs
-logs/
-
 # OS
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ AGENTS.local.md
 .agents/rules/*.local.md
 
 # Build and IDE files
+logs/
 dist/
 .memory-bank/
 .dev/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,7 @@
 ## Codebase Organization (Hexagonal Design)
 
 The codebase is a pnpm monorepo. Config and runtime data live at the repository root; application code is split across three packages under `packages/`:
+
 ```
 config/
   user-config.json           # Active user configuration (written by `npm run setup`)
@@ -18,8 +19,9 @@ data/
   strategy-library.json      # Saved LP strategy profiles
   token-blacklist.json       # Hard-blocked token mints
   hivemind-cache.json        # Cached shared HiveMind lessons + presets
-logs/
+data/logs/
   agent-YYYY-MM-DD.log       # Rotating application logs
+  actions-YYYY-MM-DD.jsonl   # Structured audit trail
 packages/
   cli/src/
     Cli.ts                   # CLI entrypoint: one-shot command runner
@@ -68,36 +70,40 @@ packages/
       types.ts               # Shared TypeScript types and Zod schemas
 ```
 
-
 ---
 
 ## The ReAct Loop & Tools Logic
 
-Meridian relies on a **ReAct loop** (`agent-loop.ts`) to let the LLM autonomously inspect live data and call tools. 
+Meridian relies on a **ReAct loop** (`agent-loop.ts`) to let the LLM autonomously inspect live data and call tools.
 
 ### 1. Tool Definitions (`ToolDefinitions.ts`)
+
 Exposes Zod schemas converted to OpenAI-format JSON schemas. These schemas are what the LLM sees to understand available actions (e.g. `deploy_position`, `close_position`, `swap_token`, `get_position_pnl`, `get_top_candidates`).
 
 ### 2. Tool Executor (`ToolExecutor.ts`)
+
 Routes the tool call from the LLM to the corresponding adapter implementation. It enforces crucial safety checks:
-* **Pre-deploy checks**: Verifies the pool metrics are still valid on-chain immediately before executing a deploy transaction.
-* **Auto-swap base→SOL**: After successfully executing a `close_position` tool call, the executor automatically swaps the returned base token back to SOL via Jupiter Swap.
-* **Notifications**: Emits Telegram notifications for all key transactions.
+
+- **Pre-deploy checks**: Verifies the pool metrics are still valid on-chain immediately before executing a deploy transaction.
+- **Auto-swap base→SOL**: After successfully executing a `close_position` tool call, the executor automatically swaps the returned base token back to SOL via Jupiter Swap.
+- **Notifications**: Emits Telegram notifications for all key transactions.
 
 ---
 
 ## Strategy Library (`strategy-library.ts`)
 
 The strategy library defines preset configurations for Meteora DLMM pool deployments. These presets define:
-* **Bin Distribution**: How liquidity is distributed across the bins (e.g. `spot`, `bid_ask`, or `curve`).
-* **Bins Below/Above**: How many bins are placed below and above the active price bin.
-* **SOL/Token Ratio**: For screening-driven deployments, the bot hardcodes single-sided SOL-only deposits (`bins_above = 0`, `amount_x = 0`).
+
+- **Bin Distribution**: How liquidity is distributed across the bins (e.g. `spot`, `bid_ask`, or `curve`).
+- **Bins Below/Above**: How many bins are placed below and above the active price bin.
+- **SOL/Token Ratio**: For screening-driven deployments, the bot hardcodes single-sided SOL-only deposits (`bins_above = 0`, `amount_x = 0`).
 
 ---
 
 ## Dry-Run Mode & Transaction Interception
 
 When `DRY_RUN=true` is set in the environment:
-* **Interceptors**: Inside `MeteoraAdapter.ts`, the functions `deployPosition`, `claimFees`, and `closePosition` check for the dry-run flag.
-* **Mock Responses**: Instead of submitting a transaction payload to the Solana blockchain, the adapter intercepts the call and returns a mock object containing `dry_run: true` and a mock transaction ID.
-* *Note:* Mock positions are only saved to the local `state.json` registry during the deploy step; they are not simulated dynamically by the management loop since they do not exist on the Solana blockchain.
+
+- **Interceptors**: Inside `MeteoraAdapter.ts`, the functions `deployPosition`, `claimFees`, and `closePosition` check for the dry-run flag.
+- **Mock Responses**: Instead of submitting a transaction payload to the Solana blockchain, the adapter intercepts the call and returns a mock object containing `dry_run: true` and a mock transaction ID.
+- _Note:_ Mock positions are only saved to the local `state.json` registry during the deploy step; they are not simulated dynamically by the management loop since they do not exist on the Solana blockchain.

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -76,7 +76,7 @@
 
 **A: Yes — and it is NOT only in `decision-log.json`.** The bot already writes the entire run to **three separate destinations**, all implemented in `packages/core/src/shared/logger.ts`:
 
-1. **`logs/agent-<YYYY-MM-DD>.log`** — human-readable text log of _every_ event, including the operational tags you want to review:
+1. **`data/logs/agent-<YYYY-MM-DD>.log`** — human-readable text log of _every_ event, including the operational tags you want to review:
    - `[screening]` — each screening cycle, hard-filter rejections, PVP guards, indicator confirmations (`ScreeningAdapter.ts`)
    - `[deploy]` / `[deploy_error]` — position opens, bin/amount/tx details (`MeteoraAdapter.ts:802`)
    - `[close]` / `[claim]` — position closes, fee claims, auto-swap-back-to-SOL steps (`MeteoraAdapter.ts:1513`, `1471`)
@@ -84,7 +84,7 @@
    - `[positions]` / `[pnl_tick]` — portfolio/PnL polling during the management loop
    - Also `info` / `warn` / `error` / `debug` standard lines.
 
-2. **`logs/actions-<YYYY-MM-DD>.jsonl`** — structured per-tool **audit trail** (`logAction`, `ToolExecutor.ts:724`). Every tool call (e.g. `deploy_position`, `close_position`, `swap_token`, `claim_fees`, `screen`/candidate tools) is appended as one JSON line with `tool`, `args`, `result`, `duration_ms`, `success`/`error`. This is the most machine-readable way to replay the exact actions taken.
+2. **`data/logs/actions-<YYYY-MM-DD>.jsonl`** — structured per-tool **audit trail** (`logAction`, `ToolExecutor.ts:724`). Every tool call (e.g. `deploy_position`, `close_position`, `swap_token`, `claim_fees`, `screen`/candidate tools) is appended as one JSON line with `tool`, `args`, `result`, `duration_ms`, `success`/`error`. This is the most machine-readable way to replay the exact actions taken.
 
 3. **`data/decision-log.json`** — append-only structured **decisions** (`appendDecision`, `domain/decision-log.ts`), capped at `MAX_DECISIONS`. Types observed: `deploy`, `close`, `skip`, `no_deploy`, `note` (actors: `SCREENER`, `MANAGER`, etc.). This is the summary feed used by the daily briefing (`getDecisionSummary`).
 
@@ -94,13 +94,13 @@ Plus, if Telegram is configured, write operations also push **notifications**: `
 
 ```bash
 # Live tail the operational text log (captures ALL events, every level)
-tail -f logs/agent-$(date +%F).log
+tail -f data/logs/agent-$(date +%F).log
 
 # Filter just the lifecycle events you care about
-grep -E "\[(screening|deploy|close|swap|claim)\]" logs/agent-$(date +%F).log
+grep -E "\[(screening|deploy|close|swap|claim)\]" data/logs/agent-$(date +%F).log
 
 # Replay exact tool calls as JSON
-cat logs/actions-$(date +%F).jsonl | jq 'select(.tool=="deploy_position" or .tool=="close_position" or .tool=="swap_token")'
+cat data/logs/actions-$(date +%F).jsonl | jq 'select(.tool=="deploy_position" or .tool=="close_position" or .tool=="swap_token")'
 
 # Decision summary
 cat data/decision-log.json | jq '.decisions[0:10]'
@@ -110,7 +110,7 @@ cat data/decision-log.json | jq '.decisions[0:10]'
 
 **A: Be careful — `LOG_LEVEL` controls the console, not the files.**
 
-- The logger (`logger.ts:35`) **always** appends every event to the `logs/agent-<date>.log` file, regardless of `LOG_LEVEL`.
+- The logger (`logger.ts:35`) **always** appends every event to the `data/logs/agent-<date>.log` file, regardless of `LOG_LEVEL`.
 - The console (`process.stdout`) only prints lines whose level is one of the _standard_ levels (`debug`/`info`/`warn`/`error`) AND `>= LOG_LEVEL`. The operational tags (`screening`, `deploy`, `close`, `swap`, `claim`, `positions`, `pnl_tick`, `pnl_warn`, …) are **custom level strings**, so they are written to the file but are **never printed to the console** — even at `LOG_LEVEL=debug`.
 
-So on `LOG_LEVEL=info` the terminal will show `info`/`warn`/`error` lines but **not** the `deploy`/`close`/`swap`/`screening` events. To review those you must read the log **file** (`logs/agent-<date>.log`) or the `actions-<date>.jsonl` audit trail — not the live console. `LOG_LEVEL=info` is already the default (`.env.example:41`); set it to `debug` only if you also want the standard `debug` lines echoed to the terminal.
+So on `LOG_LEVEL=info` the terminal will show `info`/`warn`/`error` lines but **not** the `deploy`/`close`/`swap`/`screening` events. To review those you must read the log **file** (`data/logs/agent-<date>.log`) or the `data/logs/actions-<date>.jsonl` audit trail — not the live console. `LOG_LEVEL=info` is already the default (`.env.example:41`); set it to `debug` only if you also want the standard `debug` lines echoed to the terminal.

--- a/packages/core/src/shared/logger.ts
+++ b/packages/core/src/shared/logger.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { REPO_ROOT } from './constants.js';
+import { REPO_ROOT, dataPath } from './constants.js';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -14,7 +14,7 @@ const LOG_LEVELS: Record<LogLevel, number> = {
 const currentLevel: LogLevel = (process.env.LOG_LEVEL as LogLevel) || 'info';
 const minLevel = LOG_LEVELS[currentLevel] ?? LOG_LEVELS.info;
 
-const logsDir = path.join(REPO_ROOT, 'logs');
+const logsDir = dataPath('logs');
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }


### PR DESCRIPTION
## Summary
- Move logs directory from repo root to `data/logs/` so logs survive Docker container restarts
- Update logger to use existing `dataPath()` helper
- Update documentation references from `logs/` to `data/logs/`
- Update `.gitignore` and `.dockerignore` accordingly

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run typecheck` passes
- [ ] Docker container writes logs to `/app/data/logs/` which persists on `meridian_data` volume
- [ ] `data/logs/agent-<date>.log` and `data/logs/actions-<date>.jsonl` are created on startup