### PR TITLE
fix(smart-wallets): refactor diff/veto logic, fix snapshot retry bug & update docs (#126)

### DIFF
--- a/docs/QA.md
+++ b/docs/QA.md
@@ -309,4 +309,4 @@ You can change the `entrySource` under the `screening` section of your `config/u
 }
 ```
 
-When this mode is enabled, the agent completely skips scraping public markets for trending pools. Instead, it regularly checks the LP positions of the tracked `lp` smart wallets and will automatically copy them into any new positions they enter, provided the new pools pass the deterministic screening filters (TVL, token age, warnings, etc.) configured in your `user-config.json`. The LLM veto engine is bypassed for maximum speed.
+When this mode is enabled, the agent completely skips scraping public markets for trending pools. Instead, it regularly checks the LP positions of the tracked `lp` smart wallets and uses newly entered pools as candidate signals. If the candidate pool passes your configured deterministic screening filters (TVL, token age, warnings, organic score, etc.), the agent deploys into the pool using your own strategy, SOL deposit sizing, and management rules. (Note: This is candidate discovery driven by smart wallet signals; deploy sizing, bin strategies, and exit rules remain 100% your own).

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -10,3 +10,4 @@ export * from './strategy-library.js';
 export * from './token-blacklist.js';
 export * from './dev-blocklist.js';
 export * from './smart-wallets.js';
+export * from './smart-wallets-screening.js';

--- a/packages/core/src/domain/smart-wallets-screening.test.ts
+++ b/packages/core/src/domain/smart-wallets-screening.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { diffSmartWalletPositions, updateSnapshotPositions, type SmartWalletSnapshot, type WalletPositionItem } from './smart-wallets-screening.js';
+
+describe('Smart Wallets Screening Logic', () => {
+  describe('diffSmartWalletPositions', () => {
+    it('initializes snapshot on first run and records baseline without returning new positions', () => {
+      const current: WalletPositionItem[] = [
+        { position: 'pos1', pool: 'poolA' },
+        { position: 'pos2', pool: 'poolB' },
+      ];
+
+      const res = diffSmartWalletPositions(current, null);
+
+      expect(res.isFirstRun).toBe(true);
+      expect(res.newPositions).toEqual([]);
+      expect(res.uniquePools).toEqual([]);
+      expect(res.nextSnapshot).toEqual({
+        initialized: true,
+        positions: ['pos1', 'pos2'],
+      });
+    });
+
+    it('initializes snapshot on first run even when zero positions are active', () => {
+      const current: WalletPositionItem[] = [];
+
+      const res = diffSmartWalletPositions(current, { initialized: false, positions: [] });
+
+      expect(res.isFirstRun).toBe(true);
+      expect(res.nextSnapshot.initialized).toBe(true);
+      expect(res.nextSnapshot.positions).toEqual([]);
+
+      // Second run: wallet opens position 1
+      const currentRun2: WalletPositionItem[] = [{ position: 'pos1', pool: 'poolA' }];
+      const resRun2 = diffSmartWalletPositions(currentRun2, res.nextSnapshot);
+
+      expect(resRun2.isFirstRun).toBe(false);
+      expect(resRun2.newPositions).toEqual([{ position: 'pos1', pool: 'poolA' }]);
+      expect(resRun2.uniquePools).toEqual(['poolA']);
+    });
+
+    it('identifies newly opened positions and unique pools correctly', () => {
+      const snapshot: SmartWalletSnapshot = {
+        initialized: true,
+        positions: ['pos1'],
+      };
+
+      const current: WalletPositionItem[] = [
+        { position: 'pos1', pool: 'poolA' },
+        { position: 'pos2', pool: 'poolB' },
+        { position: 'pos3', pool: 'poolB' }, // duplicate poolB
+      ];
+
+      const res = diffSmartWalletPositions(current, snapshot);
+
+      expect(res.isFirstRun).toBe(false);
+      expect(res.newPositions).toEqual([
+        { position: 'pos2', pool: 'poolB' },
+        { position: 'pos3', pool: 'poolB' },
+      ]);
+      expect(res.uniquePools).toEqual(['poolB']);
+    });
+  });
+
+  describe('updateSnapshotPositions', () => {
+    it('only commits resolved (successful or vetoed) positions to snapshot', () => {
+      const snapshot: SmartWalletSnapshot = {
+        initialized: true,
+        positions: ['pos1'],
+      };
+
+      const processed = [
+        { position: 'pos2', resolved: true }, // Vetoed or successfully deployed
+        { position: 'pos3', resolved: false }, // Deploy failed with network error
+      ];
+
+      const updated = updateSnapshotPositions(snapshot, processed);
+
+      expect(updated.positions).toContain('pos1');
+      expect(updated.positions).toContain('pos2');
+      expect(updated.positions).not.toContain('pos3'); // Retry pos3 on next tick
+    });
+  });
+});

--- a/packages/core/src/domain/smart-wallets-screening.ts
+++ b/packages/core/src/domain/smart-wallets-screening.ts
@@ -1,0 +1,80 @@
+/**
+ * @file smart-wallets-screening.ts
+ * @description Pure helper logic for smart wallet candidate discovery, snapshot diffing, and position ledger tracking.
+ */
+
+export interface SmartWalletSnapshot {
+  initialized: boolean;
+  positions: string[];
+}
+
+export interface WalletPositionItem {
+  position: string;
+  pool: string;
+}
+
+export interface SmartWalletDiffResult {
+  isFirstRun: boolean;
+  newPositions: WalletPositionItem[];
+  uniquePools: string[];
+  nextSnapshot: SmartWalletSnapshot;
+}
+
+/**
+ * Calculates new smart wallet positions against a snapshot ledger.
+ * On first run (!snapshot.initialized), initializes the snapshot with currentPositions and returns isFirstRun: true.
+ */
+export function diffSmartWalletPositions(
+  currentPositions: WalletPositionItem[],
+  existingSnapshot?: SmartWalletSnapshot | null,
+): SmartWalletDiffResult {
+  const snapshot: SmartWalletSnapshot =
+    existingSnapshot && typeof existingSnapshot === 'object'
+      ? { initialized: Boolean(existingSnapshot.initialized), positions: Array.isArray(existingSnapshot.positions) ? existingSnapshot.positions : [] }
+      : { initialized: false, positions: [] };
+
+  if (!snapshot.initialized) {
+    const allPos = Array.from(new Set(currentPositions.map((p) => p.position)));
+    return {
+      isFirstRun: true,
+      newPositions: [],
+      uniquePools: [],
+      nextSnapshot: {
+        initialized: true,
+        positions: allPos,
+      },
+    };
+  }
+
+  const knownSet = new Set(snapshot.positions);
+  const newPositions = currentPositions.filter((p) => !knownSet.has(p.position));
+  const uniquePools = Array.from(new Set(newPositions.map((p) => p.pool).filter(Boolean)));
+
+  return {
+    isFirstRun: false,
+    newPositions,
+    uniquePools,
+    nextSnapshot: { ...snapshot },
+  };
+}
+
+/**
+ * Updates snapshot ledger with newly processed positions.
+ * Only positions marked as resolved (successful deploy or vetoed) are committed to the known positions set.
+ * Failed deployments are left uncommitted so they can retry on the next screening tick.
+ */
+export function updateSnapshotPositions(
+  snapshot: SmartWalletSnapshot,
+  processedPositions: { position: string; resolved: boolean }[],
+): SmartWalletSnapshot {
+  const knownSet = new Set(snapshot.positions);
+  for (const item of processedPositions) {
+    if (item.resolved) {
+      knownSet.add(item.position);
+    }
+  }
+  return {
+    initialized: true,
+    positions: Array.from(knownSet),
+  };
+}

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -1248,7 +1248,7 @@ IMPORTANT:
 
     // 2. Load snapshot
     const snapshotPath = path.join(getDataDir(), '.smart-wallets-snapshot.json');
-    let snapshot: { positions: string[] } = { positions: [] };
+    let snapshot: domain.SmartWalletSnapshot | null = null;
     if (fs.existsSync(snapshotPath)) {
       try {
         snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
@@ -1256,48 +1256,50 @@ IMPORTANT:
         log('cron_error', `[SmartWallets] Failed to load snapshot: ${e.message}`);
       }
     }
-    const isFirstRun = snapshot.positions.length === 0;
 
     // 3. Fetch positions for each wallet
-    const currentPositions: string[] = [];
-    const poolToPos = new Map<string, string>();
+    const currentPositions: domain.WalletPositionItem[] = [];
     for (const w of trackedWallets) {
       try {
         const result = await meteora.getWalletPositions({ wallet_address: w.address });
         for (const p of result.positions || []) {
-          currentPositions.push(p.position);
-          poolToPos.set(p.position, p.pool);
+          if (p.position && p.pool) {
+            currentPositions.push({ position: p.position, pool: p.pool });
+          }
         }
       } catch (e: any) {
         log('cron_error', `[SmartWallets] Failed to fetch positions for ${w.address}: ${e.message}`);
       }
     }
 
-    // 4. Update snapshot
-    const newPositions = currentPositions.filter((p) => !snapshot.positions.includes(p));
-    snapshot.positions = currentPositions;
-    fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2), 'utf8');
+    // 4. Calculate diff using pure domain helper
+    const diff = domain.diffSmartWalletPositions(currentPositions, snapshot);
 
