### PR TITLE
fix: load private strategy library without agent suffix

### DIFF
--- a/packages/core/src/domain/strategy-library.test.ts
+++ b/packages/core/src/domain/strategy-library.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import * as lib from './strategy-library.js';
+import * as logger from '../shared/logger.js';
+import { config } from '../config/Config.js';
 
 // No need for global vi.mock here, using vi.spyOn in the test
 
@@ -40,5 +42,111 @@ describe('strategy-library persistence and validation', () => {
 
     expect(result).toHaveProperty('error');
     expect((result as any).error).toMatch(/Failed to update user config.*Disk full/);
+  });
+});
+
+describe('strategy-library loads both shared and private libraries', () => {
+  const sharedStrategies = {
+    single_sided_reseed: { id: 'single_sided_reseed', name: 'Single-Sided Reseed', author: 'meridian' },
+    custom_ratio_spot: { id: 'custom_ratio_spot', name: 'Custom Ratio Spot', author: 'meridian' },
+  };
+  const privateStrategies = {
+    copy_trade_lag: { id: 'copy_trade_lag', name: 'Copy Trade Lag', author: 'custom' },
+  };
+
+  const actualExistsSync = fs.existsSync;
+  const actualReadFileSync = fs.readFileSync;
+
+  function mockLibraries() {
+    vi.spyOn(fs, 'existsSync').mockImplementation((pathArg: any) => {
+      const p = pathArg.toString();
+      if (p.includes('strategy-library.shared.json')) return true;
+      if (p.includes('strategy-library.json')) return true;
+      return actualExistsSync(pathArg);
+    });
+    vi.spyOn(fs, 'readFileSync').mockImplementation((pathArg: any, options: any) => {
+      const p = pathArg.toString();
+      if (p.includes('strategy-library.shared.json')) {
+        return JSON.stringify({ strategies: sharedStrategies });
+      }
+      if (p.includes('strategy-library.json')) {
+        return JSON.stringify({ strategies: privateStrategies });
+      }
+      return actualReadFileSync(pathArg, options);
+    });
+  }
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('listStrategies includes strategies from both the shared and private libraries', () => {
+    mockLibraries();
+    const result = lib.listStrategies();
+    const ids = (result.strategies as Array<{ id: string }>).map((s) => s.id);
+    expect(ids).toContain('single_sided_reseed');
+    expect(ids).toContain('custom_ratio_spot');
+    expect(ids).toContain('copy_trade_lag');
+  });
+
+  it('getStrategy resolves a strategy that only exists in the private library', () => {
+    mockLibraries();
+    const result = lib.getStrategy({ id: 'copy_trade_lag' });
+    expect(result.error).toBeUndefined();
+    expect(result.name).toBe('Copy Trade Lag');
+    expect(result.author).toBe('custom');
+  });
+
+  it('getStrategy returns not-found for an id in neither library', () => {
+    mockLibraries();
+    const result = lib.getStrategy({ id: 'does_not_exist' });
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('validateActiveStrategy succeeds for a strategy that only exists in the private library', () => {
+    mockLibraries();
+    const originalActive = config.strategy.activeStrategyId;
+    try {
+      config.strategy.activeStrategyId = 'copy_trade_lag';
+      expect(() => lib.validateActiveStrategy()).not.toThrow();
+    } finally {
+      config.strategy.activeStrategyId = originalActive;
+    }
+  });
+
+  it('validateActiveStrategy throws for an id present in neither library', () => {
+    mockLibraries();
+    const originalActive = config.strategy.activeStrategyId;
+    try {
+      config.strategy.activeStrategyId = 'does_not_exist';
+      expect(() => lib.validateActiveStrategy()).toThrow(/not found in the strategy library/);
+    } finally {
+      config.strategy.activeStrategyId = originalActive;
+    }
+  });
+
+  it('flags duplicate strategy ids shared between the private and shared libraries', () => {
+    const logSpy = vi.spyOn(logger, 'log');
+    const sharedWithCollision = {
+      copy_trade_lag: { id: 'copy_trade_lag', name: 'Shared copy trade', author: 'meridian' },
+    };
+    vi.spyOn(fs, 'existsSync').mockImplementation((pathArg: any) => {
+      const p = pathArg.toString();
+      return p.includes('strategy-library.shared.json') || p.includes('strategy-library.json');
+    });
+    vi.spyOn(fs, 'readFileSync').mockImplementation((pathArg: any, options: any) => {
+      const p = pathArg.toString();
+      if (p.includes('strategy-library.shared.json')) {
+        return JSON.stringify({ strategies: sharedWithCollision });
+      }
+      if (p.includes('strategy-library.json')) {
+        return JSON.stringify({ strategies: privateStrategies });
+      }
+      return actualReadFileSync(pathArg, options);
+    });
+
+    lib.listStrategies();
+
+    const warned = logSpy.mock.calls.some((call) => typeof call[1] === 'string' && /collides with a shared strategy id/.test(call[1]));
+    expect(warned).toBe(true);
   });
 });

--- a/packages/core/src/domain/strategy-library.ts
+++ b/packages/core/src/domain/strategy-library.ts
@@ -11,12 +11,12 @@
 
 import fs from 'node:fs';
 import { log } from '../shared/logger.js';
-import { dataPath, repoPath, configPath } from '../shared/constants.js';
+import { strategyLibraryPath, repoPath, configPath } from '../shared/constants.js';
 import { loadJsonFile, saveJsonFile } from '../shared/utils.js';
 import { config } from '../config/Config.js';
 import type { Strategy, StrategyLibraryData } from '../shared/types.js';
 
-const STRATEGY_FILE = dataPath('strategy-library.json');
+const STRATEGY_FILE = strategyLibraryPath('strategy-library.json');
 const SHARED_STRATEGY_FILE = repoPath('data', 'strategy-library.shared.json');
 
 function loadPrivate(): StrategyLibraryData {
@@ -31,7 +31,7 @@ function load(): StrategyLibraryData {
   let sharedDb = loadJsonFile<StrategyLibraryData>(SHARED_STRATEGY_FILE, { strategies: {} });
 
   if (Object.keys(sharedDb.strategies).length === 0) {
-    const localSharedFile = dataPath('strategy-library.shared.json');
+    const localSharedFile = strategyLibraryPath('strategy-library.shared.json');
     if (fs.existsSync(localSharedFile)) {
       sharedDb = loadJsonFile<StrategyLibraryData>(localSharedFile, { strategies: {} });
     }
@@ -42,6 +42,14 @@ function load(): StrategyLibraryData {
   }
 
   const privateDb = loadPrivate();
+
+  const sharedIds = new Set(Object.keys(sharedDb.strategies));
+  for (const id of Object.keys(privateDb.strategies)) {
+    if (sharedIds.has(id)) {
+      log('strategy', `Warning: private strategy '${id}' collides with a shared strategy id and overrides it.`);
+      log('strategy', `Duplicate strategy ids between shared and private libraries should be resolved (see issue #148).`);
+    }
+  }
 
   return {
     strategies: {

--- a/packages/core/src/shared/constants.test.ts
+++ b/packages/core/src/shared/constants.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { REPO_ROOT, configPath, dataPath, getDataDir } from './constants.js';
+import { REPO_ROOT, configPath, dataPath, getDataDir, strategyLibraryPath } from './constants.js';
 
 const ENV_KEYS = ['USER_CONFIG_PATH', 'ETEMARO_DATA_DIR', 'DATA_DIR'] as const;
 
@@ -97,5 +97,19 @@ describe('REPO_ROOT resolves to the pnpm workspace root', () => {
     if (!home) return;
     process.env.ETEMARO_DATA_DIR = '~/.config/etemaro/data';
     expect(getDataDir()).toBe(path.resolve(home, '.config/etemaro/data'));
+  });
+
+  it('strategyLibraryPath does NOT add agent suffix even with a custom USER_CONFIG_PATH (issue #148 regression)', () => {
+    envSnap = snapshotEnv();
+    delete process.env.ETEMARO_DATA_DIR;
+    delete process.env.DATA_DIR;
+    process.env.USER_CONFIG_PATH = '/path/to/config/agt_a717d5fa29c5d09fe188bc16.json';
+
+    // state.json is intentionally agent-suffixed...
+    expect(dataPath('state.json')).toBe(path.join(REPO_ROOT, 'data', 'state-agt_a717d5fa29c5d09fe188bc16.json'));
+    // ...but the strategy library files must NOT be, so the private/shared
+    // libraries resolve for every agent and validateActiveStrategy() finds the strategy.
+    expect(strategyLibraryPath('strategy-library.json')).toBe(path.join(REPO_ROOT, 'data', 'strategy-library.json'));
+    expect(strategyLibraryPath('strategy-library.shared.json')).toBe(path.join(REPO_ROOT, 'data', 'strategy-library.shared.json'));
   });
 });

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -113,6 +113,20 @@ export function dataPath(...segments: string[]): string {
   return path.join(baseDir, ...segments);
 }
 
+/**
+ * Resolve a path relative to the data directory for the strategy libraries.
+ *
+ * Unlike `dataPath`, the strategy library files must NOT get an agent-name
+ * suffix: there are exactly two shared-across-agents strategy libraries
+ * (the repo-tracked `strategy-library.shared.json` and the per-deployment,
+ * user-maintained `strategy-library.json`). Applying the agent suffix here
+ * made `validateActiveStrategy()` fail to find private strategies when a
+ * custom agent config was active (see GitHub issue #148).
+ */
+export function strategyLibraryPath(...segments: string[]): string {
+  return path.join(getDataDir(), ...segments);
+}
+
 /** Resolve a path relative to the config directory. */
 export function configPath(...segments: string[]): string {
   // Honor USER_CONFIG_PATH env var for the main config file


### PR DESCRIPTION
Fixes #148

## Problem

The private strategy library (`data/strategy-library.json`) was resolved via `dataPath('strategy-library.json')`. `dataPath()` appends an agent-name suffix to `.json` filenames when a custom `USER_CONFIG_PATH` is active. So with a custom agent config the daemon looked for `data/strategy-library-<suffix>.json` (which doesn't exist), the private library contributed nothing, and `validateActiveStrategy()` threw:

```
Startup failed: Strategy 'copy_trade_lag' specified in config is not found in the strategy library.
```

## Fix

- Add `strategyLibraryPath(...)` in `packages/core/src/shared/constants.ts` that resolves strategy library files under the data dir **without** the agent suffix. There are exactly two shared-across-agents strategy libraries: the repo-tracked `strategy-library.shared.json` and the per-deployment, user-maintained `strategy-library.json` — these must not be per-agent.
- Use it in `packages/core/src/domain/strategy-library.ts` for the private file and the local shared fallback.
- Emit a `Warning:` (non-fatal) in `load()` when a private strategy id collides with a shared id, surfacing the duplicate-id concern.

## Tests

- `constants.test.ts`: regression guard — `strategyLibraryPath('strategy-library.json')` / `strategy-library.shared.json` are **not** suffixed even with a custom `USER_CONFIG_PATH`, while `state.json` still is.
- `strategy-library.test.ts`: `listStrategies` includes ids from both libraries; `getStrategy` resolves a private-only strategy (`copy_trade_lag`); not-found for unknown id; `validateActiveStrategy` succeeds for a private-only id and throws for a missing one; duplicate shared/private ids are flagged.

## Verification

- `npm test`: 106 passed (all suites).
- `tsc --noEmit` clean for `@etemaro/core` and `@etemaro/daemon`.
