### PR TITLE
feat(cli): support explicit --config and --data-dir CLI flags with unified precedence

### DIFF
--- a/packages/cli/src/Cli.test.ts
+++ b/packages/cli/src/Cli.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { resolveGlobalFlagValue } from './Cli.js';
+
+describe('resolveGlobalFlagValue', () => {
+  it('returns the value following the long flag', () => {
+    expect(resolveGlobalFlagValue(['--config', '/tmp/cfg.json'], '--config')).toBe('/tmp/cfg.json');
+  });
+
+  it('returns the value following an alias', () => {
+    expect(resolveGlobalFlagValue(['-c', '/tmp/cfg.json'], '--config', '-c')).toBe('/tmp/cfg.json');
+  });
+
+  it('returns undefined when the flag is absent', () => {
+    expect(resolveGlobalFlagValue(['balance', '--portal'], '--config', '-c')).toBeUndefined();
+  });
+
+  it('returns undefined when the flag has no following value', () => {
+    expect(resolveGlobalFlagValue(['balance', '--config'], '--config')).toBeUndefined();
+  });
+
+  it('returns undefined when the following token is another flag', () => {
+    expect(resolveGlobalFlagValue(['balance', '--config', '--dry-run'], '--config')).toBeUndefined();
+  });
+
+  it('extends forward to find the value past the subcommand', () => {
+    expect(resolveGlobalFlagValue(['balance', '--data-dir', '/tmp/d'], '--data-dir', '-d')).toBe('/tmp/d');
+  });
+});

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -16,28 +16,64 @@ dotenv.config({ override: true });
 import fs from 'fs';
 import path from 'path';
 import { parseArgs } from 'util';
-import {
-  config,
-  computeDeployAmount,
-  getTrackedPosition,
-  log,
-  dataPath,
-  meteora,
-  wallet,
-  screening,
-  toolExecutor,
-  domain,
-  token,
-  study,
-  telegram,
-  desktop,
-  briefing,
-  hivemind,
-  tools,
-  defaultUserConfigStr,
-  DEFAULT_STRATEGIES,
-} from '@etemaro/core';
-import { Daemon } from '@etemaro/daemon';
+
+// Type-only imports to help tsc
+type CoreExports = typeof import('@etemaro/core');
+type DaemonExports = typeof import('@etemaro/daemon');
+
+// Lazily populated core exports (set after flag parsing)
+let config: CoreExports['config'] = null as any;
+let computeDeployAmount: CoreExports['computeDeployAmount'] = null as any;
+let getTrackedPosition: CoreExports['getTrackedPosition'] = null as any;
+let log: CoreExports['log'] = null as any;
+let dataPath: CoreExports['dataPath'] = null as any;
+let meteora: CoreExports['meteora'] = null as any;
+let wallet: CoreExports['wallet'] = null as any;
+let screening: CoreExports['screening'] = null as any;
+let toolExecutor: CoreExports['toolExecutor'] = null as any;
+let domain: CoreExports['domain'] = null as any;
+let token: CoreExports['token'] = null as any;
+let study: CoreExports['study'] = null as any;
+let telegram: CoreExports['telegram'] = null as any;
+let desktop: CoreExports['desktop'] = null as any;
+let briefing: CoreExports['briefing'] = null as any;
+let hivemind: CoreExports['hivemind'] = null as any;
+let tools: CoreExports['tools'] = null as any;
+let defaultUserConfigStr: CoreExports['defaultUserConfigStr'] = null as any;
+let DEFAULT_STRATEGIES: CoreExports['DEFAULT_STRATEGIES'] = null as any;
+
+// Lazily populated Daemon constructor
+let DaemonCtor: DaemonExports['Daemon'] = null as any;
+
+/**
+ * Load core and daemon modules after environment is prepared.
+ * Must be called before using any core functionality.
+ */
+async function loadCore(): Promise<void> {
+  const [coreMod, daemonMod] = await Promise.all([import('@etemaro/core'), import('@etemaro/daemon')]);
+  // Assign core exports
+  config = coreMod.config;
+  computeDeployAmount = coreMod.computeDeployAmount;
+  getTrackedPosition = coreMod.getTrackedPosition;
+  log = coreMod.log;
+  dataPath = coreMod.dataPath;
+  meteora = coreMod.meteora;
+  wallet = coreMod.wallet;
+  screening = coreMod.screening;
+  toolExecutor = coreMod.toolExecutor;
+  domain = coreMod.domain;
+  token = coreMod.token;
+  study = coreMod.study;
+  telegram = coreMod.telegram;
+  desktop = coreMod.desktop;
+  briefing = coreMod.briefing;
+  hivemind = coreMod.hivemind;
+  tools = coreMod.tools;
+  defaultUserConfigStr = coreMod.defaultUserConfigStr;
+  DEFAULT_STRATEGIES = coreMod.DEFAULT_STRATEGIES;
+  // Assign Daemon constructor
+  DaemonCtor = daemonMod.Daemon;
+}
 
 // ─── Adapter Imports ────────────────────────────────────────────
 
