### PR TITLE
feat(telemetry): disambiguate Price PnL vs Net PnL in PerformanceRecord and reporting

### DIFF
--- a/packages/core/src/adapters/BriefingAdapter.ts
+++ b/packages/core/src/adapters/BriefingAdapter.ts
@@ -58,7 +58,8 @@ export async function generateBriefing(options?: GenerateBriefingOptions): Promi
 
   // 2. Performance Activity (from performance log)
   const perfLast24h = (lessonsData.performance || []).filter((p) => p.recorded_at && new Date(p.recorded_at) > last24h);
-  const totalPnLUsd = perfLast24h.reduce((sum, p) => sum + (p.pnl_usd || 0), 0);
+  const totalNetPnLUsd = perfLast24h.reduce((sum, p) => sum + (p.net_pnl_usd ?? p.pnl_usd ?? 0), 0);
+  const totalPricePnLUsd = perfLast24h.reduce((sum, p) => sum + (p.price_pnl_usd ?? (p.pnl_usd || 0) - (p.fees_earned_usd || 0)), 0);
   const totalFeesUsd = perfLast24h.reduce((sum, p) => sum + (p.fees_earned_usd || 0), 0);
 
   // Derive solPrice if not explicitly passed
@@ -97,8 +98,9 @@ export async function generateBriefing(options?: GenerateBriefingOptions): Promi
     `📤 Positions Closed: ${closedLast24h.length}`,
     '',
     'Performance:',
-    `💰 Net PnL: ${totalPnLUsd >= 0 ? '+' : ''}$${totalPnLUsd.toFixed(2)}${fmtSol(totalPnLUsd)}`,
+    `📉 Price PnL: ${totalPricePnLUsd >= 0 ? '+' : ''}$${totalPricePnLUsd.toFixed(2)}${fmtSol(totalPricePnLUsd)}`,
     `💎 Fees Earned: $${totalFeesUsd.toFixed(2)}${fmtSol(totalFeesUsd)}`,
+    `💰 Net PnL: ${totalNetPnLUsd >= 0 ? '+' : ''}$${totalNetPnLUsd.toFixed(2)}${fmtSol(totalNetPnLUsd)}`,
     perfLast24h.length > 0
       ? `📈 Win Rate (24h): ${Math.round((perfLast24h.filter((p) => (p.pnl_pct ?? 0) >= 0).length / perfLast24h.length) * 100)}%`
       : '📈 Win Rate (24h): N/A',

--- a/packages/core/src/adapters/external/HivemindAdapter.test.ts
+++ b/packages/core/src/adapters/external/HivemindAdapter.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../config/Config.js', () => ({
+  config: {
+    hiveMind: {
+      enabled: true,
+      url: 'https://test-hivemind.api',
+      apiKey: 'test-key',
+      agentId: 'agt_test123',
+    },
+  },
+}));
+
+vi.mock('../../shared/logger.js', () => ({
+  log: vi.fn(),
+}));
+
+import { pushHivePerformanceEvent } from './HivemindAdapter.js';
+
+describe('HivemindAdapter — pushHivePerformanceEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('correctly maps pricePnlUsd, netPnlUsd, and pnlUsd in the event payload', async () => {
+    let capturedBody: any = null;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (_url, options) => {
+        capturedBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          json: async () => ({ status: 'ok' }),
+        };
+      }),
+    );
+
+    const result = await pushHivePerformanceEvent({
+      position: 'pos123',
+      pool: 'pool456',
+      pool_name: 'TEST-SOL',
+      initial_value_usd: 100,
+      final_value_usd: 85,
+      fees_earned_usd: 20,
+      price_pnl_usd: -15,
+      price_pnl_pct: -15,
+      net_pnl_usd: 5,
+      pnl_usd: 5,
+      pnl_pct: 5,
+      close_reason: 'manual close',
+    });
+
+    expect(result).toEqual({ status: 'ok' });
+    expect(capturedBody).not.toBeNull();
+
+    const event = capturedBody.event;
+    expect(event.pricePnlUsd).toBe(-15);
+    expect(event.pricePnlPct).toBe(-15);
+    expect(event.netPnlUsd).toBe(5);
+    expect(event.pnlUsd).toBe(5);
+    expect(event.feesUsd).toBe(20);
+  });
+
+  it('falls back to computing pricePnlUsd if price_pnl_usd is missing from legacy record', async () => {
+    let capturedBody: any = null;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (_url, options) => {
+        capturedBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          json: async () => ({ status: 'ok' }),
+        };
+      }),
+    );
+
+    await pushHivePerformanceEvent({
+      position: 'legacy_pos',
+      pool: 'pool1',
+      pnl_usd: 10,
+      fees_earned_usd: 15,
+      pnl_pct: 10,
+      close_reason: 'manual',
+    });
+
+    const event = capturedBody.event;
+    // Fallback: pricePnlUsd = pnl_usd ($10) - fees_earned_usd ($15) = -$5
+    expect(event.pricePnlUsd).toBe(-5);
+    expect(event.netPnlUsd).toBe(10);
+    expect(event.pnlUsd).toBe(10);
+    expect(event.feesUsd).toBe(15);
+  });
+});

