### PR TITLE
docs(config): document autoSwapInterSwapDelayMs and config set keys

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -147,6 +147,7 @@ Conventional environment variables that the daemon reads:
 | `autoSwapAfterClaim`                           | Swap claimed base token back to SOL after claiming.                     | `false` → leave base token; `true` → auto-swap to SOL.                            |
 | `autoSwapRetryAttempts`                        | Number of retries if auto-swap fails.                                   | `3` → retry up to 3 times.                                                        |
 | `autoSwapRetryDelayMs`                         | Delay between auto-swap retries (ms).                                   | `3000` → wait 3s between attempts.                                                |
+| `autoSwapInterSwapDelayMs`                     | Delay between sequential token swaps in a batch (ms).                   | `1500` → ~40 swaps/min, safe for Free Jupiter tier (60 RPM).                      |
 | `haltOnSwapFailure`                            | Enable circuit-breaker: block new deploys after repeated swap failures. | `true` → fail-safe (block deploys). `false` → log only, keep deploying.           |
 | `maxFailedSwapsBeforeHalt`                     | Consecutive failed swaps before circuit-breaker trips.                  | `5` → after 5 failed swaps, new deploys are blocked until operator resets.        |
 | `outOfRangeBinsToClose`                        | Bins a position can drift out-of-range before it counts.                | `10` → position must exceed active bin by >10 bins to be "OOR".                   |

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -204,7 +204,7 @@ Returns the full runtime config.
 ### etemaro config set <key> <value>
 Updates a config key. Parses value as JSON when possible.
 \`\`\`
-Valid keys: minTvl, maxTvl, minVolume, maxPositions, deployAmountSol, managementIntervalMin, screeningIntervalMin, managementModel, screeningModel, generalModel, autoSwapAfterClaim, minClaimAmount, outOfRangeWaitMinutes
+Valid keys: minTvl, maxTvl, minVolume, maxPositions, deployAmountSol, managementIntervalMin, screeningIntervalMin, managementModel, screeningModel, generalModel, autoSwapAfterClaim, autoSwapRetryAttempts, autoSwapRetryDelayMs, autoSwapInterSwapDelayMs, minClaimAmount, outOfRangeWaitMinutes
 \`\`\`
 
 ### etemaro lessons [--limit 50]


### PR DESCRIPTION
This PR adds documentation for the new configuration field autoSwapInterSwapDelayMs in the CONFIGURATION.md and updates the CLI help text to include the new config set keys autoSwapRetryAttempts, autoSwapRetryDelayMs, and autoSwapInterSwapDelayMs.\n\nTesting plan:\n- CI runs typecheck to ensure TypeScript correctness.\n- Existing tests pass, confirming no regression.\n- Documentation changes are validated by CI linting.