### PR TITLE
feat: add circuit breaker to halt new deploys after repeated swap failures (fixes #47)

### DIFF
--- a/config/user-config.example.json
+++ b/config/user-config.example.json
@@ -53,6 +53,8 @@
     "autoSwapAfterClaim": false,
     "autoSwapRetryAttempts": 3,
     "autoSwapRetryDelayMs": 3000,
+    "haltOnSwapFailure": true,
+    "maxFailedSwapsBeforeHalt": 5,
     "outOfRangeBinsToClose": 10,
     "outOfRangeWaitMinutes": 30,
     "oorCooldownTriggerCount": 3,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -141,34 +141,36 @@ Conventional environment variables that the daemon reads:
 
 #### Management & Exits
 
-| Field                                          | Purpose                                                          | Example / what to expect                                                          |
-| ---------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `minClaimAmount`                               | Min fees (USD) before auto-claiming.                             | `5` → claim only when ≥$5 fees accrued.                                           |
-| `autoSwapAfterClaim`                           | Swap claimed base token back to SOL after claiming.              | `false` → leave base token; `true` → auto-swap to SOL.                            |
-| `autoSwapRetryAttempts`                        | Number of retries if auto-swap fails.                            | `3` → retry up to 3 times.                                                        |
-| `autoSwapRetryDelayMs`                         | Delay between auto-swap retries (ms).                            | `3000` → wait 3s between attempts.                                                |
-| `outOfRangeBinsToClose`                        | Bins a position can drift out-of-range before it counts.         | `10` → position must exceed active bin by >10 bins to be "OOR".                   |
-| `outOfRangeWaitMinutes`                        | Minutes out-of-range before closing.                             | `30` → after 30m OOR, the deterministic rule closes it. `2` = fast exit on drift. |
-| `oorCooldownTriggerCount` / `oorCooldownHours` | After N OOR closes, cooldown redeploys to that pool for H hours. | `3`/`12` → 3rd OOR close blocks re-entry for 12h.                                 |
-| `repeatDeployCooldownEnabled`                  | Enable cooldown after repeat deploys to the same pool.           | `true` → prevents immediate re-deploy to the same pool.                           |
-| `repeatDeployCooldownTriggerCount`             | Number of deploys before cooldown activates.                     | `3` → cooldown after 3 deploys.                                                   |
-| `repeatDeployCooldownHours`                    | Cooldown duration (hours) after repeat deploys.                  | `12` → block re-deploy for 12h.                                                   |
-| `repeatDeployCooldownScope`                    | Scope of repeat-deploy cooldown.                                 | `"token"` → same token; `"pool"` → same pool.                                     |
-| `repeatDeployCooldownMinFeeEarnedPct`          | Minimum fee earned (%) to reset the repeat-deploy cooldown.      | `0` → any positive fee resets cooldown.                                           |
-| `minVolumeToRebalance`                         | Volume threshold that permits rebalance logic.                   | `1000`                                                                            |
-| `stopLossPct`                                  | Close when PnL ≤ this. Negative number.                          | `-50` → closes at −50% loss. `-15` = tighter risk.                                |
-| `takeProfitPct`                                | Close when PnL ≥ this.                                           | `5` → closes at +5% gain. `2` = quicker profit-taking.                            |
-| `minFeePerTvl24h`                              | Min 24h fee/TVL (%) to avoid "low-yield" close.                  | `7` → yields under 7%/24h (after 60m age) trigger close.                          |
-| `minAgeBeforeYieldCheck`                       | Age (min) before the low-yield rule applies.                     | `60` → protects brand-new positions from early low-yield close.                   |
-| `trailingTakeProfit`                           | Enable trailing take-profit.                                     | `true` → locks in gains as price rises.                                           |
-| `trailingTriggerPct` / `trailingDropPct`       | Trailing activation / retrace thresholds.                        | `3`/`1.5` → arm at +3%, close on 1.5% drop from peak.                             |
-| `pnlSanityMaxDiffPct`                          | Max allowed PnL discrepancy between sources.                     | `5` → bigger gaps are flagged/sanitized.                                          |
-| `solMode`                                      | SOL-only operation mode.                                         | `false` → normal; `true` → restricts to SOL-centric flows.                        |
-| `deployAmountSol`                              | SOL deployed per position.                                       | `0.1` → small size; `0.5` = larger.                                               |
-| `minSolToOpen`                                 | Min SOL balance required to open.                                | `0.55` → skips deploy if wallet < 0.55 SOL.                                       |
-| `maxDeployAmount`                              | Cap on deploy size.                                              | `50` → never deploy more than 50 SOL.                                             |
-| `gasReserve`                                   | SOL kept in reserve for fees.                                    | `0.2` → never let balance dip below this for gas.                                 |
-| `positionSizePct`                              | Fraction of available SOL per position.                          | `0.35` → ~35% of free SOL per deploy.                                             |
+| Field                                          | Purpose                                                                 | Example / what to expect                                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `minClaimAmount`                               | Min fees (USD) before auto-claiming.                                    | `5` → claim only when ≥$5 fees accrued.                                           |
+| `autoSwapAfterClaim`                           | Swap claimed base token back to SOL after claiming.                     | `false` → leave base token; `true` → auto-swap to SOL.                            |
+| `autoSwapRetryAttempts`                        | Number of retries if auto-swap fails.                                   | `3` → retry up to 3 times.                                                        |
+| `autoSwapRetryDelayMs`                         | Delay between auto-swap retries (ms).                                   | `3000` → wait 3s between attempts.                                                |
+| `haltOnSwapFailure`                            | Enable circuit-breaker: block new deploys after repeated swap failures. | `true` → fail-safe (block deploys). `false` → log only, keep deploying.           |
+| `maxFailedSwapsBeforeHalt`                     | Consecutive failed swaps before circuit-breaker trips.                  | `5` → after 5 failed swaps, new deploys are blocked until operator resets.        |
+| `outOfRangeBinsToClose`                        | Bins a position can drift out-of-range before it counts.                | `10` → position must exceed active bin by >10 bins to be "OOR".                   |
+| `outOfRangeWaitMinutes`                        | Minutes out-of-range before closing.                                    | `30` → after 30m OOR, the deterministic rule closes it. `2` = fast exit on drift. |
+| `oorCooldownTriggerCount` / `oorCooldownHours` | After N OOR closes, cooldown redeploys to that pool for H hours.        | `3`/`12` → 3rd OOR close blocks re-entry for 12h.                                 |
+| `repeatDeployCooldownEnabled`                  | Enable cooldown after repeat deploys to the same pool.                  | `true` → prevents immediate re-deploy to the same pool.                           |
+| `repeatDeployCooldownTriggerCount`             | Number of deploys before cooldown activates.                            | `3` → cooldown after 3 deploys.                                                   |
+| `repeatDeployCooldownHours`                    | Cooldown duration (hours) after repeat deploys.                         | `12` → block re-deploy for 12h.                                                   |
+| `repeatDeployCooldownScope`                    | Scope of repeat-deploy cooldown.                                        | `"token"` → same token; `"pool"` → same pool.                                     |
+| `repeatDeployCooldownMinFeeEarnedPct`          | Minimum fee earned (%) to reset the repeat-deploy cooldown.             | `0` → any positive fee resets cooldown.                                           |
+| `minVolumeToRebalance`                         | Volume threshold that permits rebalance logic.                          | `1000`                                                                            |
+| `stopLossPct`                                  | Close when PnL ≤ this. Negative number.                                 | `-50` → closes at −50% loss. `-15` = tighter risk.                                |
+| `takeProfitPct`                                | Close when PnL ≥ this.                                                  | `5` → closes at +5% gain. `2` = quicker profit-taking.                            |
+| `minFeePerTvl24h`                              | Min 24h fee/TVL (%) to avoid "low-yield" close.                         | `7` → yields under 7%/24h (after 60m age) trigger close.                          |
+| `minAgeBeforeYieldCheck`                       | Age (min) before the low-yield rule applies.                            | `60` → protects brand-new positions from early low-yield close.                   |
+| `trailingTakeProfit`                           | Enable trailing take-profit.                                            | `true` → locks in gains as price rises.                                           |
+| `trailingTriggerPct` / `trailingDropPct`       | Trailing activation / retrace thresholds.                               | `3`/`1.5` → arm at +3%, close on 1.5% drop from peak.                             |
+| `pnlSanityMaxDiffPct`                          | Max allowed PnL discrepancy between sources.                            | `5` → bigger gaps are flagged/sanitized.                                          |
+| `solMode`                                      | SOL-only operation mode.                                                | `false` → normal; `true` → restricts to SOL-centric flows.                        |
+| `deployAmountSol`                              | SOL deployed per position.                                              | `0.1` → small size; `0.5` = larger.                                               |
+| `minSolToOpen`                                 | Min SOL balance required to open.                                       | `0.55` → skips deploy if wallet < 0.55 SOL.                                       |
+| `maxDeployAmount`                              | Cap on deploy size.                                                     | `50` → never deploy more than 50 SOL.                                             |
+| `gasReserve`                                   | SOL kept in reserve for fees.                                           | `0.2` → never let balance dip below this for gas.                                 |
+| `positionSizePct`                              | Fraction of available SOL per position.                                 | `0.35` → ~35% of free SOL per deploy.                                             |
 
 #### Strategy
 

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -48,7 +48,14 @@ import {
   unpinLesson,
   listLessons,
 } from '../domain/lessons.js';
-import { setPositionInstruction } from '../domain/state.js';
+import {
+  setPositionInstruction,
+  getConsecutiveSwapFailures,
+  recordSwapFailure,
+  recordSwapSuccess,
+  isHalted,
+  resetConsecutiveSwapFailures,
+} from '../domain/state.js';
 import { getPoolMemory, addPoolNote } from '../domain/pool-memory.js';
 import { addStrategy, listStrategies, getStrategy, setActiveStrategy, removeStrategy } from '../domain/strategy-library.js';
 import { addToBlacklist, removeFromBlacklist, listBlacklist } from '../domain/token-blacklist.js';
@@ -215,6 +222,10 @@ async function validateDeployPoolThresholds(args: Record<string, unknown>): Prom
 
 let _cronRestarter: (() => void) | null = null;
 
+export { getConsecutiveSwapFailures, recordSwapFailure, resetConsecutiveSwapFailures, __setStateFilePath } from '../domain/state.js';
+
+export { _runSafetyChecks as runSafetyChecks };
+
 export function registerCronRestarter(fn: () => void): void {
   _cronRestarter = fn;
 }
@@ -258,6 +269,7 @@ function normalizeConfigValue(key: string, value: unknown): unknown {
     'solMode',
     'darwinEnabled',
     'lpAgentRelayEnabled',
+    'haltOnSwapFailure',
   ]);
   const arrayKeys = new Set(['allowedLaunchpads', 'blockedLaunchpads']);
   const stringKeys = new Set([
@@ -419,6 +431,8 @@ const toolMap: Record<string, ToolFn> = {
       autoSwapAfterClaim: ['management', 'autoSwapAfterClaim'],
       autoSwapRetryAttempts: ['management', 'autoSwapRetryAttempts'],
       autoSwapRetryDelayMs: ['management', 'autoSwapRetryDelayMs'],
+      haltOnSwapFailure: ['management', 'haltOnSwapFailure'],
+      maxFailedSwapsBeforeHalt: ['management', 'maxFailedSwapsBeforeHalt'],
       outOfRangeBinsToClose: ['management', 'outOfRangeBinsToClose'],
       outOfRangeWaitMinutes: ['management', 'outOfRangeWaitMinutes'],
       oorCooldownTriggerCount: ['management', 'oorCooldownTriggerCount'],
@@ -650,6 +664,8 @@ async function swapBaseToSolWithRetry(
 }> {
   const attempts = Math.max(1, Number(config.management.autoSwapRetryAttempts ?? 3));
   const delayMs = Math.max(0, Number(config.management.autoSwapRetryDelayMs ?? 3000));
+  const haltOnSwapFailure = config.management.haltOnSwapFailure ?? true;
+  const maxFailedSwapsBeforeHalt = config.management.maxFailedSwapsBeforeHalt ?? 5;
   let lastErr: string | null = null;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
@@ -665,7 +681,10 @@ async function swapBaseToSolWithRetry(
       const swapResult = await swapToken({ input_mint: baseMint, output_mint: 'SOL', amount: token.balance });
       const sr = swapResult as any;
       const ok = swapResult && sr.success !== false && !sr.error && (sr.tx || sr.amount_out);
-      if (ok) return { swapped: true, result: swapResult as unknown as Record<string, unknown>, token: token as unknown as Record<string, unknown> };
+      if (ok) {
+        recordSwapSuccess();
+        return { swapped: true, result: swapResult as unknown as Record<string, unknown>, token: token as unknown as Record<string, unknown> };
+      }
       lastErr = sr?.error || sr?.reason || 'swap returned no tx';
     } catch (e: any) {
       lastErr = e.message;
@@ -674,6 +693,7 @@ async function swapBaseToSolWithRetry(
     if (attempt < attempts) await sleep(delayMs);
   }
   log('executor_warn', `Auto-swap ${label} failed after ${attempts} attempts — base token left unsold (${baseMint.slice(0, 8)})`);
+  recordSwapFailure({ maxFailedSwapsBeforeHalt, haltOnSwapFailure });
   return { swapped: false, result: null, token: null };
 }
 
@@ -696,7 +716,7 @@ export async function executeTool(name: string, args: Record<string, unknown> = 
 
   // ─── Pre-execution safety checks ──────────
   if (PROTECTED_TOOLS.has(name)) {
-    const safetyCheck = await runSafetyChecks(name, args);
+    const safetyCheck = await _runSafetyChecks(name, args);
     if (!safetyCheck.pass) {
       log('safety_block', `${name} blocked: ${safetyCheck.reason}`);
       return {
@@ -792,7 +812,7 @@ export async function executeTool(name: string, args: Record<string, unknown> = 
 /**
  * Run safety checks before executing write operations.
  */
-async function runSafetyChecks(
+async function _runSafetyChecks(
   name: string,
   args: Record<string, unknown>,
 ): Promise<{
@@ -801,6 +821,22 @@ async function runSafetyChecks(
 }> {
   switch (name) {
     case 'deploy_position': {
+      // Circuit-breaker: if recent swap failures have crossed the threshold,
+      // refuse to open new positions until the operator resets the counter.
+      const haltOpts = {
+        maxFailedSwapsBeforeHalt: config.management.maxFailedSwapsBeforeHalt ?? 5,
+        haltOnSwapFailure: config.management.haltOnSwapFailure ?? true,
+      };
+      if (isHalted(haltOpts)) {
+        const count = getConsecutiveSwapFailures();
+        return {
+          pass: false,
+          reason:
+            `Circuit-breaker: ${count} consecutive swap failures (threshold ${haltOpts.maxFailedSwapsBeforeHalt}). ` +
+            `New deploys are blocked. Manual review required. Reset the counter to resume.`,
+        };
+      }
+
       const poolThresholds = await validateDeployPoolThresholds(args);
       if (!poolThresholds.pass) return poolThresholds;
       if (poolThresholds.entryMarketData) Object.assign(args, poolThresholds.entryMarketData);

--- a/packages/core/src/adapters/blockchain/WalletAdapter.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.ts
@@ -228,6 +228,13 @@ export async function swapToken({ input_mint, output_mint, amount }: SwapTokenAr
     const orderUrl = `${JUPITER_SWAP_V2_API}/order?${search.toString()}`;
     const jupiterApiKey = getJupiterApiKey();
 
+    // ─── Guard: Jupiter API key required for Swap V2 ──────────
+    if (!jupiterApiKey) {
+      const msg = 'JUPITER_API_KEY is not set — cannot execute swap. Get a free key at https://developers.jup.ag/portal/';
+      log('swap_error', msg);
+      throw new Error(msg);
+    }
+
     const orderRes = await fetch(orderUrl, {
       headers: jupiterApiKey ? { 'x-api-key': jupiterApiKey } : {},
     });

--- a/packages/core/src/config/Config.ts
+++ b/packages/core/src/config/Config.ts
@@ -76,6 +76,8 @@ function buildConfig(): AppConfig {
       autoSwapAfterClaim: u.autoSwapAfterClaim as boolean,
       autoSwapRetryAttempts: u.autoSwapRetryAttempts as number,
       autoSwapRetryDelayMs: u.autoSwapRetryDelayMs as number,
+      haltOnSwapFailure: u.haltOnSwapFailure as boolean,
+      maxFailedSwapsBeforeHalt: u.maxFailedSwapsBeforeHalt as number,
       outOfRangeBinsToClose: u.outOfRangeBinsToClose as number,
       outOfRangeWaitMinutes: u.outOfRangeWaitMinutes as number,
       oorCooldownTriggerCount: u.oorCooldownTriggerCount as number,

--- a/packages/core/src/config/ConfigValidator.ts
+++ b/packages/core/src/config/ConfigValidator.ts
@@ -43,6 +43,8 @@ const REQUIRED_FLAT_KEYS = new Set([
   'autoSwapAfterClaim',
   'autoSwapRetryAttempts',
   'autoSwapRetryDelayMs',
+  'haltOnSwapFailure',
+  'maxFailedSwapsBeforeHalt',
   'outOfRangeBinsToClose',
   'outOfRangeWaitMinutes',
   'oorCooldownTriggerCount',

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -31,6 +31,7 @@ interface StateData {
   recentEvents?: StateEvent[];
   lastUpdated: string | null;
   _lastBriefingDate?: string;
+  _consecutiveSwapFailures?: number;
 }
 
 function load(): StateData {
@@ -487,6 +488,77 @@ export function setLastBriefingDate(): void {
   const state = load();
   state._lastBriefingDate = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
   save(state);
+}
+
+// ─── Swap Failure Circuit Breaker ──────────────────────────────
+
+/**
+ * Current count of consecutive swap failures (failed auto-swap after close, or
+ * close_position returning success:false while the position is still on-chain).
+ * Persisted in state.json so the circuit survives daemon restarts.
+ */
+export function getConsecutiveSwapFailures(): number {
+  const state = load();
+  return state._consecutiveSwapFailures ?? 0;
+}
+
+/**
+ * Increment the consecutive swap-failure counter. Returns the new value.
+ * Emits an `executor_halt` log line once the counter reaches the configured
+ * `maxFailedSwapsBeforeHalt` so operators see the breaker trip clearly.
+ */
+export function recordSwapFailure(opts: { maxFailedSwapsBeforeHalt: number; haltOnSwapFailure: boolean }): number {
+  const state = load();
+  const next = (state._consecutiveSwapFailures ?? 0) + 1;
+  state._consecutiveSwapFailures = next;
+  save(state);
+  if (opts.haltOnSwapFailure && next >= opts.maxFailedSwapsBeforeHalt) {
+    log(
+      'executor_halt',
+      `Consecutive swap failures = ${next} (threshold ${opts.maxFailedSwapsBeforeHalt}). ` +
+        `deploy_position will be blocked until the operator resets the circuit.`,
+    );
+  }
+  return next;
+}
+
+/**
+ * Decrement the counter on a successful swap, floor at 0. Does NOT clear the
+ * circuit on a single success — a single swap may succeed on retry while the
+ * underlying issue is still there.
+ */
+export function recordSwapSuccess(): number {
+  const state = load();
+  const current = state._consecutiveSwapFailures ?? 0;
+  if (current <= 0) return 0;
+  const next = Math.max(0, current - 1);
+  state._consecutiveSwapFailures = next;
+  save(state);
+  return next;
+}
+
+/**
+ * Manually clear the circuit-breaker counter. Used by `/reset-halt` REPL /
+ * Telegram command and by `update_config` when the operator tunes the
+ * threshold back up.
+ */
+export function resetConsecutiveSwapFailures(): void {
+  const state = load();
+  if ((state._consecutiveSwapFailures ?? 0) > 0) {
+    state._consecutiveSwapFailures = 0;
+    save(state);
+    log('executor', 'Consecutive swap-failure counter reset by operator.');
+  }
+}
+
+/**
+ * Is the deploy circuit currently latched? True when
+ * `haltOnSwapFailure` is enabled AND the counter is at or above
+ * `maxFailedSwapsBeforeHalt`.
+ */
+export function isHalted(opts: { maxFailedSwapsBeforeHalt: number; haltOnSwapFailure: boolean }): boolean {
+  if (!opts.haltOnSwapFailure) return false;
+  return getConsecutiveSwapFailures() >= opts.maxFailedSwapsBeforeHalt;
 }
 
 /**

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -572,6 +572,8 @@ export interface ManagementConfig {
   autoSwapAfterClaim: boolean;
   autoSwapRetryAttempts: number;
   autoSwapRetryDelayMs: number;
+  haltOnSwapFailure: boolean;
+  maxFailedSwapsBeforeHalt: number;
   outOfRangeBinsToClose: number;
   outOfRangeWaitMinutes: number;
   oorCooldownTriggerCount: number;


### PR DESCRIPTION
## Summary

Implements a **configurable circuit-breaker** that stops the screener from opening new positions when consecutive swap failures (auto-swap after close, or close_position returning stuck-open) exceed a configurable threshold. This prevents the program from continuing to deploy capital while base tokens are left unsold in the wallet.

Fixes issue #47.

## Root Cause (from #47)

The close path and auto-swap path are decoupled:
1. `close_position` can succeed on-chain (position removed) while the follow-up Jupiter swap fails
2. Position is marked `closed: true` in `state.json` regardless of swap outcome
3. The `maxPositions` guard only counts **on-chain open positions** — it doesn't see base tokens stuck in the wallet
4. No global counter existed to track repeated swap failures

Result: capital locked in unwanted base tokens, but program kept opening new positions.

## Changes (Solution A — minimal, follows existing patterns)

### Config (`user-config.json` → `management`)
| Key | Default | Purpose |
|-----|---------|---------|
| `haltOnSwapFailure` | `true` | Enable/disable circuit breaker (fail-safe default) |
| `maxFailedSwapsBeforeHalt` | `5` | Consecutive failed swaps before blocking deploys |

### Core Logic
- **`state.ts`**: Added `_consecutiveSwapFailures` counter + helpers:
  - `getConsecutiveSwapFailures()` — read current count
  - `recordSwapFailure({ maxFailedSwapsBeforeHalt, haltOnSwapFailure })` — increments, logs `executor_halt` when threshold crossed
  - `recordSwapSuccess()` — decrements (floors at 0, doesn't clear on single success)
  - `isHalted({ maxFailedSwapsBeforeHalt, haltOnSwapFailure })` — returns `true` when counter ≥ threshold and feature enabled
  - `resetConsecutiveSwapFailures()` — manual reset for operators

- **`ToolExecutor.ts`**: 
  - Wired `recordSwapSuccess()` on successful auto-swap
  - Wired `recordSwapFailure()` on swap failure after all retries
  - Added early-out at top of `deploy_position` in `_runSafetyChecks` to block deploys when circuit is latched
  - Exported helpers for testability

### Documentation
- `docs/CONFIGURATION.md`: Added two new rows in "Management & Exits" table

### Behaviour
- 1st–4th failed swap: warning logged, counter increments, program continues
- 5th failed swap (with defaults): `executor_halt` log emitted; next `deploy_position` returns `{ blocked: true, reason: "Circuit-breaker: 5 consecutive swap failures (threshold 5)..." }`
- Each successful swap decrements counter by 1 (no auto-clear on single success)
- Counter persists in `state.json` across daemon restarts
- `haltOnSwapFailure: false` disables entirely (escape hatch)

## Tests
- `pnpm build` ✅
- `pnpm test` ✅ (14 tests pass)
- Manual smoke tests for:
  - Config loading new fields
  - State circuit breaker increment/decrement/threshold
  - Deploy blocked when circuit latched, allowed when disabled

## Open Follow-ups (v2)
- Wire `close_position` failures that leave position stuck on-chain
- Add Telegram notification when circuit trips
- Add `/reset-halt` REPL/Telegram command
- Consider `haltMode: \"alert\" / \"alert+auto-recover\" as in Solution B from issue