### PR TITLE
feat(cli): wire desktop chat adapter into daemon startup

### DIFF
--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -24,6 +24,7 @@ import {
   token,
   study,
   telegram,
+  desktop,
   briefing,
   hivemind,
   tools,
@@ -782,6 +783,7 @@ if (isMain) {
     screening,
     toolExecutor,
     telegram,
+    desktop,
     briefing,
     hivemind,
     domain: {


### PR DESCRIPTION
## Summary
Wire the Desktop Chat HTTP/IPC adapter into the CLI daemon initialization so the etemaro daemon starts listening for desktop app chat connections on port 31415 upon startup.

Closes #96

## Testing Plan
- [x] Unit tests pass: `pnpm test` (10 test files, 44 tests pass including DesktopAdapter.test.ts)
- [x] Workspace build pass: `pnpm build`
- [x] Lint & formatting pass: Husky pre-commit hooks clean