--- a/packages/core/src/adapters/external/HivemindAdapter.ts
+++ b/packages/core/src/adapters/external/HivemindAdapter.ts
@@ -478,7 +478,12 @@ export async function pushHivePerformanceEvent(perf: Record<string, unknown>): P
           baseMint: sanitizeStoredText(perf.base_mint, 64) || null,
           strategy: sanitizeStoredText(perf.strategy, 32) || null,
           closeReason: sanitizeStoredText(perf.close_reason, 200) || 'unknown',
-          pnlUsd: Number(perf.pnl_usd || 0),
+          // pnlUsd & netPnlUsd: Net return = price change + fees earned
+          pnlUsd: Number(perf.net_pnl_usd ?? perf.pnl_usd ?? 0),
+          netPnlUsd: Number(perf.net_pnl_usd ?? perf.pnl_usd ?? 0),
+          // pricePnlUsd: Capital gain/loss strictly from token price movement (final_value - initial_value), excluding fees
+          pricePnlUsd: Number(perf.price_pnl_usd ?? Number(perf.pnl_usd ?? 0) - Number(perf.fees_earned_usd ?? 0)),
+          pricePnlPct: Number(perf.price_pnl_pct ?? 0),
           pnlPct: Number(perf.pnl_pct || 0),
           feesUsd: Number(perf.fees_earned_usd || 0),
           feesSol: Number(perf.fees_earned_sol || 0),