-    if (isFirstRun) {
-      log('cron', `[SmartWallets] Smart wallets initialized (first run snapshot recorded with ${currentPositions.length} positions).`);
-      return 'Smart wallets initialized (first run snapshot recorded).';
+    if (diff.isFirstRun) {
+      fs.writeFileSync(snapshotPath, JSON.stringify(diff.nextSnapshot, null, 2), 'utf8');
+      log('cron', `[SmartWallets] Smart wallets initialized (baseline snapshot recorded with ${diff.nextSnapshot.positions.length} positions).`);
+      return 'Smart wallets initialized (baseline snapshot recorded).';
     }
 
-    if (!newPositions.length) {
+    if (!diff.newPositions.length) {
       log('cron', '[SmartWallets] No new positions detected by smart wallets.');
       return 'No new positions detected by smart wallets.';
     }
 
-    // 5. Deploy on new unique pools
+    // 5. Deploy on candidate pools and track resolution
     let deployedCount = 0;
-    const uniquePools = Array.from(new Set(newPositions.map((pos) => poolToPos.get(pos)!).filter(Boolean)));
+    const processedPositions: { position: string; resolved: boolean }[] = [];
 
-    for (const pool of uniquePools) {
+    for (const posItem of diff.newPositions) {
+      const pool = posItem.pool;
+      if (!pool) continue;
+
       try {
         // Skip if already deployed
         const openPositions = getTrackedPositions(true);
         if (openPositions.some((p) => p.pool === pool)) {
           log('cron', `[SmartWallets] Skipped pool ${pool}: Already have an open position.`);
+          processedPositions.push({ position: posItem.position, resolved: true });
           continue;
         }
 
@@ -1305,12 +1307,14 @@ IMPORTANT:
         const detail = await screening.getPoolDetail({ pool_address: pool });
         if (!detail) {
           log('cron', `[SmartWallets] Could not fetch pool details for ${pool}.`);
+          processedPositions.push({ position: posItem.position, resolved: false });
           continue;
         }
 
         const rejectReason = screening.getRawPoolScreeningRejectReason(detail as any, config.screening);
         if (rejectReason) {
           log('cron', `[SmartWallets] Vetoed ${detail.name || pool}: ${rejectReason}`);
+          processedPositions.push({ position: posItem.position, resolved: true });
           continue;
         }
 
@@ -1331,10 +1335,16 @@ IMPORTANT:
         domain.recordPositionSnapshot(pool, deployRes.position);
         log('cron', `[SmartWallets] Deployed ${deployRes.position.position} on ${detail.name || pool}`);
         deployedCount++;
+        processedPositions.push({ position: posItem.position, resolved: true });
       } catch (e: any) {
         log('cron_error', `[SmartWallets] Deploy failed for pool ${pool}: ${e.message}`);
+        processedPositions.push({ position: posItem.position, resolved: false });
       }
     }
+
+    // Save updated snapshot after processing
+    const updatedSnapshot = domain.updateSnapshotPositions(diff.nextSnapshot, processedPositions);
+    fs.writeFileSync(snapshotPath, JSON.stringify(updatedSnapshot, null, 2), 'utf8');
 
     return `Smart wallet cycle completed. Deployed to ${deployedCount} new pools.`;
   }


### PR DESCRIPTION
## Description
Addresses PR review feedback for Issue #123.

### Changes Included
1. **Pure Domain Module (`smart-wallets-screening.ts`):**
   - Extracted `diffSmartWalletPositions` and `updateSnapshotPositions` into a pure, testable domain module.
   - Added explicit `initialized: boolean` state flag to prevent the 'first-run baseline' bug when wallets initially have zero open positions.
2. **Retry Support for Failed Deployments:**
   - Position pubkeys that fail deployment (e.g. RPC/network error) are NOT committed to the snapshot ledger (`resolved: false`), allowing them to be safely retried on subsequent screening ticks.
   - Vetoed pools and successful deploys are marked `resolved: true` and committed to the ledger.
3. **Comprehensive Unit Tests (`smart-wallets-screening.test.ts`):**
   - Tests baseline initialization with 0 positions vs N positions.
   - Tests diffing logic and unique pool grouping.
   - Tests snapshot updating behavior for resolved vs unresolved positions.
4. **Documentation & QA Terminology Update:**
   - Removed misleading 'copying' language in `docs/QA.md`.
   - Explicitly clarified that `entrySource: "smart_wallets"` provides wallet-sourced candidate discovery while deploy sizing, bin strategy, risk filters, and exits remain 100% our own.