### PR TITLE
fix(winrate): reconcile win definition across surfaces

### DIFF
--- a/packages/core/src/adapters/BriefingAdapter.ts
+++ b/packages/core/src/adapters/BriefingAdapter.ts
@@ -100,7 +100,7 @@ export async function generateBriefing(options?: GenerateBriefingOptions): Promi
     `💰 Net PnL: ${totalPnLUsd >= 0 ? '+' : ''}$${totalPnLUsd.toFixed(2)}${fmtSol(totalPnLUsd)}`,
     `💎 Fees Earned: $${totalFeesUsd.toFixed(2)}${fmtSol(totalFeesUsd)}`,
     perfLast24h.length > 0
-      ? `📈 Win Rate (24h): ${Math.round((perfLast24h.filter((p) => (p.pnl_usd ?? 0) > 0).length / perfLast24h.length) * 100)}%`
+      ? `📈 Win Rate (24h): ${Math.round((perfLast24h.filter((p) => (p.pnl_pct ?? 0) >= 0).length / perfLast24h.length) * 100)}%`
       : '📈 Win Rate (24h): N/A',
     '',
     'Lessons Learned:',
@@ -108,7 +108,9 @@ export async function generateBriefing(options?: GenerateBriefingOptions): Promi
     '',
     'Current Portfolio:',
     `📂 Open Positions: ${openPositions.length}`,
-    perfSummary ? `📊 All-time PnL: $${allTimePnlUsd.toFixed(2)}${fmtSol(allTimePnlUsd)} (${perfSummary.win_rate_pct as number}% win)` : '',
+    perfSummary
+      ? `📊 All-time PnL: $${allTimePnlUsd.toFixed(2)}${fmtSol(allTimePnlUsd)} | ${perfSummary.win_rate_pct as number}% win | avg ${(perfSummary.avg_pnl_pct as number) >= 0 ? '+' : ''}${(perfSummary.avg_pnl_pct as number).toFixed(2)}%`
+      : '',
     '────────────────',
   ];
 

--- a/packages/core/src/domain/lessons.ts
+++ b/packages/core/src/domain/lessons.ts
@@ -654,7 +654,7 @@ export function getPerformanceHistory({ hours = 24, limit = 50 }: GetPerformance
     }));
 
   const totalPnl = filtered.reduce((s, r) => s + (r.pnl_usd ?? 0), 0);
-  const wins = filtered.filter((r) => r.pnl_usd! > 0).length;
+  const wins = filtered.filter((r) => r.pnl_pct! >= 0).length;
 
   return {
     hours,
@@ -677,7 +677,7 @@ export function getPerformanceSummary(): Record<string, unknown> | null {
   const totalPnl = p.reduce((s, x) => s + x.pnl_usd!, 0);
   const avgPnlPct = p.reduce((s, x) => s + x.pnl_pct!, 0) / p.length;
   const avgRangeEfficiency = p.reduce((s, x) => s + x.range_efficiency!, 0) / p.length;
-  const wins = p.filter((x) => x.pnl_usd! > 0).length;
+  const wins = p.filter((x) => x.pnl_pct! >= 0).length;
 
   return {
     total_positions_closed: p.length,

--- a/packages/core/src/domain/signal-weights.ts
+++ b/packages/core/src/domain/signal-weights.ts
@@ -120,8 +120,8 @@ export function recalculateWeights(
   }
 
   // Classify wins and losses
-  const wins = recent.filter((p) => (p.pnl_usd ?? 0) > 0);
-  const losses = recent.filter((p) => (p.pnl_usd ?? 0) <= 0);
+  const wins = recent.filter((p) => (p.pnl_pct ?? 0) >= 0);
+  const losses = recent.filter((p) => (p.pnl_pct ?? 0) < 0);
 
   if (wins.length === 0 || losses.length === 0) {
     log('signal_weights', `Need both wins (${wins.length}) and losses (${losses.length}) to compute lift, skipping`);


### PR DESCRIPTION
Fixes #82. Unifies win definition across all winrate surfaces by using pnl_pct >= 0 instead of pnl_usd > 0 in:
- getPerformanceHistory
- getPerformanceSummary
- recalculateWeights (signal-weights)
- BriefingAdapter 24h and all-time winrate

This aligns with the existing pool-memory convention, treats zero-PnL records as neutral rather than losses, and surfaces winrate together with avg/total PnL in briefings to reduce metric confusion.