### PR TITLE
fix(state): surface state.json write failures

### DIFF
--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { reconcileTrackedPositions, getTrackedPositions, trackPosition, syncOpenPositions, __setStateFilePath } from './state.js';
+import {
+  reconcileTrackedPositions,
+  getTrackedPositions,
+  getTrackedPosition,
+  trackPosition,
+  recordClose,
+  syncOpenPositions,
+  __setStateFilePath,
+} from './state.js';
 
 // Isolate the test from the real data/state.json via the test seam.
 const TMP_STATE = path.join(os.tmpdir(), `etemaro-state-test-${process.pid}.json`);
@@ -85,5 +93,66 @@ describe('reconcileTrackedPositions', () => {
     syncOpenPositions(['PosY']); // PosZ not in on-chain list
     const tracked = getTrackedPositions(true);
     expect(tracked.find((p) => p.position === 'PosZ')).toBeUndefined();
+  });
+});
+
+function deployOpts(position: string) {
+  return {
+    position,
+    pool: 'PoolFail',
+    pool_name: 'FAIL/SOL',
+    strategy: 'bid_ask',
+    bin_range: { min: 1, max: 2 },
+    amount_sol: 0.1,
+    active_bin: 1,
+    bin_step: 100,
+    volatility: 1,
+    fee_tvl_ratio: 1,
+    organic_score: 70,
+    initial_value_usd: 50,
+  } as const;
+}
+
+describe('save() persistence failures', () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  it('trackPosition throws when state.json cannot be written and does not pretend the position was tracked', () => {
+    const spy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    try {
+      expect(() => trackPosition(deployOpts('PosPersistFail') as any)).toThrow('disk full');
+      expect(getTrackedPosition('PosPersistFail')).toBeNull();
+      expect(fs.existsSync(TMP_STATE)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('recordClose throws when state.json cannot be written and leaves the position open on disk', () => {
+    trackPosition(deployOpts('PosCloseFail') as any);
+    expect(getTrackedPosition('PosCloseFail')?.closed).toBe(false);
+
+    const spy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('permission denied');
+    });
+
+    try {
+      expect(() => recordClose('PosCloseFail', 'agent decision')).toThrow('permission denied');
+      expect(getTrackedPosition('PosCloseFail')?.closed).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -51,6 +51,7 @@ function save(state: StateData): void {
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     log('state_error', `Failed to write state.json: ${message}`);
+    throw err;
   }
 }
 

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -523,6 +523,8 @@ Summarize the current portfolio health, total fees earned, and performance of al
           }
           break; // one action per tick
         }
+      } catch (e: any) {
+        log('cron_error', `PnL poll failed: ${e.message}`);
       } finally {
         this.pnlPollBusy = false;
       }


### PR DESCRIPTION
## Summary
`save()` in `state.ts` logged `state.json` write failures and returned as if persistence succeeded. Every mutator reloads from disk, so the next call (not just a restart) already lost the write. This rethrows after the existing `state_error` log, matching `lessons` / `pool-memory`. The PnL poller now catches the throw so it does not become an unhandled rejection.

Closes #134

## Root Cause & Gap Analysis
- **Why/When**: `saveJsonFile` throws on disk-full / permission / rename failure; `save()` swallowed it. Callers (`trackPosition`, `recordClose`, `recordSwapFailure`, `confirmPeak`, …) logged success anyway.
- **Why we missed it**: atomic-write tests exist for `saveJsonFile`, but nothing asserted that `state.save()` propagated the throw.

## Acceptance Criteria Checklist
- [x] AC1: `save()` logs then rethrows the original error
- [x] AC2: `trackPosition` / `recordClose` do not pretend disk was updated
- [x] AC3: PnL poller stays up (`cron_error`) if persistence throws
- [x] AC4: 126 tests passing; core typecheck clean

## Testing Plan
- [x] Unit: disk-full `trackPosition` throws and leaves no file
- [x] Unit: permission-denied `recordClose` throws and leaves position open
- [x] CI: Typecheck & Lint
- [x] CI: Automated Tests

## Production notes
- Deploy/close adapters already map thrown errors to `{ success: false, error }` — operators see the failure instead of a silent desync.
- Disk-full remains an operator incident; this does not invent a new alert channel.