### PR TITLE
fix(core): prevent stop-loss redeploy and duplicate deploy_position in one message

### DIFF
--- a/packages/core/src/application/agent-loop.test.ts
+++ b/packages/core/src/application/agent-loop.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { agentLoop } from '../application/agent-loop.js';
+
+const mockOpenAICreate = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      chat = {
+        completions: {
+          create: mockOpenAICreate,
+        },
+      };
+    },
+  };
+});
+
+function makeToolCall(id: string, name: string, args: Record<string, unknown> = {}) {
+  return {
+    id,
+    type: 'function',
+    function: {
+      name,
+      arguments: JSON.stringify(args),
+    },
+  };
+}
+
+describe('agent-loop — deploy_position duplicate guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks duplicate deploy_position calls in the same assistant message', async () => {
+    const executeTool = vi.fn().mockResolvedValue({ success: true, position: 'pos_123' });
+    const getTools = vi.fn().mockReturnValue([]);
+    const getWalletBalances = vi.fn().mockResolvedValue({ sol: 10, tokens: [] });
+    const getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    const getStateSummary = vi.fn().mockReturnValue(null);
+    const getLessonsForPrompt = vi.fn().mockReturnValue(null);
+    const getPerformanceSummary = vi.fn().mockReturnValue(null);
+    const getDecisionSummary = vi.fn().mockReturnValue(null);
+
+    // First LLM response: two deploy_position tool calls in one message
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              makeToolCall('call_1', 'deploy_position', { pool_address: 'PoolA', amount_y: 0.1 }),
+              makeToolCall('call_2', 'deploy_position', { pool_address: 'PoolB', amount_y: 0.1 }),
+            ],
+          },
+        },
+      ],
+    });
+
+    // Second LLM response: final text answer (so the loop terminates)
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Done deploying.',
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const result = await agentLoop('deploy to two pools', 3, [], 'SCREENER', null, null, {
+      interactive: false,
+      deps: {
+        executeTool,
+        getTools,
+        getWalletBalances,
+        getMyPositions,
+        getStateSummary,
+        getLessonsForPrompt,
+        getPerformanceSummary,
+        getDecisionSummary,
+      },
+    });
+
+    expect(result.content).toBe('Done deploying.');
+    // Only the first deploy_position should execute; the second should be blocked
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    expect(executeTool).toHaveBeenCalledWith('deploy_position', expect.objectContaining({ pool_address: 'PoolA' }));
+  });
+});

--- a/packages/core/src/application/agent-loop.ts
+++ b/packages/core/src/application/agent-loop.ts
@@ -443,9 +443,34 @@ export async function agentLoop(
       }
       sawToolCall = true;
 
+      // Pre-filter duplicate deploy_position calls within the same assistant message
+      // to avoid race conditions in parallel execution.
+      const deploySeenInMessage = new Set<string>();
+      const blockedInMessage: Array<{ toolCall: any; functionName: string; functionArgs: Record<string, unknown> }> = [];
+
+      for (const tc of msg.tool_calls) {
+        const fn = tc.function.name.replace(/<.*$/, '').trim();
+        if (fn === 'deploy_position') {
+          if (deploySeenInMessage.has(fn)) {
+            let args: Record<string, unknown> = {};
+            try {
+              args = JSON.parse(tc.function.arguments);
+            } catch {
+              /* best-effort */
+            }
+            blockedInMessage.push({ toolCall: tc, functionName: fn, functionArgs: args });
+          } else {
+            deploySeenInMessage.add(fn);
+          }
+        }
+      }
+
+      const blockedIds = new Set(blockedInMessage.map((b) => b.toolCall.id));
+      const toolCallsToExecute = msg.tool_calls.filter((tc: any) => !blockedIds.has(tc.id));
+
       // Execute each tool call in parallel
       const toolResults = await Promise.all(
-        msg.tool_calls.map(async (toolCall: any) => {
+        toolCallsToExecute.map(async (toolCall: any) => {
           const functionName = toolCall.function.name.replace(/<.*$/, '').trim();
           let functionArgs: Record<string, unknown>;
 
@@ -529,7 +554,35 @@ export async function agentLoop(
         }),
       );
 
-      messages.push(...toolResults);
+      // Build results in original tool_call order, inserting blocked duplicates
+      const resultsById = new Map<string, any>();
+      for (const r of toolResults) resultsById.set(r.tool_call_id, r);
+
+      const orderedResults = msg.tool_calls.map((tc: any) => {
+        if (blockedIds.has(tc.id)) {
+          const block = blockedInMessage.find((b) => b.toolCall.id === tc.id)!;
+          log('agent', `Blocked duplicate ${block.functionName} call in same message — already executed this turn`);
+          const blockedResult = {
+            blocked: true,
+            reason: 'Only one deploy_position per message is allowed. If you need to deploy to multiple pools, send separate messages.',
+          };
+          onToolFinish?.({
+            name: block.functionName,
+            args: block.functionArgs,
+            result: blockedResult,
+            success: false,
+            step,
+          });
+          return {
+            role: 'tool' as const,
+            tool_call_id: tc.id,
+            content: JSON.stringify(blockedResult),
+          };
+        }
+        return resultsById.get(tc.id)!;
+      });
+
+      messages.push(...orderedResults);
     } catch (error: any) {
       log('error', `Agent loop error at step ${step}: ${error.message}`);
 

--- a/packages/core/src/domain/pool-memory.test.ts
+++ b/packages/core/src/domain/pool-memory.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { recordPoolDeploy, isPoolOnCooldown, isBaseMintOnCooldown, __setPoolMemoryFilePath } from '../domain/pool-memory.js';
+
+const TMP_POOL_MEMORY = path.join(os.tmpdir(), `etemaro-pool-memory-test-${process.pid}.json`);
+
+describe('pool-memory — stop-loss cooldown', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TMP_POOL_MEMORY)) fs.unlinkSync(TMP_POOL_MEMORY);
+    __setPoolMemoryFilePath(TMP_POOL_MEMORY);
+  });
+
+  afterAll(() => {
+    __setPoolMemoryFilePath(null);
+    if (fs.existsSync(TMP_POOL_MEMORY)) fs.unlinkSync(TMP_POOL_MEMORY);
+  });
+
+  it('sets pool + base-mint cooldown on stop-loss close', () => {
+    recordPoolDeploy('PoolA', {
+      pool_name: 'GOBLIN-SOL',
+      base_mint: 'TokenMintXYZ',
+      pnl_pct: -6.35,
+      close_reason: 'stop loss',
+    });
+
+    expect(isPoolOnCooldown('PoolA')).toBe(true);
+    expect(isBaseMintOnCooldown('TokenMintXYZ')).toBe(true);
+  });
+
+  it('does not set stop-loss cooldown on non-stop-loss negative close', () => {
+    recordPoolDeploy('PoolB', {
+      pool_name: 'OTHER/SOL',
+      base_mint: 'OtherMintABC',
+      pnl_pct: -3.2,
+      close_reason: 'agent decision',
+    });
+
+    expect(isPoolOnCooldown('PoolB')).toBe(false);
+    expect(isBaseMintOnCooldown('OtherMintABC')).toBe(false);
+  });
+
+  it('still sets low-yield cooldown as before', () => {
+    recordPoolDeploy('PoolC', {
+      pool_name: 'LOWYIELD/SOL',
+      base_mint: 'LowYieldMint',
+      pnl_pct: 1.2,
+      close_reason: 'low yield (fee/tvl_24h=2.95% threshold=7%)',
+    });
+
+    expect(isPoolOnCooldown('PoolC')).toBe(true);
+  });
+});

