### PR TITLE
feat: remove redundant claimSwapFee before removeLiquidity in closePosition (issue #11)

### DIFF
--- a/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
+++ b/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
@@ -1731,31 +1731,8 @@ export async function closePosition({ position_address, reason }: { position_add
     const claimTxHashes: string[] = [];
     const closeTxHashes: string[] = [];
 
-    const recentlyClaimed = tracked?.last_claim_at && Date.now() - new Date(tracked.last_claim_at).getTime() < 60_000;
-    try {
-      if (recentlyClaimed) {
-        log(
-          'close',
-          `Step 1: Skipping claim — fees already claimed ${Math.round((Date.now() - new Date(tracked!.last_claim_at!).getTime()) / 1000)}s ago`,
-        );
-      } else {
-        log('close', `Step 1: Claiming fees for ${position_address}`);
-        const positionData = await pool.getPosition(positionPubKey);
-        const claimTxs = await pool.claimSwapFee({
-          owner: wallet.publicKey,
-          position: positionData,
-        });
-        if (claimTxs && claimTxs.length > 0) {
-          for (const tx of claimTxs) {
-            const claimHash = await sendAndConfirmTransaction(getConnection(), tx, [wallet]);
-            claimTxHashes.push(claimHash);
-          }
-          log('close', `Step 1 OK (claim only): ${claimTxHashes.join(', ')}`);
-        }
-      }
-    } catch (e: any) {
-      log('close_warn', `Step 1 (Claim) failed or nothing to claim: ${e.message}`);
-    }
+    // Fees are claimed atomically by removeLiquidity with shouldClaimAndClose: true below.
+    // No separate claimSwapFee call needed — the relay path already uses this pattern.
 
     let hasLiquidity = false;
     let closeFromBinId = -887272;


### PR DESCRIPTION
## What

Removes the redundant `claimSwapFee` call (Step 1) from the local close path of `closePosition()` in `MeteoraAdapter.ts`. The `removeLiquidity` call with `shouldClaimAndClose: true` (Step 2) already atomically claims swap fees, LM rewards, and closes the position in a single Solana transaction. The separate Step 1 claim was burning an extra ~0.003–0.01 SOL per close for zero benefit.

## Acceptance criteria status

- [x] Redundant Step 1 `claimSwapFee` block removed from `closePosition()` local path — `MeteoraAdapter.ts:1734-1758` deleted
- [x] No PnL, state, or post-close auto-swap behavior changed — `recordClaim()` only called from standalone `claimFees()`, not from `closePosition()`
- [x] Standalone `claimFees()` function untouched — still correct for harvesting fees on open positions

## Approach

Pure deletion of ~25 lines. The `shouldClaimAndClose: true` flag on `removeLiquidity` is the canonical single-tx pattern — confirmed by Meteora DLMM SDK source code (PRs #272, #274) and already used by the relay (LPAgent) path which returns `claimTxHashes: []`.

## What was deliberately NOT included

- No changes to standalone `claimFees()` function (still needed for open positions)
- No new tests (zero existing test coverage for MeteoraAdapter — this is a separate concern)
- No changes to PnL calculation, state tracking, or post-close auto-swap logic

## Documentation

No public API changes — no doc updates needed.

## Test coverage

- TypeScript compilation: passes on `packages/core`
- Existing test suite: 2 pre-existing failures in `Config.test.ts` (config scaling, unrelated to this change) — same failures on `main`
- No new test files added (MeteoraAdapter has zero existing test coverage)

## Complexity guard status

- Complexity verdict: lean ✅
- Auto-generated files excluded: none
- Change surface: single file (`MeteoraAdapter.ts`), 2 insertions, 25 deletions

Closes #11