### PR TITLE
[Strategy Library] Shared open-source strategy DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ dist/
 .dev/
 data/
 !data/smart-wallets.example.json
+!data/strategy-library.shared.json
 
 .worktrees/
 

--- a/data/strategy-library.shared.json
+++ b/data/strategy-library.shared.json
@@ -1,0 +1,120 @@
+{
+  "active": null,
+  "strategies": {
+    "custom_ratio_spot": {
+      "id": "custom_ratio_spot",
+      "name": "Custom Ratio Spot",
+      "author": "meridian",
+      "lp_strategy": "spot",
+      "token_criteria": {
+        "notes": "Any token. Ratio expresses directional bias."
+      },
+      "entry": {
+        "condition": "Directional view on token",
+        "single_side": null,
+        "notes": "75% token = bullish (sell on pump out of range). 75% SOL = bearish/DCA-in (buy on dip). Set bins_below:bins_above proportional to ratio."
+      },
+      "range": {
+        "type": "custom",
+        "notes": "bins_below:bins_above ratio matches token:SOL ratio. E.g., 75% token → ~52 bins below, ~17 bins above."
+      },
+      "exit": {
+        "take_profit_pct": 10,
+        "notes": "Close when OOR or TP hit. Re-deploy with updated ratio based on new momentum signals."
+      },
+      "best_for": "Expressing directional bias while earning fees both ways"
+    },
+    "single_sided_reseed": {
+      "id": "single_sided_reseed",
+      "name": "Single-Sided Bid-Ask + Re-seed",
+      "author": "meridian",
+      "lp_strategy": "bid_ask",
+      "token_criteria": {
+        "notes": "Volatile tokens with strong narrative. Must have active volume."
+      },
+      "entry": {
+        "condition": "Deploy token-only (amount_x only, amount_y=0) bid-ask, bins below active bin only",
+        "single_side": "token",
+        "notes": "As price drops through bins, token sold for SOL. Bid-ask concentrates at bottom edge."
+      },
+      "range": {
+        "type": "default",
+        "bins_below_pct": 100,
+        "notes": "All bins below active bin. bins_above=0."
+      },
+      "exit": {
+        "notes": "When OOR downside: close_position(skip_swap=true) → redeploy token-only bid-ask at new lower price. Do NOT swap to SOL. Full close only when token dead or after N re-seeds with declining performance."
+      },
+      "best_for": "Riding volatile tokens down without cutting losses. DCA out via LP."
+    },
+    "fee_compounding": {
+      "id": "fee_compounding",
+      "name": "Fee Compounding",
+      "author": "meridian",
+      "lp_strategy": "any",
+      "token_criteria": {
+        "notes": "Stable volume pools with consistent fee generation."
+      },
+      "entry": {
+        "condition": "Deploy normally with any shape",
+        "notes": "Strategy is about management, not entry shape."
+      },
+      "range": {
+        "type": "default",
+        "notes": "Standard range for the pair."
+      },
+      "exit": {
+        "notes": "When unclaimed fees > $5 AND in range: claim_fees → add_liquidity back into same position. Normal close rules otherwise."
+      },
+      "best_for": "Maximizing yield on stable, range-bound pools via compounding"
+    },
+    "multi_layer": {
+      "id": "multi_layer",
+      "name": "Multi-Layer",
+      "author": "meridian",
+      "lp_strategy": "mixed",
+      "token_criteria": {
+        "notes": "High volume pools. Layer multiple shapes into ONE position via addLiquidityByStrategy to sculpt a composite distribution."
+      },
+      "entry": {
+        "condition": "Create ONE position, then layer additional shapes onto it with add-liquidity. Each layer adds a different strategy/shape to the same position, compositing them.",
+        "notes": "Step 1: deploy (creates position with first shape). Step 2+: add-liquidity to same position with different shapes. All layers share the same bin range but different distribution curves stack on top of each other.",
+        "example_patterns": {
+          "smooth_edge": "Deploy Bid-Ask (edges) → add-liquidity Spot (fills the middle gap). 2 layers, 1 position.",
+          "full_composite": "Deploy Bid-Ask (edges) → add-liquidity Spot (middle) → add-liquidity Curve (center boost). 3 layers, 1 position.",
+          "edge_heavy": "Deploy Bid-Ask → add-liquidity Bid-Ask again (double edge weight). 2 layers, 1 position."
+        }
+      },
+      "range": {
+        "type": "custom",
+        "notes": "All layers share the position's bin range (set at deploy). Choose range wide enough for the widest layer needed."
+      },
+      "exit": {
+        "notes": "Single position — one close, one claim. The composite shape means fees earned reflect ALL layers combined."
+      },
+      "best_for": "Creating custom liquidity distributions by stacking shapes in one position. Single position to manage."
+    },
+    "partial_harvest": {
+      "id": "partial_harvest",
+      "name": "Partial Harvest",
+      "author": "meridian",
+      "lp_strategy": "any",
+      "token_criteria": {
+        "notes": "High fee pools where taking profit incrementally is preferred."
+      },
+      "entry": {
+        "condition": "Deploy normally",
+        "notes": "Strategy is about progressive profit-taking, not entry."
+      },
+      "range": {
+        "type": "default",
+        "notes": "Standard range."
+      },
+      "exit": {
+        "take_profit_pct": 10,
+        "notes": "When total return >= 10% of deployed capital: withdraw_liquidity(bps=5000) to take 50% off. Remaining 50% keeps running. Repeat at next threshold."
+      },
+      "best_for": "Locking in profits without fully exiting winning positions"
+    }
+  }
+}