--- a/packages/core/src/domain/pool-memory.ts
+++ b/packages/core/src/domain/pool-memory.ts
@@ -13,14 +13,22 @@ import type { PoolMemoryEntry, PoolMemoryDeploy, PoolSnapshot } from '../shared/
 
 const POOL_MEMORY_FILE = dataPath('pool-memory.json');
 
+let _poolMemoryFilePath: string | null = null;
+
+export function __setPoolMemoryFilePath(path: string | null): void {
+  _poolMemoryFilePath = path;
+}
+
 type PoolMemoryDb = Record<string, PoolMemoryEntry>;
 
 function load(): PoolMemoryDb {
-  return loadJsonFile<PoolMemoryDb>(POOL_MEMORY_FILE, {});
+  const file = _poolMemoryFilePath || POOL_MEMORY_FILE;
+  return loadJsonFile<PoolMemoryDb>(file, {});
 }
 
 function save(data: PoolMemoryDb): void {
-  saveJsonFile(POOL_MEMORY_FILE, data);
+  const file = _poolMemoryFilePath || POOL_MEMORY_FILE;
+  saveJsonFile(file, data);
 }
 
 function isFeeGeneratingDeploy(deploy: PoolMemoryDeploy): boolean {
@@ -154,6 +162,21 @@ export function recordPoolDeploy(poolAddress: string, deployData: RecordPoolDepl
     const cooldownHours = 4;
     const cooldownUntil = setPoolCooldown(entry, cooldownHours, 'low yield');
     log('pool-memory', `Cooldown set for ${entry.name} until ${cooldownUntil} (low yield close)`);
+  }
+
+  // Set cooldown for stop-loss closes — pool and token should not be redeployed immediately
+  if (
+    String(deploy.close_reason || '')
+      .toLowerCase()
+      .includes('stop loss')
+  ) {
+    const cooldownHours = Math.max(0, Number(config.management.repeatDeployCooldownHours ?? 12));
+    const poolCooldownUntil = setPoolCooldown(entry, cooldownHours, 'stop loss');
+    const mintCooldownUntil = setBaseMintCooldown(db, entry.base_mint, cooldownHours, 'stop loss');
+    log('pool-memory', `Cooldown set for ${entry.name} until ${poolCooldownUntil} (stop loss close)`);
+    if (entry.base_mint && mintCooldownUntil) {
+      log('pool-memory', `Base mint cooldown set for ${entry.base_mint.slice(0, 8)} until ${mintCooldownUntil} (stop loss close)`);
+    }
   }
 
   const oorTriggerCount = config.management.oorCooldownTriggerCount ?? 3;


### PR DESCRIPTION
Closes #83.

## Summary

- **pool-memory.ts**: Set pool + base-mint cooldown on stop-loss closes using , matching the existing low-yield cooldown behavior. This prevents the same pool from being re-deployed 2.5h after a stop-loss hit.
- **agent-loop.ts**: Pre-filter duplicate `deploy_position` calls within the same assistant message before parallel execution, avoiding the race condition that allowed double-exposure in a single LLM response.

## Tests

- Added `pool-memory.test.ts`: verifies stop-loss cooldown sets both pool and base-mint cooldown, and that non-stop-loss closes do not trigger it.
- Added `agent-loop.test.ts`: verifies a message with 2 `deploy_position` calls results in exactly 1 execution.