### PR TITLE
fix(agent-loop): allow SCREENER no-deploy verdicts and deploy_position fallback on safety blocks

### DIFF
--- a/packages/core/src/application/agent-loop.test.ts
+++ b/packages/core/src/application/agent-loop.test.ts
@@ -189,3 +189,242 @@ describe('agent-loop — resilient concurrent tool execution (Issue #133)', () =
     expect(onToolFinish).toHaveBeenCalledWith(expect.objectContaining({ name: 'check_pool', success: false }));
   });
 });
+
+describe('agent-loop — SCREENER tool enforcement & deploy_position lockout (Issue #127)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows SCREENER role to return ⛔ NO DEPLOY without tool calls on first step', async () => {
+    const executeTool = vi.fn();
+    const getTools = vi.fn().mockReturnValue([]);
+    const getWalletBalances = vi.fn().mockResolvedValue({ sol: 10, tokens: [] });
+    const getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    const getStateSummary = vi.fn().mockReturnValue(null);
+    const getLessonsForPrompt = vi.fn().mockReturnValue(null);
+    const getPerformanceSummary = vi.fn().mockReturnValue(null);
+    const getDecisionSummary = vi.fn().mockReturnValue(null);
+
+    // LLM response: ⛔ NO DEPLOY text on first turn without any tool calls
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: '⛔ NO DEPLOY\n\nCycle finished with no valid entry.\n\nWHY SKIPPED\nAll candidate pools had low organic volume.',
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const screeningGoal = `
+SCREENING CYCLE
+Positions: 0/2 | SOL: 10.000 | Deploy: 1.0 SOL
+PRE-LOADED CANDIDATES (2 pools):
+POOL: TEST/SOL (Pool1)
+  metrics: bin_step=20, fee_pct=0.25%, windowed_fee/TVL(5m)=0.01
+
+STEPS:
+1. Decide if any candidate is actually worth deploying.
+2. Call deploy_position if valid.
+3. If no pool qualifies, report in this exact format:
+   ⛔ NO DEPLOY
+`;
+
+    const result = await agentLoop(screeningGoal, 3, [], 'SCREENER', null, null, {
+      interactive: false,
+      deps: {
+        executeTool,
+        getTools,
+        getWalletBalances,
+        getMyPositions,
+        getStateSummary,
+        getLessonsForPrompt,
+        getPerformanceSummary,
+        getDecisionSummary,
+      },
+    });
+
+    expect(result.content).toContain('⛔ NO DEPLOY');
+    expect(result.content).not.toContain("couldn't complete that reliably because no tool call was made");
+    expect(mockOpenAICreate).toHaveBeenCalledTimes(1);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it('allows deploy_position fallback to a second candidate if the first candidate is blocked by pre-flight safety check', async () => {
+    const executeTool = vi.fn().mockImplementation(async (name: string, args: any) => {
+      if (name === 'deploy_position' && args.pool_address === 'UnsafePool') {
+        return {
+          blocked: true,
+          reason: 'fee/active-TVL ratio 0.001 is below threshold 0.02',
+        };
+      }
+      if (name === 'deploy_position' && args.pool_address === 'SafeBackupPool') {
+        return {
+          success: true,
+          position: 'pos_safe_456',
+          pool_name: 'SafeBackupPool',
+        };
+      }
+      return { success: true };
+    });
+
+    const getTools = vi.fn().mockReturnValue([]);
+    const getWalletBalances = vi.fn().mockResolvedValue({ sol: 10, tokens: [] });
+    const getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    const getStateSummary = vi.fn().mockReturnValue(null);
+    const getLessonsForPrompt = vi.fn().mockReturnValue(null);
+    const getPerformanceSummary = vi.fn().mockReturnValue(null);
+    const getDecisionSummary = vi.fn().mockReturnValue(null);
+
+    // Turn 1: LLM tries deploying into UnsafePool
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [makeToolCall('call_unsafe', 'deploy_position', { pool_address: 'UnsafePool', amount_y: 0.5 })],
+          },
+        },
+      ],
+    });
+
+    // Turn 2: LLM sees safety block, tries fallback SafeBackupPool
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [makeToolCall('call_safe', 'deploy_position', { pool_address: 'SafeBackupPool', amount_y: 0.5 })],
+          },
+        },
+      ],
+    });
+
+    // Turn 3: LLM outputs final report
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: '🚀 DEPLOYED\n\nSafeBackupPool\n\n◎ 0.5 SOL',
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const result = await agentLoop('SCREENING CYCLE: Deploy: 0.5 SOL', 5, [], 'SCREENER', null, null, {
+      interactive: false,
+      deps: {
+        executeTool,
+        getTools,
+        getWalletBalances,
+        getMyPositions,
+        getStateSummary,
+        getLessonsForPrompt,
+        getPerformanceSummary,
+        getDecisionSummary,
+      },
+    });
+
+    expect(result.content).toContain('🚀 DEPLOYED');
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    expect(executeTool).toHaveBeenNthCalledWith(1, 'deploy_position', expect.objectContaining({ pool_address: 'UnsafePool' }));
+    expect(executeTool).toHaveBeenNthCalledWith(2, 'deploy_position', expect.objectContaining({ pool_address: 'SafeBackupPool' }));
+  });
+
+  it('locks deploy_position for subsequent steps if deploy_position was actually executed', async () => {
+    const executeTool = vi.fn().mockResolvedValue({
+      success: true,
+      position: 'pos_123',
+    });
+
+    const getTools = vi.fn().mockReturnValue([]);
+    const getWalletBalances = vi.fn().mockResolvedValue({ sol: 10, tokens: [] });
+    const getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    const getStateSummary = vi.fn().mockReturnValue(null);
+    const getLessonsForPrompt = vi.fn().mockReturnValue(null);
+    const getPerformanceSummary = vi.fn().mockReturnValue(null);
+    const getDecisionSummary = vi.fn().mockReturnValue(null);
+
+    // Turn 1: LLM executes deploy_position
+    mockOpenAICreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [makeToolCall('call_1', 'deploy_position', { pool_address: 'PoolA', amount_y: 0.5 })],
+          },
+        },
+      ],
+    });
+
+    // Turn 2: LLM erroneously attempts a second deploy_position in turn 2
+    let turn2ToolResponse: any = null;
+    mockOpenAICreate.mockImplementationOnce(async (payload: any) => {
+      turn2ToolResponse = payload.messages;
+      return {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [makeToolCall('call_2', 'deploy_position', { pool_address: 'PoolB', amount_y: 0.5 })],
+            },
+          },
+        ],
+      };
+    });
+
+    // Turn 3: LLM acknowledges block and concludes
+    let turn3Messages: any[] = [];
+    mockOpenAICreate.mockImplementationOnce(async (payload: any) => {
+      turn3Messages = payload.messages;
+      return {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Deployment finished.',
+              tool_calls: null,
+            },
+          },
+        ],
+      };
+    });
+
+    const result = await agentLoop('SCREENING CYCLE: Deploy: 0.5 SOL', 5, [], 'SCREENER', null, null, {
+      interactive: false,
+      deps: {
+        executeTool,
+        getTools,
+        getWalletBalances,
+        getMyPositions,
+        getStateSummary,
+        getLessonsForPrompt,
+        getPerformanceSummary,
+        getDecisionSummary,
+      },
+    });
+
+    expect(result.content).toBe('Deployment finished.');
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    expect(executeTool).toHaveBeenCalledWith('deploy_position', expect.objectContaining({ pool_address: 'PoolA' }));
+
+    // Verify turn 3 received the once-per-session block message for the second deploy_position attempt
+    const turn3ToolMessages = turn3Messages.filter((m: any) => m.role === 'tool');
+    const secondDeployToolMessage = turn3ToolMessages.find((m: any) => m.tool_call_id === 'call_2');
+    expect(secondDeployToolMessage).toBeDefined();
+    expect(JSON.parse(secondDeployToolMessage.content)).toEqual(
+      expect.objectContaining({
+        blocked: true,
+        reason: expect.stringContaining('already attempted this session'),
+      }),
+    );
+  });
+});