--- a/packages/core/src/domain/strategy-library.ts
+++ b/packages/core/src/domain/strategy-library.ts
@@ -7,18 +7,37 @@
  */
 
 import { log } from '../shared/logger.js';
-import { dataPath } from '../shared/constants.js';
+import { dataPath, repoPath } from '../shared/constants.js';
 import { loadJsonFile, saveJsonFile } from '../shared/utils.js';
 import type { Strategy, StrategyLibraryData } from '../shared/types.js';
 
 const STRATEGY_FILE = dataPath('strategy-library.json');
+const SHARED_STRATEGY_FILE = repoPath('data', 'strategy-library.shared.json');
 
-function load(): StrategyLibraryData {
+function loadPrivate(): StrategyLibraryData {
   return loadJsonFile<StrategyLibraryData>(STRATEGY_FILE, { active: null, strategies: {} });
 }
 
-function save(data: StrategyLibraryData): void {
+function savePrivate(data: StrategyLibraryData): void {
   saveJsonFile(STRATEGY_FILE, data);
+}
+
+function load(): StrategyLibraryData {
+  const sharedDb = loadJsonFile<StrategyLibraryData>(SHARED_STRATEGY_FILE, { active: null, strategies: {} });
+
+  if (Object.keys(sharedDb.strategies).length === 0) {
+    sharedDb.strategies = DEFAULT_STRATEGIES;
+  }
+
+  const privateDb = loadPrivate();
+
+  return {
+    active: privateDb.active || sharedDb.active,
+    strategies: {
+      ...sharedDb.strategies,
+      ...privateDb.strategies,
+    },
+  };
 }
 
 // ─── Default Strategies ─────────────────────────────────────────
@@ -112,22 +131,17 @@ const DEFAULT_STRATEGIES: Record<string, Strategy> = {
 };
 
 function ensureDefaultStrategies(): void {
-  const db = load();
-  let added = false;
-  for (const [id, strategy] of Object.entries(DEFAULT_STRATEGIES)) {
-    if (!db.strategies[id]) {
-      db.strategies[id] = {
-        ...strategy,
-        added_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      };
-      added = true;
-    }
+  const privateDb = loadPrivate();
+  let changed = false;
+
+  if (!privateDb.active) {
+    privateDb.active = 'custom_ratio_spot';
+    changed = true;
   }
-  if (added) {
-    if (!db.active) db.active = 'custom_ratio_spot';
-    save(db);
-    log('strategy', 'Preloaded default strategies');
+
+  if (changed) {
+    savePrivate(privateDb);
+    log('strategy', 'Initialized private strategy library');
   }
 }
 
@@ -166,7 +180,7 @@ export function addStrategy({
 }: AddStrategyOpts): Record<string, unknown> {
   if (!id || !name) return { error: 'id and name are required' };
 
-  const db = load();
+  const privateDb = loadPrivate();
 
   // Slugify id
   const slug = id
@@ -174,7 +188,7 @@ export function addStrategy({
     .replace(/\s+/g, '_')
     .replace(/[^a-z0-9_]/g, '');
 
-  db.strategies[slug] = {
+  privateDb.strategies[slug] = {
     id: slug,
     name,
     author,
@@ -190,11 +204,11 @@ export function addStrategy({
   };
 
   // Auto-set as active if it's the first strategy
-  if (!db.active) db.active = slug;
+  if (!privateDb.active) privateDb.active = slug;
 
-  save(db);
+  savePrivate(privateDb);
   log('strategy', `Strategy saved: ${name} (${slug})`);
-  return { saved: true, id: slug, name, active: db.active === slug };
+  return { saved: true, id: slug, name, active: privateDb.active === slug };
 }
 
 /**
@@ -230,12 +244,14 @@ export function getStrategy({ id }: { id: string }): Record<string, unknown> {
  */
 export function setActiveStrategy({ id }: { id: string }): Record<string, unknown> {
   if (!id) return { error: 'id required' };
-  const db = load();
-  if (!db.strategies[id]) return { error: `Strategy "${id}" not found`, available: Object.keys(db.strategies) };
-  db.active = id;
-  save(db);
-  log('strategy', `Active strategy set to: ${db.strategies[id].name}`);
-  return { active: id, name: db.strategies[id].name };
+  const mergedDb = load();
+  if (!mergedDb.strategies[id]) return { error: `Strategy "${id}" not found`, available: Object.keys(mergedDb.strategies) };
+
+  const privateDb = loadPrivate();
+  privateDb.active = id;
+  savePrivate(privateDb);
+  log('strategy', `Active strategy set to: ${mergedDb.strategies[id].name}`);
+  return { active: id, name: mergedDb.strategies[id].name };
 }
 
 /**
@@ -243,14 +259,31 @@ export function setActiveStrategy({ id }: { id: string }): Record<string, unknow
  */
 export function removeStrategy({ id }: { id: string }): Record<string, unknown> {
   if (!id) return { error: 'id required' };
-  const db = load();
-  if (!db.strategies[id]) return { error: `Strategy "${id}" not found` };
-  const name = db.strategies[id].name;
-  delete db.strategies[id];
-  if (db.active === id) db.active = Object.keys(db.strategies)[0] || null;
-  save(db);
+  const privateDb = loadPrivate();
+
+  if (!privateDb.strategies[id]) {
+    const sharedDb = loadJsonFile<StrategyLibraryData>(SHARED_STRATEGY_FILE, { active: null, strategies: {} });
+    if (sharedDb.strategies[id] || DEFAULT_STRATEGIES[id]) {
+      return { error: `Strategy "${id}" is a shared open-source strategy and cannot be removed locally.` };
+    }
+    return { error: `Strategy "${id}" not found` };
+  }
+
+  const name = privateDb.strategies[id].name;
+  delete privateDb.strategies[id];
+
+  const sharedDb = loadJsonFile<StrategyLibraryData>(SHARED_STRATEGY_FILE, { active: null, strategies: {} });
+  const hasSharedFallback = !!(sharedDb.strategies[id] || DEFAULT_STRATEGIES[id]);
+
+  if (privateDb.active === id && !hasSharedFallback) {
+    const available = new Set([...Object.keys(privateDb.strategies), ...Object.keys(sharedDb.strategies), ...Object.keys(DEFAULT_STRATEGIES)]);
+    available.delete(id);
+    privateDb.active = Array.from(available)[0] || null;
+  }
+
+  savePrivate(privateDb);
   log('strategy', `Strategy removed: ${name}`);
-  return { removed: true, id, name, new_active: db.active };
+  return { removed: true, id, name, new_active: privateDb.active };
 }
 
 /**


### PR DESCRIPTION
## Summary

Implemented a dual-layer strategy library to support a shared, open-source strategy database alongside private, per-client strategies.
- Extracted the hardcoded `DEFAULT_STRATEGIES` into a new, git-tracked file: `data/strategy-library.shared.json`.
- Updated `packages/core/src/domain/strategy-library.ts` to merge the shared strategies with the user's private strategies (`data/strategy-library.json`), prioritizing the private overlay.
- Ensures the active strategy pointer and user modifications live safely in the private overlay, untouched by `git pull`.

Closes #98

## Testing Plan

- [ ] **Manual: First run** — Verify that a fresh start populates the active strategy correctly from the shared file.
- [ ] **Manual: Override** — Verify that modifying a strategy locally creates a private entry that overshadows the shared one.
- [ ] **Edge case: Shared file absent** — Verify that the system falls back to the hardcoded `DEFAULT_STRATEGIES` gracefully.
- [ ] **CI: TypeScript check** — no new type errors
- [ ] **CI: Lint** — no lint errors
- [ ] **CI: Build** — project builds successfully