--- a/packages/core/src/domain/lessons.test.ts
+++ b/packages/core/src/domain/lessons.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Redirect dataPath() to a temp directory for isolated test environment
+vi.mock('../shared/constants.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../shared/constants.js')>();
+  const nodeFs = await import('node:fs');
+  const nodeOs = await import('node:os');
+  const nodePath = await import('node:path');
+  const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'lessons-test-'));
+  return {
+    ...actual,
+    dataPath: (...segments: string[]) => nodePath.join(dir, ...segments),
+    __testDataDir: dir,
+  };
+});
+
+import { recordPerformance, getPerformanceSummary, getPerformanceHistory } from './lessons.js';
+
+type MockedConstants = typeof import('../shared/constants.js') & { __testDataDir: string };
+const constants = (await import('../shared/constants.js')) as MockedConstants;
+const tmpDir = constants.__testDataDir;
+const lessonsFile = path.join(tmpDir, 'lessons.json');
+
+describe('lessons domain — Price PnL vs Net PnL disambiguation', () => {
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(lessonsFile, JSON.stringify({ lessons: [], performance: [] }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('correctly calculates price_pnl_usd, price_pnl_pct, net_pnl_usd when Price Loss is offset by Fee Yield', async () => {
+    // Initial value: $100
+    // Final value: $90 (price dropped by $10)
+    // Fees earned: $15 (yield)
+    // Price PnL: -$10 (-10%)
+    // Net PnL: -$10 + $15 = +$5 (+5%)
+    await recordPerformance({
+      position: 'pos123',
+      pool: 'pool456',
+      pool_name: 'TEST-SOL',
+      strategy: 'classic',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.2,
+      fee_tvl_ratio: 0.05,
+      organic_score: 85,
+      amount_sol: 1.0,
+      initial_value_usd: 100,
+      final_value_usd: 90,
+      fees_earned_usd: 15,
+      minutes_in_range: 60,
+      minutes_held: 60,
+      close_reason: 'manual close',
+    });
+
+    const fileContent = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'));
+    expect(fileContent.performance).toHaveLength(1);
+
+    const record = fileContent.performance[0];
+    expect(record.price_pnl_usd).toBe(-10);
+    expect(record.price_pnl_pct).toBe(-10);
+    expect(record.net_pnl_usd).toBe(5);
+    expect(record.pnl_usd).toBe(5); // Backward-compatible net return
+    expect(record.pnl_pct).toBe(5);
+    expect(record.fees_earned_usd).toBe(15);
+  });
+
+  it('aggregates summary metrics including price_pnl_usd and total_fees_earned_usd in getPerformanceSummary', async () => {
+    await recordPerformance({
+      position: 'pos1',
+      pool: 'pool1',
+      pool_name: 'FOO-SOL',
+      strategy: 'classic',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.1,
+      fee_tvl_ratio: 0.05,
+      organic_score: 80,
+      amount_sol: 1.0,
+      initial_value_usd: 200,
+      final_value_usd: 180, // Price PnL = -$20 (-10%)
+      fees_earned_usd: 30, // Net PnL = +$10
+      minutes_in_range: 30,
+      minutes_held: 30,
+      close_reason: 'take profit',
+    });
+
+    const summary = getPerformanceSummary();
+    expect(summary).not.toBeNull();
+    expect(summary?.total_positions_closed).toBe(1);
+    expect(summary?.total_pnl_usd).toBe(10);
+    expect(summary?.total_price_pnl_usd).toBe(-20);
+    expect(summary?.total_fees_earned_usd).toBe(30);
+    expect(summary?.avg_pnl_pct).toBe(5);
+    expect(summary?.avg_price_pnl_pct).toBe(-10);
+  });
+
+  it('returns price_pnl_usd and net_pnl_usd in getPerformanceHistory', async () => {
+    await recordPerformance({
+      position: 'pos1',
+      pool: 'pool1',
+      pool_name: 'BAR-SOL',
+      strategy: 'classic',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.1,
+      fee_tvl_ratio: 0.05,
+      organic_score: 80,
+      amount_sol: 1.0,
+      initial_value_usd: 50,
+      final_value_usd: 60, // Price PnL = +$10
+      fees_earned_usd: 5, // Net PnL = +$15
+      minutes_in_range: 30,
+      minutes_held: 30,
+      close_reason: 'manual',
+    });
+
+    const history = getPerformanceHistory({ hours: 24, limit: 10 });
+    expect(history.count).toBe(1);
+    expect(history.total_pnl_usd).toBe(15);
+    expect(history.total_price_pnl_usd).toBe(10);
+    expect(history.total_fees_earned_usd).toBe(5);
+
+    const pos = (history.positions as Record<string, unknown>[])[0]!;
+    expect(pos.price_pnl_usd).toBe(10);
+    expect(pos.net_pnl_usd).toBe(15);
+    expect(pos.pnl_usd).toBe(15);
+  });
+});

--- a/packages/core/src/domain/lessons.ts
+++ b/packages/core/src/domain/lessons.ts
@@ -74,7 +74,10 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
     return;
   }
 
-  const pnl_usd = perf.final_value_usd + perf.fees_earned_usd - perf.initial_value_usd;
+  const price_pnl_usd = perf.final_value_usd - perf.initial_value_usd;
+  const price_pnl_pct = perf.initial_value_usd > 0 ? (price_pnl_usd / perf.initial_value_usd) * 100 : 0;
+  const net_pnl_usd = price_pnl_usd + perf.fees_earned_usd;
+  const pnl_usd = net_pnl_usd;
   const pnl_pct = perf.initial_value_usd > 0 ? (pnl_usd / perf.initial_value_usd) * 100 : 0;
   const range_efficiency = perf.minutes_held > 0 ? (perf.minutes_in_range / perf.minutes_held) * 100 : 0;
 
@@ -94,6 +97,9 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
   const entry = {
     ...perf,
     signal_snapshot: signalSnapshot as SignalSnapshot | null as unknown as SignalSnapshot | undefined,
+    price_pnl_usd: Math.round(price_pnl_usd * 100) / 100,
+    price_pnl_pct: Math.round(price_pnl_pct * 100) / 100,
+    net_pnl_usd: Math.round(net_pnl_usd * 100) / 100,
     pnl_usd: Math.round(pnl_usd * 100) / 100,
     pnl_pct: Math.round(pnl_pct * 100) / 100,
     range_efficiency: Math.round(range_efficiency * 10) / 10,
@@ -126,6 +132,9 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
       base_mint: perf.base_mint,
       deployed_at: perf.deployed_at,
       closed_at: entry.recorded_at,
+      price_pnl_usd: entry.price_pnl_usd,
+      price_pnl_pct: entry.price_pnl_pct,
+      net_pnl_usd: entry.net_pnl_usd,
       pnl_pct: entry.pnl_pct,
       pnl_usd: entry.pnl_usd,
       range_efficiency: entry.range_efficiency,
@@ -648,6 +657,10 @@ export function getPerformanceHistory({ hours = 24, limit = 50 }: GetPerformance
       pool_name: r.pool_name,
       pool: r.pool,
       strategy: r.strategy,
+      price_pnl_usd:
+        r.price_pnl_usd ?? (r.pnl_usd != null && r.fees_earned_usd != null ? Math.round((r.pnl_usd - r.fees_earned_usd) * 100) / 100 : null),
+      price_pnl_pct: r.price_pnl_pct ?? null,
+      net_pnl_usd: r.net_pnl_usd ?? r.pnl_usd,
       pnl_usd: r.pnl_usd,
       pnl_pct: r.pnl_pct,
       fees_earned_usd: r.fees_earned_usd,
@@ -657,13 +670,17 @@ export function getPerformanceHistory({ hours = 24, limit = 50 }: GetPerformance
       closed_at: r.recorded_at,
     }));
 
-  const totalPnl = filtered.reduce((s, r) => s + (r.pnl_usd ?? 0), 0);
-  const wins = filtered.filter((r) => r.pnl_pct! >= 0).length;
+  const totalPnl = filtered.reduce((s, r) => s + (r.net_pnl_usd ?? r.pnl_usd ?? 0), 0);
+  const totalPricePnl = filtered.reduce((s, r) => s + (r.price_pnl_usd ?? (r.pnl_usd ?? 0) - (r.fees_earned_usd ?? 0)), 0);
+  const totalFees = filtered.reduce((s, r) => s + (r.fees_earned_usd ?? 0), 0);
+  const wins = filtered.filter((r) => (r.pnl_pct ?? 0) >= 0).length;
 
   return {
     hours,
     count: filtered.length,
     total_pnl_usd: Math.round(totalPnl * 100) / 100,
+    total_price_pnl_usd: Math.round(totalPricePnl * 100) / 100,
+    total_fees_earned_usd: Math.round(totalFees * 100) / 100,
     win_rate_pct: filtered.length > 0 ? Math.round((wins / filtered.length) * 100) : null,
     positions: filtered,
   };
@@ -678,15 +695,21 @@ export function getPerformanceSummary(): Record<string, unknown> | null {
 
   if (p.length === 0) return null;
 
-  const totalPnl = p.reduce((s, x) => s + x.pnl_usd!, 0);
-  const avgPnlPct = p.reduce((s, x) => s + x.pnl_pct!, 0) / p.length;
-  const avgRangeEfficiency = p.reduce((s, x) => s + x.range_efficiency!, 0) / p.length;
-  const wins = p.filter((x) => x.pnl_pct! >= 0).length;
+  const totalPnl = p.reduce((s, x) => s + (x.net_pnl_usd ?? x.pnl_usd ?? 0), 0);
+  const totalPricePnl = p.reduce((s, x) => s + (x.price_pnl_usd ?? (x.pnl_usd ?? 0) - (x.fees_earned_usd ?? 0)), 0);
+  const totalFees = p.reduce((s, x) => s + (x.fees_earned_usd ?? 0), 0);
+  const avgPnlPct = p.reduce((s, x) => s + (x.pnl_pct ?? 0), 0) / p.length;
+  const avgPricePnlPct = p.reduce((s, x) => s + (x.price_pnl_pct ?? 0), 0) / p.length;
+  const avgRangeEfficiency = p.reduce((s, x) => s + (x.range_efficiency ?? 0), 0) / p.length;
+  const wins = p.filter((x) => (x.pnl_pct ?? 0) >= 0).length;
 
   return {
     total_positions_closed: p.length,
     total_pnl_usd: Math.round(totalPnl * 100) / 100,
+    total_price_pnl_usd: Math.round(totalPricePnl * 100) / 100,
+    total_fees_earned_usd: Math.round(totalFees * 100) / 100,
     avg_pnl_pct: Math.round(avgPnlPct * 100) / 100,
+    avg_price_pnl_pct: Math.round(avgPricePnlPct * 100) / 100,
     avg_range_efficiency_pct: Math.round(avgRangeEfficiency * 10) / 10,
     win_rate_pct: Math.round((wins / p.length) * 100),
     total_lessons: data.lessons.length,

--- a/packages/core/src/domain/pool-memory.ts
+++ b/packages/core/src/domain/pool-memory.ts
@@ -74,6 +74,9 @@ interface RecordPoolDeployData {
   closed_at?: string;
   pnl_pct?: number | null;
   pnl_usd?: number | null;
+  price_pnl_usd?: number | null;
+  price_pnl_pct?: number | null;
+  net_pnl_usd?: number | null;
   fees_earned_usd?: number | null;
   fees_earned_sol?: number | null;
   fee_earned_pct?: number | null;
@@ -122,6 +125,9 @@ export function recordPoolDeploy(poolAddress: string, deployData: RecordPoolDepl
     closed_at: deployData.closed_at || new Date().toISOString(),
     pnl_pct: deployData.pnl_pct ?? null,
     pnl_usd: deployData.pnl_usd ?? null,
+    price_pnl_usd: deployData.price_pnl_usd ?? null,
+    price_pnl_pct: deployData.price_pnl_pct ?? null,
+    net_pnl_usd: deployData.net_pnl_usd ?? null,
     fees_earned_usd: deployData.fees_earned_usd ?? null,
     fees_earned_sol: deployData.fees_earned_sol ?? null,
     fee_earned_pct: deployData.fee_earned_pct ?? null,

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -220,7 +220,15 @@ export interface PerformanceRecord {
   close_reason: string;
   deployed_at?: string;
   signal_snapshot?: SignalSnapshot;
+  /** Price-only PnL in USD (final_value_usd - initial_value_usd), excluding fees */
+  price_pnl_usd?: number;
+  /** Percentage price-only PnL */
+  price_pnl_pct?: number;
+  /** Net return in USD (price_pnl_usd + fees_earned_usd) */
+  net_pnl_usd?: number;
+  /** Legacy alias for net_pnl_usd (net return including fees) */
   pnl_usd?: number;
+  /** Legacy alias for net percentage return */
   pnl_pct?: number;
   range_efficiency?: number;
   recorded_at?: string;
@@ -328,6 +336,12 @@ export interface PoolMemoryDeploy {
   closed_at: string;
   pnl_pct: number | null;
   pnl_usd: number | null;
+  /** Price-only PnL in USD (final_value_usd - initial_value_usd) */
+  price_pnl_usd?: number | null;
+  /** Percentage price-only PnL */
+  price_pnl_pct?: number | null;
+  /** Net return in USD (price_pnl_usd + fees_earned_usd) */
+  net_pnl_usd?: number | null;
   fees_earned_usd: number | null;
   fees_earned_sol: number | null;
   fee_earned_pct: number | null;


### PR DESCRIPTION
## Context & Summary

In `PerformanceRecord`, `pnl_usd` represents **Net Return** (Price Change + Fees Earned). However, concentrated liquidity positions often experience **Price Loss** (underlying token price dropping) offset by positive **LP Fee Yield**. Without separating `price_pnl_usd` from `fees_earned_usd`, downstream dashboards and reporting tools cannot distinguish price movement from fee yield.

This PR extends performance tracking to explicitly calculate and record:
- `price_pnl_usd` — Pure price change (`final_value_usd - initial_value_usd`)
- `price_pnl_pct` — Percentage price change
- `net_pnl_usd` — Net return (`price_pnl_usd + fees_earned_usd`)
- `pnl_usd` — Backward-compatible alias equal to `net_pnl_usd`

Closes #117

## Changes Made
- **Types (`types.ts`)**: Added `price_pnl_usd`, `price_pnl_pct`, and `net_pnl_usd` to `PerformanceRecord` and `PoolMemoryDeploy`.
- **Domain Logic (`lessons.ts` & `pool-memory.ts`)**: Updated `recordPerformance` and pool deploy tracking to calculate price and net PnL, and updated `getPerformanceSummary` and `getPerformanceHistory` to aggregate price/fee metrics.
- **Reporting Adapters (`BriefingAdapter.ts` & `HivemindAdapter.ts`)**: Formatted Telegram briefings to display Price PnL, Fees Earned, and Net PnL, and updated HiveMind performance telemetry push.
- **Tests**: Added unit tests in `lessons.test.ts` and `HivemindAdapter.test.ts`.

## Testing Plan
- [x] **Unit tests**: Passed 49/49 unit tests across 12 test suites (`pnpm test`).
- [x] **Typecheck**: Clean TypeScript compilation across `@etemaro/core`, `@etemaro/daemon`, and `@etemaro/cli` (`tsc --noEmit`).