@@ -271,6 +307,8 @@ Starts the autonomous agent with cron jobs (management + screening).
 ## Flags
 --dry-run     Skip all on-chain transactions
 --silent      Suppress Telegram notifications for this run
+--config <path>  Path to user-config.json (alias: -c). Overrides USER_CONFIG_PATH env var.
+--data-dir <path>  Data directory (alias: -d). Overrides ETEMARO_DATA_DIR/DATA_DIR env vars.
 `;
 
 // ─── Output Helpers ─────────────────────────────────────────────
@@ -859,6 +897,38 @@ function isCliTarget(filePath: string | undefined): boolean {
 const isMain = isCliTarget(process.argv[1]) || (typeof require !== 'undefined' && require.main === module);
 
 if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+/**
+ * Extract the value for a `--flag`/`-f` pair from an argv array.
+ * Returns undefined if the flag is absent, has no value, or the value
+ * looks like another flag (so `etemaro balance --config` with no path
+ * does not swallow the next subcommand).
+ *
+ * Extracted as a pure function for direct unit testing.
+ */
+export function resolveGlobalFlagValue(argv: string[], flag: string, alias?: string): string | undefined {
+  const idx = argv.findIndex((a) => a === flag || (alias !== undefined && a === alias));
+  if (idx === -1) return undefined;
+  const value = argv[idx + 1];
+  if (value === undefined || value.startsWith('-')) return undefined;
+  return value;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+
+  const configPathArg = resolveGlobalFlagValue(argv, '--config', '-c');
+  const dataDirArg = resolveGlobalFlagValue(argv, '--data-dir', '-d');
+  if (configPathArg) process.env.USER_CONFIG_PATH = path.resolve(configPathArg);
+  if (dataDirArg) process.env.ETEMARO_DATA_DIR = path.resolve(dataDirArg);
+
+  await loadCore();
+
   const agentLoopDeps = {
     executeTool: toolExecutor.executeTool,
     getTools: () => tools,
@@ -886,7 +956,7 @@ if (isMain) {
     getWeightsSummary: domain.getWeightsSummary,
   };
 
-  const daemon = new Daemon({
+  const daemon = new DaemonCtor({
     meteora,
     wallet,
     screening,
@@ -920,8 +990,5 @@ if (isMain) {
     token,
     daemon,
   });
-  cli.run().catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+  await cli.run(argv);
 }


### PR DESCRIPTION
Closes #169

## Summary
Add global CLI flags `--config`/`-c` and `--data-dir`/`-d` to the standalone CLI so users can point at a custom user config and data directory without touching environment variables.

## Precedence
CLI flag \> env var (`USER_CONFIG_PATH`, `ETEMARO_DATA_DIR`/`DATA_DIR`) \> default path (`config/user-config.json`, `<REPO_ROOT>/data`)

## Implementation
- Parse flags in a new async `main()` *before* any `@etemaro/core`/`@etemaro/daemon` module is imported (config singleton + data-path resolution run at import time)
- Replaced static imports with type-only imports + lazily-populated module bindings via `loadCore()`
- Added exported pure helper `resolveGlobalFlagValue()` (unit-tested)
- Daemon started via `etemaro start` inherits the flags through env vars since it is a child of the CLI

## Verification
- 130/130 tests pass (6 new for `resolveGlobalFlagValue`)
- `pnpm run typecheck` clean (core/daemon/cli)
- tsup CJS build success