--- a/packages/core/src/application/agent-loop.ts
+++ b/packages/core/src/application/agent-loop.ts
@@ -197,7 +197,7 @@ function getToolsForRole(agentType: AgentRole, allTools: ToolDef[], goal = ''): 
 }
 
 function shouldRequireRealToolUse(goal: string, agentType: AgentRole, interactive = false): boolean {
-  if (agentType === 'MANAGER') return false;
+  if (agentType === 'MANAGER' || agentType === 'SCREENER') return false;
   if (DECISION_EXPLANATION_INTENTS.test(goal)) return false;
   if (CONFIG_READ_ONLY_INTENTS.test(goal)) return false;
   if (MUTATING_TOOL_INTENTS.test(goal)) return true;
@@ -648,10 +648,17 @@ export async function agentLoop(
             log('warn', `onToolFinish hook failed for ${functionName}: ${finishErr?.message || finishErr}`);
           }
 
-          // Lock deploy_position after first attempt regardless of outcome — retrying is never right
-          // For close/swap: only lock on success so genuine failures can be retried
-          if (NO_RETRY_TOOLS.has(functionName)) firedOnce.add(functionName);
-          else if (ONCE_PER_SESSION.has(functionName) && result?.success === true) firedOnce.add(functionName);
+          // Lock deploy_position after first attempt unless it was blocked by pre-flight safety checks (no on-chain action occurred).
+          // If blocked at pre-flight (result?.blocked === true), allow the agent to attempt a fallback candidate in the same session.
+          // If execution proceeded (success or on-chain failure/rejection), lock to prevent duplicate deployment.
+          // For other ONCE_PER_SESSION tools (close/swap): only lock on success so genuine failures can be retried.
+          if (NO_RETRY_TOOLS.has(functionName)) {
+            if (result?.blocked !== true) {
+              firedOnce.add(functionName);
+            }
+          } else if (ONCE_PER_SESSION.has(functionName) && result?.success === true) {
+            firedOnce.add(functionName);
+          }
 
           return {
             role: 'tool' as const,


### PR DESCRIPTION
## Summary
- Exempt `SCREENER` from `shouldRequireRealToolUse` in `agent-loop.ts` so that autonomous screening cycles with pre-loaded candidate pools can cleanly conclude with `⛔ NO DEPLOY` without triggering anti-hallucination rejections or forced retries.
- Guard `firedOnce.add('deploy_position')` so that pre-flight safety check blocks (`result.blocked === true`, where no on-chain transaction or simulation occurred) do not permanently lock `deploy_position` for the remainder of the session, enabling fallback attempts into secondary candidate pools.
- Added comprehensive unit and regression test coverage for both scenarios in `agent-loop.test.ts`.

Closes #127

## Root Cause & Gap Analysis
- **Why/When it happened**:
  1. `shouldRequireRealToolUse` checked `MUTATING_TOOL_INTENTS` on screening cycle prompts (which contain `Deploy:` and `Call deploy_position`). While `MANAGER` had an exemption, `SCREENER` did not, causing valid `⛔ NO DEPLOY` verdicts to be rejected as "no-tool answers".
  2. `NO_RETRY_TOOLS` unconditionally added `deploy_position` to `firedOnce` even when the tool was blocked at pre-flight safety validation in `ToolExecutor.ts` before reaching the blockchain.
- **Why we missed it**:
  - Missing unit tests for `SCREENER` role returning `⛔ NO DEPLOY` without tools.
  - Missing unit tests for sequential `deploy_position` fallback across steps after pre-flight safety blocks.

## Acceptance Criteria Checklist
- [x] AC1: `SCREENER` role can return `⛔ NO DEPLOY` without tool calls on first step without anti-hallucination rejections.
- [x] AC2: `deploy_position` blocked by pre-flight safety check (`blocked: true`) does not set `firedOnce`, allowing fallback to alternative candidates.
- [x] AC3: Actual `deploy_position` executions continue to lock `deploy_position` via `firedOnce` for subsequent steps.
- [x] AC4: Duplicate `deploy_position` in the same assistant message remains strictly blocked.
- [x] AC5: Full test suite passes with zero lint or typecheck errors.

## Testing Plan
- [x] **Automated Unit Tests**: `npx vitest run packages/core/src/application/agent-loop.test.ts` (5/5 passing)
- [x] **Monorepo Test Suite**: `npm test` (138/138 passing across 24 test files)
- [x] **Typecheck**: `pnpm typecheck` (zero errors across workspace)
- [x] **Build**: `pnpm build` (all workspace packages built successfully)