### PR TITLE
fix(screening): resolve candidate count and fee/TVL log contradictions

### DIFF
--- a/packages/core/src/adapters/ToolDefinitions.ts
+++ b/packages/core/src/adapters/ToolDefinitions.ts
@@ -26,11 +26,11 @@ Pools are pre-filtered for safety:
 - Base token holders >= 100
 - Volume >= $1k (in timeframe)
 - Active TVL >= $10k
-- Fee/Active TVL ratio >= 0.01 (in timeframe)
+- Windowed fee/TVL (screening timeframe, not real-time active-bin) >= 0.01
 - Both tokens organic score >= 60
 
 Returns condensed pool data: address, name, tokens, bin_step, fee_pct,
-active_tvl, fee_window, volume_window, fee_tvl_ratio, volatility from max(timeframe, 30m), organic_score,
+active_tvl, fee_window, volume_window, windowed fee/TVL (fee_active_tvl_ratio), volatility from max(timeframe, 30m), organic_score,
 holders, mcap, active_positions, price_change_pct, warning count.
 
 Use this as the primary tool for finding new LP opportunities.`,
@@ -62,7 +62,8 @@ Use this as the primary tool for finding new LP opportunities.`,
       name: 'get_top_candidates',
       description: `Get the top pre-scored pool candidates for deployment review.
 All filtering, scoring, and rule-checking is done in code — no analysis needed.
-Returns the top N eligible pools ranked by score (fee/TVL, organic, stability, volume).
+Returns the top N eligible pools ranked by score (windowed fee/TVL, organic, stability, volume).
+Also returns total_screened (raw pools evaluated) and filtered_examples so logs can show scanned vs shortlisted.
 Each pool includes a score (0-100) and has already passed all hard disqualifiers.
 Use this instead of discover_pools for screening cycles.
 If this returns one candidate, still judge whether it is actually worth deploying; one weak candidate should be skipped.`,

--- a/packages/core/src/adapters/ToolExecutor.screening.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.screening.test.ts
@@ -134,6 +134,7 @@ describe('ToolExecutor - deploy_position screening via validateDeployPoolThresho
     const result = await _validateDeployPoolThresholds({ pool_address: discoveryPool.pool_address });
 
     expect(result.pass).toBe(false);
+    expect(result.reason).toContain('Real-time active-bin fee/TVL');
     expect(result.reason).toContain('below configured minFeeActiveTvlRatio');
   });
 });

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -247,16 +247,16 @@ async function validateDeployPoolThresholds(args: Record<string, unknown>): Prom
       if (!usingDlmmFallback) {
         return {
           pass: false,
-          reason: 'Could not verify pool fee/active-TVL before deploy.',
+          reason: 'Could not verify pool real-time active-bin fee/TVL before deploy.',
         };
       }
       warnings.push(
-        'Pool fee/active-TVL ratio unavailable (Pool Discovery API indexing lag); using DLMM fallback pair data — skipped strict ratio filter.',
+        'Pool real-time active-bin fee/TVL ratio unavailable (Pool Discovery API indexing lag); using DLMM fallback pair data — skipped strict ratio filter.',
       );
     } else if (feeActiveTvlRatio < minFeeActiveTvlRatio) {
       return {
         pass: false,
-        reason: `Pool fee/active-TVL ${feeActiveTvlRatio}% is below configured minFeeActiveTvlRatio ${minFeeActiveTvlRatio}%.`,
+        reason: `Real-time active-bin fee/TVL ${feeActiveTvlRatio}% is below configured minFeeActiveTvlRatio ${minFeeActiveTvlRatio}%.`,
       };
     }
   }

--- a/packages/core/src/adapters/blockchain/ScreeningAdapter.test.ts
+++ b/packages/core/src/adapters/blockchain/ScreeningAdapter.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { candidateScanTotals, windowedFeeTvlRejectReason } from './ScreeningAdapter.js';
+
+describe('candidateScanTotals', () => {
+  it('counts filtered discovery pools as scanned even when none are shortlisted', () => {
+    expect(candidateScanTotals({ pools: [], filtered_examples: [{}, {}, {}, {}, {}] }, 0)).toEqual({
+      total_screened: 5,
+      total_eligible: 0,
+    });
+  });
+
+  it('adds surviving discovery pools to filtered examples (issue #168: 6 scanned / 1 shortlisted)', () => {
+    expect(candidateScanTotals({ pools: [{}], filtered_examples: [{}, {}, {}, {}, {}] }, 1)).toEqual({
+      total_screened: 6,
+      total_eligible: 1,
+    });
+  });
+});
+
+describe('windowedFeeTvlRejectReason', () => {
+  it('labels the screening-time metric as windowed fee/TVL with the timeframe', () => {
+    expect(windowedFeeTvlRejectReason(0.0129, 0.05, '24h')).toBe('windowed fee/TVL (24h) 0.0129 < min 0.05');
+  });
+
+  it('uses unknown when the ratio is missing', () => {
+    expect(windowedFeeTvlRejectReason(Number.NaN, 0.05, '5m')).toBe('windowed fee/TVL (5m) unknown < min 0.05');
+  });
+});

--- a/packages/core/src/adapters/blockchain/ScreeningAdapter.ts
+++ b/packages/core/src/adapters/blockchain/ScreeningAdapter.ts
@@ -182,7 +182,26 @@ export interface DiscoverPoolsResult {
 export interface TopCandidatesResult {
   candidates: CondensedPool[];
   total_screened: number;
+  total_eligible: number;
   filtered_examples: FilteredExample[];
+}
+
+export function candidateScanTotals(
+  discovery: { pools?: unknown[]; filtered_examples?: unknown[] },
+  eligibleLength: number,
+): { total_screened: number; total_eligible: number } {
+  const poolCount = Array.isArray(discovery.pools) ? discovery.pools.length : 0;
+  const filteredCount = Array.isArray(discovery.filtered_examples) ? discovery.filtered_examples.length : 0;
+  return {
+    total_screened: poolCount + filteredCount,
+    total_eligible: eligibleLength,
+  };
+}
+
+export function windowedFeeTvlRejectReason(feeTvlRatio: number, minFeeTvlRatio: number, timeframe: string): string {
+  const value = Number.isFinite(feeTvlRatio) ? String(feeTvlRatio) : 'unknown';
+  const tf = timeframe || 'window';
+  return `windowed fee/TVL (${tf}) ${value} < min ${minFeeTvlRatio}`;
 }
 
 export interface PoolDetailResult {
@@ -325,7 +344,7 @@ export function getRawPoolScreeningRejectReason(pool: RawPool, s: typeof config.
   if (binStep == null || binStep < s.minBinStep) return `bin_step ${binStep ?? 'unknown'} below minBinStep ${s.minBinStep}`;
   if (binStep > s.maxBinStep) return `bin_step ${binStep} above maxBinStep ${s.maxBinStep}`;
   if (feeActiveTvlRatio == null || feeActiveTvlRatio < s.minFeeActiveTvlRatio) {
-    return `fee/active-TVL ${feeActiveTvlRatio ?? 'unknown'} below minFeeActiveTvlRatio ${s.minFeeActiveTvlRatio}`;
+    return windowedFeeTvlRejectReason(feeActiveTvlRatio ?? Number.NaN, s.minFeeActiveTvlRatio, String(s.timeframe || ''));
   }
   if (!isUsableVolatility(volatility)) {
     return `volatility ${volatility ?? 'unknown'} is unusable`;
@@ -897,7 +916,7 @@ export async function getTopCandidates({ limit = 10 } = {}): Promise<TopCandidat
         pushFilteredReason(
           filteredOut,
           p,
-          `fee/active-TVL ${Number.isFinite(feeActiveTvlRatio) ? feeActiveTvlRatio : 'unknown'} below minFeeActiveTvlRatio ${minFeeActiveTvlRatio}`,
+          windowedFeeTvlRejectReason(feeActiveTvlRatio, minFeeActiveTvlRatio, String(config.screening.timeframe || '')),
         );
         return false;
       }
@@ -994,10 +1013,12 @@ export async function getTopCandidates({ limit = 10 } = {}): Promise<TopCandidat
     }
   }
 
+  const totals = candidateScanTotals(discovery, eligible.length);
   return {
     candidates: eligible,
-    total_screened: pools.length,
-    filtered_examples: filteredOut.slice(0, 3),
+    total_screened: totals.total_screened,
+    total_eligible: totals.total_eligible,
+    filtered_examples: filteredOut.slice(0, 8),
   };
 }
 

--- a/packages/core/src/adapters/notifications/TelegramAdapter.test.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { notifySwap, notifySwapError } from './TelegramAdapter.js';
+import { notifySwap, notifySwapError, summarizeToolResult } from './TelegramAdapter.js';
 import * as NotificationSink from './NotificationSink.js';
 
 vi.mock('./NotificationSink.js', () => ({
@@ -48,6 +48,30 @@ describe('TelegramAdapter notifications', () => {
       'Swapped Council → SOL',
       'In: 1250 | Out: 0.0240 SOL\nTx: 5K8x7q1234567890...',
     );
+  });
+
+  it('summarizeToolResult reports scanned vs shortlisted for get_top_candidates', () => {
+    expect(
+      summarizeToolResult('get_top_candidates', {
+        candidates: [{ name: 'STACY-SOL' }],
+        total_screened: 6,
+        filtered_examples: [{ name: 'fone-SOL' }, { name: 'TOAD-SOL' }],
+      }),
+    ).toBe('6 scanned / 1 shortlisted');
+  });
+
+  it('summarizeToolResult does not say 0 candidates when pools were scanned but none shortlisted', () => {
+    expect(
+      summarizeToolResult('get_top_candidates', {
+        candidates: [],
+        total_screened: 0,
+        filtered_examples: [{ name: 'fone-SOL' }, { name: 'TOAD-SOL' }, { name: 'GTA6-SOL' }, { name: 'Morty-SOL' }, { name: 'GHOST-SOL' }],
+      }),
+    ).toBe('5 scanned / 0 shortlisted');
+  });
+
+  it('summarizeToolResult reserves 0 candidates for a truly empty fetch', () => {
+    expect(summarizeToolResult('get_top_candidates', { candidates: [] })).toBe('0 candidates');
   });
 
   it('notifySwapError formats failure alert', async () => {

--- a/packages/core/src/adapters/notifications/TelegramAdapter.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.ts
@@ -274,6 +274,16 @@ function createTypingIndicator(): { stop: () => void } {
   };
 }
 
+export function formatCandidateScanSummary(result: any): string {
+  const shortlisted = Array.isArray(result?.candidates) ? result.candidates.length : Array.isArray(result?.pools) ? result.pools.length : 0;
+  const filtered = Array.isArray(result?.filtered_examples) ? result.filtered_examples.length : 0;
+  const reported = Number(result?.total_screened);
+  const inferred = shortlisted + filtered;
+  const scanned = Number.isFinite(reported) && reported > 0 ? Math.max(reported, inferred) : inferred;
+  if (scanned <= 0 && shortlisted <= 0) return '0 candidates';
+  return `${scanned} scanned / ${shortlisted} shortlisted`;
+}
+
 function toolLabel(name: string): string {
   const labels: Record<string, string> = {
     get_token_info: 'get token info',
@@ -298,7 +308,7 @@ function toolLabel(name: string): string {
   return labels[name] || name.replace(/_/g, ' ');
 }
 
-function summarizeToolResult(name: string, result: any): string {
+export function summarizeToolResult(name: string, result: any): string {
   if (!result) return '';
   if (result.error) return result.error;
   if (result.reason && result.blocked) return result.reason;
@@ -312,7 +322,8 @@ function summarizeToolResult(name: string, result: any): string {
     case 'update_config':
       return Object.keys(result.applied || {}).join(', ') || 'updated';
     case 'get_top_candidates':
-      return `${result.candidates?.length ?? 0} candidates`;
+    case 'discover_pools':
+      return formatCandidateScanSummary(result);
     case 'get_my_positions':
       return `${result.total_positions ?? result.positions?.length ?? 0} positions`;
     case 'get_wallet_balance':

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -960,7 +960,14 @@ After evaluating, write a brief one-line result per position.
           ? `\nSTRATEGY CONTEXT: ${activeStrategy.name} — entry: ${activeStrategy.entry?.condition || 'n/a'} | exit: ${activeStrategy.exit?.notes || 'n/a'} | best for: ${activeStrategy.bestFor}`
           : '');
 
-      const topCandidates = await this.adapters.screening.getTopCandidates({ limit: 10 }).catch(() => null);
+      await liveMessage?.toolStart('get_top_candidates');
+      const topCandidates = await this.adapters.screening.getTopCandidates({ limit: 10 }).catch(async (error: any) => {
+        await liveMessage?.toolFinish('get_top_candidates', { error: error?.message || 'failed' }, false);
+        return null;
+      });
+      if (topCandidates) {
+        await liveMessage?.toolFinish('get_top_candidates', topCandidates, true);
+      }
       const candidates = (topCandidates?.candidates || topCandidates?.pools || []).slice(0, 10);
       const earlyFilteredExamples = topCandidates?.filtered_examples || [];
 
@@ -1076,7 +1083,7 @@ After evaluating, write a brief one-line result per position.
 
         const block = [
           `POOL: ${pool.name} (${pool.pool})`,
-          `  metrics: bin_step=${pool.bin_step}, fee_pct=${pool.fee_pct}%, fee_tvl=${pool.fee_active_tvl_ratio}, vol=$${pool.volume_window}, tvl=$${pool.tvl ?? pool.active_tvl}, volatility_${pool.volatility_timeframe || '30m'}=${pool.volatility}, mcap=$${pool.mcap}, organic=${pool.organic_score}${pool.token_age_hours != null ? `, age=${pool.token_age_hours}h` : ''}`,
+          `  metrics: bin_step=${pool.bin_step}, fee_pct=${pool.fee_pct}%, windowed_fee/TVL(${config.screening.timeframe || 'window'})=${pool.fee_active_tvl_ratio}, vol=$${pool.volume_window}, tvl=$${pool.tvl ?? pool.active_tvl}, volatility_${pool.volatility_timeframe || '30m'}=${pool.volatility}, mcap=$${pool.mcap}, organic=${pool.organic_score}${pool.token_age_hours != null ? `, age=${pool.token_age_hours}h` : ''}`,
           `  audit: top10=${top10Pct}%, bots=${botPct}%, fees=${feesSol}SOL${launchpad ? `, launchpad=${launchpad}` : ''}`,
           pvpLine,
           `  smart_wallets: ${sw?.in_pool?.length ?? 0} present${sw?.in_pool?.length ? ` → CONFIDENCE BOOST (${sw.in_pool.map((w: any) => w.name).join(', ')})` : ''}`,
@@ -1117,8 +1124,17 @@ SCREENING CYCLE
 ${strategyBlock}
 Positions: ${prePositions.total_positions}/${config.risk.maxPositions} | SOL: ${currentBalance.sol.toFixed(3)} | Deploy: ${deployAmount} SOL
 
+SCAN: ${topCandidates?.total_screened ?? candidates.length} screened / ${passing.length} shortlisted
 PRE-LOADED CANDIDATES (${passing.length} pools):
 ${candidateBlocks.join('\n\n')}
+${
+  earlyFilteredExamples.length
+    ? `\nREJECTED DURING FETCH (${earlyFilteredExamples.length}):\n${earlyFilteredExamples
+        .slice(0, 8)
+        .map((entry: any) => `- ${entry.name}: ${entry.reason}`)
+        .join('\n')}`
+    : ''
+}
 
 STEPS:
 1. Decide if any candidate is actually worth deploying. One surviving candidate is not automatically good enough.
@@ -1146,7 +1162,8 @@ STEPS:
      range_coverage.width_pct
 
    MARKET
-   Fee/TVL: <x>%
+   Windowed Fee/TVL (${config.screening.timeframe || 'window'}): <x>%
+   (Do not confuse this with real-time active-bin fee/TVL from deploy_position blocks.)
    Volume: $<x>
    TVL: $<x>
    Volatility: <x>
@@ -1379,7 +1396,7 @@ IMPORTANT:
       const lines = candidates.map((pool: any, i: number) => {
         const feeTvl = pool.fee_active_tvl_ratio ?? pool.fee_tvl_ratio ?? '?';
         const vol = pool.volume_window ?? pool.volume_24h ?? '?';
-        return `${i + 1}. ${pool.name} | ${pool.pool}\n   fee/aTVL ${feeTvl}% | vol $${vol} | organic ${pool.organic_score ?? '?'}`;
+        return `${i + 1}. ${pool.name} | ${pool.pool}\n   windowed fee/TVL ${feeTvl}% | vol $${vol} | organic ${pool.organic_score ?? '?'}`;
       });
       return `Top candidates (${candidates.length})\n\n${lines.join('\n')}`;
     }
@@ -2185,7 +2202,7 @@ IMPORTANT:
       const vol = pool.volume_window ?? pool.volume_24h ?? '?';
       const active = pool.active_pct ?? '?';
       const organic = pool.organic_score ?? '?';
-      return `${i + 1}. ${pool.name} | fee/aTVL ${feeTvl}% | vol $${vol} | in-range ${active}% | organic ${organic}`;
+      return `${i + 1}. ${pool.name} | windowed fee/TVL ${feeTvl}% | vol $${vol} | in-range ${active}% | organic ${organic}`;
     });
     const age = this.latestCandidatesAt ? new Date(this.latestCandidatesAt).toLocaleString('en-US', { hour12: false }) : 'unknown';
     return `Latest candidates (${this.latestCandidates.length}) — updated ${age}\n\n${lines.join('\n')}`;
@@ -2200,10 +2217,10 @@ IMPORTANT:
       const vol = `$${((p.volume_window || 0) / 1000).toFixed(1)}k`.padStart(8);
       const active = `${p.active_pct}%`.padStart(6);
       const org = String(p.organic_score).padStart(4);
-      return `  [${i + 1}]  ${name}  fee/aTVL:${ftvl}  vol:${vol}  in-range:${active}  organic:${org}`;
+      return `  [${i + 1}]  ${name}  windowed fee/TVL:${ftvl}  vol:${vol}  in-range:${active}  organic:${org}`;
     });
 
-    return ['  #   pool                  fee/aTVL     vol    in-range  organic', '  ' + '─'.repeat(68), ...lines].join('\n');
+    return ['  #   pool                  windowed fee/TVL  vol    in-range  organic', '  ' + '─'.repeat(68), ...lines].join('\n');
   }
 
   // ─── Session History ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
Screening live logs said `0 candidates` after pools were scanned and filtered, and used the same `fee_tvl` wording for windowed screening ratios and real-time deploy-time active-bin checks.

This change reports scanned vs shortlisted counts, labels the two fee/TVL checks distinctly, and puts the daemon's own candidate fetch on the Telegram live message.

Closes #168

## Root Cause & Gap Analysis
- **Why/When it happened**: `summarizeToolResult('get_top_candidates')` used only `candidates.length`. `getTopCandidates` set `total_screened` to surviving discovery pools, ignoring filtered examples. Candidate blocks labeled `fee_tvl=` for `fee_active_tvl_ratio` while deploy validation said `fee/active-TVL` for a later snapshot.
- **Why we missed it**: No unit coverage of Telegram candidate summaries or discovery scan totals; screening reports mixed LLM prose with unlabeled metrics.

## Acceptance Criteria Checklist
- [x] AC1: `get top candidates` live summary shows `N scanned / M shortlisted`; `0 candidates` only when nothing was fetched
- [x] AC2: Screening rejects use windowed fee/TVL (timeframe); deploy blocks use real-time active-bin fee/TVL
- [x] AC3: Regression tests cover both contradictions
- [x] AC4: Full vitest suite green (118/118)

## Testing Plan
- [x] **Unit: Telegram summarizeToolResult** — scanned/shortlisted vs true empty fetch
- [x] **Unit: candidateScanTotals / windowedFeeTvlRejectReason**
- [x] **Unit: deploy threshold reason contains Real-time active-bin fee/TVL**
- [x] **CI: Automated Tests** — 118 passing locally; waiting on GitHub checks