### PR TITLE
fix: serialize deploy safety checks across triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,51 +20,28 @@ Etemaro runs continuous screening and management cycles, deploying capital into 
 
 ---
 
-## Prerequisites & Credentials
+## Run the agent
 
-Before running Etemaro, ensure you have:
-
-- **Node.js**: `>= 22.0.0`
-- **Required Credentials**:
-  - `WALLET_PRIVATE_KEY` — Solana wallet base58 private key (for deploying/closing positions)
-  - `LLM_API_KEY` — API key for OpenAI, OpenRouter, or an OpenAI-compatible provider
-  - `JUPITER_API_KEY` — Jupiter swap API key ([get one here](https://developers.jup.ag/portal/))
-
----
-
-## Getting Started
-
-> 💡 **Have questions?** Most common user questions, setup troubleshooting, multi-instance deployment steps, and PnL metric definitions are covered in **[docs/QA.md](docs/QA.md)**.
-
-### ⚡ 1-Line Quick Install (CLI)
+Need **Node.js 22+**. Then two commands:
 
 ```bash
-# Install Etemaro CLI globally (macOS / Linux)
 curl -fsSL https://etemaro.com/install.sh | sh
+etemaro init
 ```
 
-_Or install via npm / Homebrew:_
+`etemaro init` is first-time setup (~1 minute). It creates `~/.config/etemaro`, checks for a wallet key and an LLM key, and tells you what is missing. Jupiter is only needed later for live swaps.
+
+When the checklist is green:
 
 ```bash
-npm install -g @etemaro/cli
-# or: brew install romankurnovskii/awesome-brew/etemaro
-```
-
-### 🚀 30-Second Quickstart
-
-```bash
-# 1. Provide your Solana wallet private key (in a .env file or export)
-export WALLET_PRIVATE_KEY="your_base58_solana_private_key"
-
-# 2. Check live wallet balances
-etemaro balance
-
-# 3. Simulate and test strategies (dry-run mode, no real transactions)
 etemaro start --dry-run
-
-# 4. Start autonomous agent in live trading mode
-etemaro start
 ```
+
+Live mode (real trades): add `JUPITER_API_KEY`, then `etemaro start`.
+
+_Or install via `npm install -g @etemaro/cli` / `brew install romankurnovskii/awesome-brew/etemaro`._
+
+> Common questions: **[docs/QA.md](docs/QA.md)**.
 
 ---
 
@@ -98,25 +75,15 @@ pnpm run dev
 
 ---
 
-## Server Deployment
+## Server
 
-**Option A: PM2 (Production Process Manager)**
-
-```bash
-npm run build
-npm run pm2:start    # Start daemon under PM2 with auto-restart
-npm run pm2:logs     # Tail live logs
-```
-
-**Option B: Docker**
+Same two commands on a VPS. Keep the process running with tmux, systemd, or:
 
 ```bash
-# Development (hot reload, mounts source)
-docker compose -f docker-compose.dev.yml up --build
-
-# Production (on remote server, .env already present)
-docker compose -f docker-compose.prod.yml up -d --build --force-recreate --remove-orphans
+nohup etemaro start --dry-run >> ~/.config/etemaro/data/agent.out 2>&1 &
 ```
+
+Clone + PM2 / Docker is **[source setup](#developer--source-setup)** above.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ Etemaro uses a strict schema-validated configuration system (Version 3): every r
               └────────────────────────┘     ALL required fields must be present.
 ```
 
-> Initialize the configuration file before starting: `pnpm cli init` (or `etemaro init`).
+> First-time setup: `etemaro init` (creates `~/.config/etemaro` and checks wallet + LLM keys). From a source clone you can also run `pnpm cli init`.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,134 +1,60 @@
 # Getting Started with Etemaro
 
-A simple guide to run your first autonomous LP agent on Solana.
-
----
+Two commands. About a minute.
 
 ## 1. Install
 
-### Option A: 1-Line Install (CLI — Recommended)
+Need Node.js 22+.
 
 ```bash
 curl -fsSL https://etemaro.com/install.sh | sh
 ```
 
-_Or via npm:_
+_Or:_ `npm install -g @etemaro/cli`
+
+**Desktop (macOS):** `brew tap romankurnovskii/awesome-brew && brew install --cask romankurnovskii/awesome-brew/etemaro`
+
+**From source:** `git clone https://github.com/romankurnovskii/etemaro && cd etemaro && pnpm install`
+
+## 2. First-time setup
 
 ```bash
-npm install -g @etemaro/cli
+etemaro init
 ```
 
-### Option B: Desktop App (macOS)
+This creates `~/.config/etemaro` and checks the only two keys needed to start in dry-run:
+
+| Variable             | What it is                                              |
+| -------------------- | ------------------------------------------------------- |
+| `WALLET_PRIVATE_KEY` | Solana wallet base58 key (or `etemaro generate-wallet`) |
+| `LLM_API_KEY`        | OpenRouter / OpenAI / compatible LLM key                |
+
+On a terminal it will prompt. On a server without a TTY, paste the keys into `~/.config/etemaro/.env` and run `etemaro init` again.
+
+Jupiter, Telegram, and strategy JSON are **not** part of first setup. Add `JUPITER_API_KEY` only when you go live.
+
+Desktop users: paste keys in **Settings → Environment Variables** instead of the CLI.
+
+## 3. Start
 
 ```bash
-brew tap romankurnovskii/awesome-brew
-brew trust --cask romankurnovskii/awesome-brew/etemaro
-brew install romankurnovskii/awesome-brew/etemaro --cask
+etemaro start --dry-run
 ```
 
-_(Windows and Linux builds are also available on [GitHub Releases](https://github.com/romankurnovskii/etemaro/releases))_
+Default strategy is `bid_ask` with `dryRun: true`. Screening every 30 minutes, management every 10.
 
-### Option C: Developer / Source Setup
-
-```bash
-git clone https://github.com/romankurnovskii/etemaro
-cd etemaro
-pnpm install
-```
-
----
-
-## 2. Create a Telegram Bot (optional but recommended)
-
-This lets you control and monitor the agent from your phone.
-
-1. Open Telegram and search for **@BotFather**.
-2. Send `/newbot`, follow the prompts, and copy the **token** (looks like `123456:ABC-DEF...`).
-3. Send any message to your new bot (required to activate it).
-4. To get your **chat ID**:
-   - Open in a browser: `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates`
-   - Look for `"chat":{"id":123456789,...}` — that number is your chat ID.
-   - (Or use @userinfobot in Telegram.)
-
----
-
-## 3. Configure Environment Variables
-
-Initialize your configuration files and fill in your values:
-
-```bash
-pnpm cli init
-```
-
-Edit `.env` and set:
-
-> **Desktop App users**: skip manual `.env` editing — you can add these values directly in the app under **Settings → Environment Variables**. The GUI stores them as process envs at runtime.
-
-| Variable                    | What it is                                     | Where to get it                                           |
-| --------------------------- | ---------------------------------------------- | --------------------------------------------------------- |
-| `WALLET_PRIVATE_KEY`        | Your Solana wallet key (base58 string)         | Export from Phantom / Solflare wallet settings            |
-| `JUPITER_API_KEY`           | Jupiter swap API key                           | https://developers.jup.ag/portal/                         |
-| `LLM_API_KEY`               | Your AI model API key                          | OpenRouter, OpenAI, or any OpenAI-compatible provider     |
-| `LLM_BASE_URL`              | AI model endpoint                              | `https://openrouter.ai/api/v1` (default) or your provider |
-| `LLM_MODEL`                 | Model name                                     | e.g. `openrouter/healer-alpha` or `gpt-4o`                |
-| `TELEGRAM_BOT_TOKEN`        | Bot token from BotFather                       | Step 2 above                                              |
-| `TELEGRAM_CHAT_ID`          | Your Telegram chat ID                          | Step 2 above                                              |
-| `TELEGRAM_ALLOWED_USER_IDS` | Restrict bot access to specific Telegram users | Leave empty to allow anyone who knows the bot             |
-
----
-
-## 4. Choose Your First Strategy
-
-Open `config/user-config.json` and look at the `strategy` section:
-
-```json
-"strategy": {
-  "strategy": "bid_ask",
-  "minBinsBelow": 35,
-  "maxBinsBelow": 69,
-  "defaultBinsBelow": 69
-}
-```
-
-**Default: `bid_ask`** — places liquidity on both sides of the current price. This is a safe, standard LP strategy.
-
-If you want something simpler, change `"strategy"` to `"spot"` to place liquidity centered around the current price only.
-
-Keep `dryRun: true` while testing — this simulates trades without spending real SOL.
-
----
-
-## 5. Run the Agent
-
-```bash
-# Test first (no real transactions)
-npm run dev
-
-# When ready, go live
-npm start
-```
-
-You will see a REPL prompt with countdown timers:
+When you are ready for live trades: set `JUPITER_API_KEY`, then `etemaro start`.
 
 ```
 [manage: 8m 12s | screen: 24m 3s]
 >
 ```
 
-The agent will automatically:
-
-- **Screen** for new pools every 30 minutes
-- **Manage** open positions every 10 minutes
-
-If Telegram is configured, you will receive notifications for every deploy, close, and swap.
-
----
-
-## Quick Health Check
+## Quick health check
 
 ```bash
-npm run balance    # Check wallet SOL balance
-npm run positions  # See open positions
+etemaro balance
+etemaro positions
 ```
 
 ---

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -48,24 +48,12 @@ The agent loop, role-based tool access, and tool-execution safety checks are doc
 ### First-time Setup
 
 ```bash
-# 1. Clone and install
-git clone https://github.com/romankurnovskii/etemaro
-cd etemaro
-npm install
-
-# 2. Initialize configuration (.env + user-config.json)
-pnpm cli init
-
-# 3. Edit .env and enter your credentials:
-#   - WALLET_PRIVATE_KEY (Solana wallet private key)
-#   - LLM_API_KEY (OpenAI / OpenRouter API key)
-#   - JUPITER_API_KEY (Jupiter swap API key)
-#   - TELEGRAM_BOT_TOKEN & TELEGRAM_CHAT_ID (optional)
-
-# 3. Test in dry-run mode
-npm run dev
-# This starts the REPL + cron but skips all on-chain transactions
+curl -fsSL https://etemaro.com/install.sh | sh
+etemaro init
+etemaro start --dry-run
 ```
+
+From a source clone: `pnpm install` then `pnpm cli init` and `pnpm run dev`.
 
 ### Day-to-Day Operations
 

--- a/packages/cli/src/Cli.test.ts
+++ b/packages/cli/src/Cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveGlobalFlagValue } from './Cli.js';
+import { applyCliRuntimeFlags, resolveGlobalFlagValue } from './Cli.js';
 
 describe('resolveGlobalFlagValue', () => {
   it('returns the value following the long flag', () => {
@@ -24,5 +24,19 @@ describe('resolveGlobalFlagValue', () => {
 
   it('extends forward to find the value past the subcommand', () => {
     expect(resolveGlobalFlagValue(['balance', '--data-dir', '/tmp/d'], '--data-dir', '-d')).toBe('/tmp/d');
+  });
+});
+
+describe('applyCliRuntimeFlags', () => {
+  it('sets DRY_RUN when --dry-run is present', () => {
+    const env: Record<string, string | undefined> = {};
+    applyCliRuntimeFlags({ 'dry-run': true }, env);
+    expect(env.DRY_RUN).toBe('true');
+  });
+
+  it('does not set DRY_RUN when the flag is absent', () => {
+    const env: Record<string, string | undefined> = { DRY_RUN: 'false' };
+    applyCliRuntimeFlags({}, env);
+    expect(env.DRY_RUN).toBe('false');
   });
 });

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -11,11 +11,20 @@
  * @sideEffects One-shot tool execution and console JSON output
  */
 
-import dotenv from 'dotenv';
-dotenv.config({ override: true });
 import fs from 'fs';
 import path from 'path';
+import readline from 'node:readline/promises';
+import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
 import { parseArgs } from 'util';
+import {
+  assessSetup,
+  formatInitMessage,
+  loadRuntimeDotenv,
+  maybePromptSecrets,
+  parseEnvFile,
+  upsertEnvVars,
+  writeRuntimeSkeleton,
+} from './firstSetup.js';
 // Type-only imports to help tsc
 type CoreExports = typeof import('@etemaro/core');
 type DaemonExports = typeof import('@etemaro/daemon');
@@ -138,6 +147,7 @@ export interface CliAdapters {
     getPerformanceSummary: () => any;
   };
   daemon?: {
+    start?: (options?: { tty?: boolean }) => Promise<void>;
     runScreeningCycle: (opts?: { silent?: boolean }) => Promise<string | null>;
     runManagementCycle: (opts?: { silent?: boolean }) => Promise<string | null>;
     startCronJobs: () => void;
@@ -322,6 +332,9 @@ Shows pending Discord signal queue from the discord-listener process.
 Output: { count, pending, processed, signals: [{id, symbol, pool, author, channel, queued_at, rug_score, status}] }
 \`\`\`
 
+### etemaro init [--dir <path>]
+First-time setup (~1 minute). Creates runtime files and checks wallet + LLM keys.
+
 ### etemaro start [--dry-run]
 Starts the autonomous agent with cron jobs (management + screening).
 
@@ -397,10 +410,13 @@ export class Cli {
         limit: { type: 'string' },
         dir: { type: 'string' },
         label: { type: 'string' },
+        yes: { type: 'boolean' },
       },
       allowPositionals: true,
       strict: false,
     });
+
+    applyCliRuntimeFlags(flags as Record<string, unknown>, process.env);
 
     switch (subcommand) {
       case 'generate-wallet':
@@ -481,63 +497,41 @@ export class Cli {
 
   // ─── Command Handlers ──────────────────────────────────────────
 
-  private handleInit(flags: Record<string, any>): void {
+  private async handleInit(flags: Record<string, any>): Promise<void> {
     const targetDir = typeof flags.dir === 'string' && flags.dir.trim().length > 0 ? path.resolve(flags.dir) : this.etemaroDir;
-    const configDir = path.join(targetDir, 'config');
-    const dataDir = path.join(targetDir, 'data');
-
-    fs.mkdirSync(targetDir, { recursive: true });
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.mkdirSync(dataDir, { recursive: true });
-
-    // .env
-    const envFile = path.join(targetDir, '.env');
-    let envCreated = false;
-    if (!fs.existsSync(envFile)) {
-      const template = `# etemaro process environment variables
-WALLET_PRIVATE_KEY=""
-HELIUS_API_KEY=""
-RPC_URL="https://pump.helius-rpc.com"
-LLM_API_KEY=""
-LLM_BASE_URL="https://openrouter.ai/api/v1"
-LLM_MODEL="anthropic/claude-3.5-sonnet"
-TELEGRAM_BOT_TOKEN=""
-TELEGRAM_CHAT_ID=""
-TELEGRAM_ALLOWED_USER_IDS=""
-JUPITER_API_KEY=""
-`;
-      fs.writeFileSync(envFile, template);
-      envCreated = true;
-    }
-
-    // config/user-config.json
-    const userConfigFile = path.join(configDir, 'user-config.json');
-    let configCreated = false;
-    if (!fs.existsSync(userConfigFile)) {
-      fs.writeFileSync(userConfigFile, defaultUserConfigStr + '\n');
-      configCreated = true;
-    }
-
-    // data/strategy-library.shared.json
-    const sharedStrategyFile = path.join(dataDir, 'strategy-library.shared.json');
-    let strategyCreated = false;
-    if (!fs.existsSync(sharedStrategyFile)) {
-      const sharedData = { strategies: DEFAULT_STRATEGIES };
-      fs.writeFileSync(sharedStrategyFile, JSON.stringify(sharedData, null, 2) + '\n');
-      strategyCreated = true;
-    }
-
-    // SKILL.md
+    const skeleton = writeRuntimeSkeleton(targetDir, {
+      defaultUserConfigStr,
+      defaultStrategies: DEFAULT_STRATEGIES,
+    });
     this.writeSkillMd();
 
-    out({
-      success: true,
-      directory: targetDir,
-      env: { path: envFile, created: envCreated },
-      config: { path: userConfigFile, created: configCreated },
-      strategyLibrary: { path: sharedStrategyFile, created: strategyCreated },
-      message: 'Etemaro runtime directory initialized successfully.',
+    const envFile = skeleton.env.path;
+    const fileEnv = fs.existsSync(envFile) ? parseEnvFile(fs.readFileSync(envFile, 'utf8')) : {};
+    let status = assessSetup({ ...fileEnv, ...process.env });
+
+    const interactive = process.stdin.isTTY === true && flags.yes !== true;
+    const updates = await maybePromptSecrets({
+      interactive,
+      status,
+      ask: askTty,
     });
+    if (Object.keys(updates).length > 0) {
+      const next = upsertEnvVars(fs.readFileSync(envFile, 'utf8'), updates);
+      fs.writeFileSync(envFile, next);
+      for (const [key, value] of Object.entries(updates)) process.env[key] = value;
+      status = assessSetup({ ...parseEnvFile(next), ...process.env });
+    }
+
+    const text = formatInitMessage({
+      directory: targetDir,
+      firstRun: skeleton.env.created || skeleton.config.created,
+      status,
+    });
+    process.stdout.write(text + '\n');
+    if (typeof flags.dir === 'string' && flags.dir.trim()) {
+      process.stdout.write(`\nCustom dir: export ETEMARO_HOME="${targetDir}" before etemaro start\n`);
+    }
+    process.exit(status.readyForDryRun ? 0 : 1);
   }
 
   private handleGenerateWallet(flags: Record<string, any>): void {
@@ -798,10 +792,10 @@ JUPITER_API_KEY=""
     out(await this.adapters.domain.studyTopLPers({ pool_address: flags.pool, limit }));
   }
 
-  private handleStart(): void {
-    if (!this.adapters.daemon) die('Start command requires daemon adapter');
+  private async handleStart(): Promise<void> {
+    if (!this.adapters.daemon?.start) die('Start command requires daemon adapter');
     process.stderr.write('[etemaro] Starting autonomous agent...\n');
-    this.adapters.daemon.startCronJobs();
+    await this.adapters.daemon.start({ tty: process.stdout.isTTY === true });
   }
 
   private async handleLessons(argv: string[], sub2: string | undefined, flags: Record<string, any>): Promise<void> {
@@ -940,6 +934,28 @@ export function resolveGlobalFlagValue(argv: string[], flag: string, alias?: str
   return value;
 }
 
+/** Apply CLI flags that must be visible to core before any tool runs. */
+export function applyCliRuntimeFlags(flags: Record<string, unknown>, env: NodeJS.Dict<string> = process.env): void {
+  if (flags['dry-run'] === true) env.DRY_RUN = 'true';
+}
+
+function defaultEtemaroHome(): string {
+  const fromEnv = process.env.ETEMARO_HOME?.trim();
+  if (fromEnv) return path.resolve(fromEnv);
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const xdg = process.env.XDG_CONFIG_HOME || (home ? path.join(home, '.config') : '');
+  return path.join(xdg, 'etemaro');
+}
+
+async function askTty(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: stdinStream, output: stdoutStream });
+  try {
+    return (await rl.question(question)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
 
@@ -948,6 +964,7 @@ async function main() {
   if (configPathArg) process.env.USER_CONFIG_PATH = path.resolve(configPathArg);
   if (dataDirArg) process.env.ETEMARO_DATA_DIR = path.resolve(dataDirArg);
 
+  loadRuntimeDotenv(defaultEtemaroHome());
   await loadCore();
 
   const agentLoopDeps = {

--- a/packages/cli/src/firstSetup.test.ts
+++ b/packages/cli/src/firstSetup.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  assessSetup,
+  formatInitMessage,
+  loadRuntimeDotenv,
+  maybePromptSecrets,
+  parseEnvFile,
+  upsertEnvVars,
+  writeRuntimeSkeleton,
+} from './firstSetup.js';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'etemaro-init-'));
+}
+
+describe('assessSetup', () => {
+  it('is not ready when wallet and llm keys are missing', () => {
+    const status = assessSetup({});
+    expect(status.wallet).toBe(false);
+    expect(status.llm).toBe(false);
+    expect(status.readyForDryRun).toBe(false);
+    expect(status.readyForLive).toBe(false);
+  });
+
+  it('treats blank and env-ref values as missing', () => {
+    const status = assessSetup({
+      WALLET_PRIVATE_KEY: '  ',
+      LLM_API_KEY: 'env.LLM_API_KEY',
+      JUPITER_API_KEY: '""',
+    });
+    expect(status.wallet).toBe(false);
+    expect(status.llm).toBe(false);
+    expect(status.jupiter).toBe(false);
+  });
+
+  it('is ready for dry-run with only wallet and llm keys', () => {
+    const status = assessSetup({
+      WALLET_PRIVATE_KEY: 'base58wallet',
+      LLM_API_KEY: 'sk-or-v1-test',
+    });
+    expect(status.readyForDryRun).toBe(true);
+    expect(status.readyForLive).toBe(false);
+    expect(status.jupiter).toBe(false);
+  });
+
+  it('is ready for live when jupiter key is also set', () => {
+    const status = assessSetup({
+      WALLET_PRIVATE_KEY: 'base58wallet',
+      LLM_API_KEY: 'sk-or-v1-test',
+      JUPITER_API_KEY: 'jup-key',
+    });
+    expect(status.readyForLive).toBe(true);
+  });
+});
+
+describe('formatInitMessage', () => {
+  it('prints a first-time setup banner and the next command', () => {
+    const text = formatInitMessage({
+      directory: '/tmp/etemaro',
+      firstRun: true,
+      status: assessSetup({}),
+    });
+    expect(text).toContain('first-time setup');
+    expect(text).toContain('/tmp/etemaro');
+    expect(text).toContain('Wallet');
+    expect(text).toContain('LLM');
+    expect(text).toContain('etemaro start --dry-run');
+  });
+
+  it('says setup is complete when dry-run creds are present', () => {
+    const text = formatInitMessage({
+      directory: '/tmp/etemaro',
+      firstRun: false,
+      status: assessSetup({
+        WALLET_PRIVATE_KEY: 'k',
+        LLM_API_KEY: 'k',
+      }),
+    });
+    expect(text).toContain('Setup complete');
+    expect(text).toContain('etemaro start --dry-run');
+    expect(text).not.toContain('first-time setup');
+  });
+});
+
+describe('writeRuntimeSkeleton', () => {
+  it('creates .env, config, and data on a fresh directory', () => {
+    const dir = tmpDir();
+    const result = writeRuntimeSkeleton(dir, {
+      defaultUserConfigStr: '{"_version":3}',
+      defaultStrategies: [{ id: 'spot' }],
+    });
+    expect(result.env.created).toBe(true);
+    expect(result.config.created).toBe(true);
+    expect(fs.existsSync(path.join(dir, '.env'))).toBe(true);
+    expect(fs.readFileSync(path.join(dir, '.env'), 'utf8')).toContain('WALLET_PRIVATE_KEY');
+    expect(fs.existsSync(path.join(dir, 'config', 'user-config.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'data', 'strategy-library.shared.json'))).toBe(true);
+  });
+
+  it('does not overwrite an existing .env', () => {
+    const dir = tmpDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.env'), 'WALLET_PRIVATE_KEY="keep-me"\n');
+    const result = writeRuntimeSkeleton(dir, {
+      defaultUserConfigStr: '{}',
+      defaultStrategies: [],
+    });
+    expect(result.env.created).toBe(false);
+    expect(fs.readFileSync(path.join(dir, '.env'), 'utf8')).toContain('keep-me');
+  });
+});
+
+describe('upsertEnvVars', () => {
+  it('fills empty quoted values in place', () => {
+    const next = upsertEnvVars('WALLET_PRIVATE_KEY=""\nLLM_API_KEY=""\n', {
+      WALLET_PRIVATE_KEY: 'abc',
+    });
+    expect(next).toContain('WALLET_PRIVATE_KEY="abc"');
+    expect(next).toContain('LLM_API_KEY=""');
+  });
+
+  it('escapes backslashes before quotes so values round-trip', () => {
+    const raw = 'a\\b"c';
+    const next = upsertEnvVars('WALLET_PRIVATE_KEY=""\n', { WALLET_PRIVATE_KEY: raw });
+    expect(next).toContain('WALLET_PRIVATE_KEY="a\\\\b\\"c"');
+    expect(parseEnvFile(next).WALLET_PRIVATE_KEY).toBe(raw);
+  });
+});
+
+describe('loadRuntimeDotenv', () => {
+  it('loads home .env first, then cwd .env', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, '.env'), 'WALLET_PRIVATE_KEY="from-home"\n');
+    const calls: Array<Record<string, unknown>> = [];
+    loadRuntimeDotenv(dir, (opts) => {
+      calls.push(opts ?? {});
+      return { parsed: {} } as any;
+    });
+    expect(calls[0]).toEqual({ path: path.join(dir, '.env') });
+    expect(calls[1]).toEqual({ override: true });
+  });
+});
+
+describe('maybePromptSecrets', () => {
+  it('prompts only for missing wallet and llm keys', async () => {
+    const asked: string[] = [];
+    const updates = await maybePromptSecrets({
+      interactive: true,
+      status: assessSetup({}),
+      ask: async (q) => {
+        asked.push(q);
+        if (q.toLowerCase().includes('wallet')) return 'wallet-key';
+        if (q.toLowerCase().includes('llm')) return 'llm-key';
+        return '';
+      },
+    });
+    expect(asked).toHaveLength(2);
+    expect(updates).toEqual({ WALLET_PRIVATE_KEY: 'wallet-key', LLM_API_KEY: 'llm-key' });
+  });
+
+  it('skips prompts when not interactive', async () => {
+    const updates = await maybePromptSecrets({
+      interactive: false,
+      status: assessSetup({}),
+      ask: async () => {
+        throw new Error('should not prompt');
+      },
+    });
+    expect(updates).toEqual({});
+  });
+});

--- a/packages/cli/src/firstSetup.ts
+++ b/packages/cli/src/firstSetup.ts
@@ -1,0 +1,184 @@
+/**
+ * First-run operator setup: create runtime dirs, check the two keys needed
+ * for dry-run, print a short next command. Jupiter is live-only.
+ */
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+export interface SetupStatus {
+  wallet: boolean;
+  llm: boolean;
+  jupiter: boolean;
+  readyForDryRun: boolean;
+  readyForLive: boolean;
+}
+
+export interface SkeletonResult {
+  directory: string;
+  env: { path: string; created: boolean };
+  config: { path: string; created: boolean };
+  strategyLibrary: { path: string; created: boolean };
+}
+
+const ENV_TEMPLATE = `# etemaro — first-run environment
+WALLET_PRIVATE_KEY=""
+LLM_API_KEY=""
+LLM_BASE_URL="https://openrouter.ai/api/v1"
+LLM_MODEL="anthropic/claude-3.5-sonnet"
+JUPITER_API_KEY=""
+HELIUS_API_KEY=""
+RPC_URL="https://pump.helius-rpc.com"
+TELEGRAM_BOT_TOKEN=""
+TELEGRAM_CHAT_ID=""
+TELEGRAM_ALLOWED_USER_IDS=""
+`;
+
+function present(value: string | undefined): boolean {
+  if (!value) return false;
+  const v = value.trim().replace(/^["']|["']$/g, '');
+  if (!v) return false;
+  if (v.startsWith('env.')) return false;
+  return true;
+}
+
+export function assessSetup(env: NodeJS.Dict<string>): SetupStatus {
+  const wallet = present(env.WALLET_PRIVATE_KEY);
+  const llm = present(env.LLM_API_KEY);
+  const jupiter = present(env.JUPITER_API_KEY);
+  return {
+    wallet,
+    llm,
+    jupiter,
+    readyForDryRun: wallet && llm,
+    readyForLive: wallet && llm && jupiter,
+  };
+}
+
+export function formatInitMessage(opts: { directory: string; firstRun: boolean; status: SetupStatus }): string {
+  const { directory, firstRun, status } = opts;
+  const heading = firstRun ? 'Etemaro first-time setup  (~1 minute)' : 'Etemaro setup check';
+  const mark = (ok: boolean) => (ok ? 'x' : ' ');
+  const lines = [
+    heading,
+    '',
+    firstRun ? 'Dry-run is on by default. No live trades yet.' : 'Checking wallet and LLM credentials.',
+    `Runtime: ${directory}`,
+    '',
+    `  [${mark(status.wallet)}] Wallet   WALLET_PRIVATE_KEY`,
+    `  [${mark(status.llm)}] LLM      LLM_API_KEY`,
+    `  [${mark(status.jupiter)}] Jupiter  JUPITER_API_KEY  (live swaps only)`,
+    '',
+  ];
+  if (status.readyForDryRun) {
+    lines.push(firstRun ? 'Setup complete.' : 'Setup complete');
+    lines.push('');
+    lines.push('Next:');
+    lines.push('  etemaro start --dry-run');
+  } else {
+    lines.push(`Add the missing keys in ${path.join(directory, '.env')}`);
+    lines.push('then run:');
+    lines.push('  etemaro start --dry-run');
+  }
+  return lines.join('\n');
+}
+
+export function writeRuntimeSkeleton(directory: string, opts: { defaultUserConfigStr: string; defaultStrategies: unknown }): SkeletonResult {
+  const configDir = path.join(directory, 'config');
+  const dataDir = path.join(directory, 'data');
+  fs.mkdirSync(directory, { recursive: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+
+  const envFile = path.join(directory, '.env');
+  let envCreated = false;
+  if (!fs.existsSync(envFile)) {
+    fs.writeFileSync(envFile, ENV_TEMPLATE);
+    envCreated = true;
+  }
+
+  const userConfigFile = path.join(configDir, 'user-config.json');
+  let configCreated = false;
+  if (!fs.existsSync(userConfigFile)) {
+    fs.writeFileSync(userConfigFile, opts.defaultUserConfigStr.endsWith('\n') ? opts.defaultUserConfigStr : opts.defaultUserConfigStr + '\n');
+    configCreated = true;
+  }
+
+  const sharedStrategyFile = path.join(dataDir, 'strategy-library.shared.json');
+  let strategyCreated = false;
+  if (!fs.existsSync(sharedStrategyFile)) {
+    fs.writeFileSync(sharedStrategyFile, JSON.stringify({ strategies: opts.defaultStrategies }, null, 2) + '\n');
+    strategyCreated = true;
+  }
+
+  return {
+    directory,
+    env: { path: envFile, created: envCreated },
+    config: { path: userConfigFile, created: configCreated },
+    strategyLibrary: { path: sharedStrategyFile, created: strategyCreated },
+  };
+}
+
+function escapeEnvValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function unescapeEnvValue(value: string): string {
+  return value.replace(/\\([\\"])/g, '$1');
+}
+
+export function upsertEnvVars(fileContents: string, updates: Record<string, string>): string {
+  let next = fileContents;
+  for (const [key, value] of Object.entries(updates)) {
+    const line = `${key}="${escapeEnvValue(value)}"`;
+    const re = new RegExp(`^${key}=.*$`, 'm');
+    if (re.test(next)) next = next.replace(re, line);
+    else next += (next.endsWith('\n') ? '' : '\n') + line + '\n';
+  }
+  return next;
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = unescapeEnvValue(value.slice(1, -1));
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export async function maybePromptSecrets(opts: {
+  interactive: boolean;
+  status: SetupStatus;
+  ask: (question: string) => Promise<string>;
+}): Promise<Record<string, string>> {
+  if (!opts.interactive) return {};
+  const updates: Record<string, string> = {};
+  if (!opts.status.wallet) {
+    const wallet = (await opts.ask('Wallet private key (base58). Paste, or Enter to skip: ')).trim();
+    if (wallet) updates.WALLET_PRIVATE_KEY = wallet;
+  }
+  if (!opts.status.llm) {
+    const llm = (await opts.ask('LLM API key (OpenRouter / OpenAI). Paste, or Enter to skip: ')).trim();
+    if (llm) updates.LLM_API_KEY = llm;
+  }
+  return updates;
+}
+
+type DotenvLoad = (opts?: { path?: string; override?: boolean }) => unknown;
+
+export function loadRuntimeDotenv(homeDir: string, dotenvLoad: DotenvLoad = dotenv.config): void {
+  const envPath = path.join(homeDir, '.env');
+  if (fs.existsSync(envPath)) {
+    dotenvLoad({ path: envPath });
+  }
+  dotenvLoad({ override: true });
+}

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { executeTool, swapAllTokensToSol } from './ToolExecutor.js';
 import * as WalletAdapter from './blockchain/WalletAdapter.js';
 import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js';
@@ -96,6 +96,11 @@ describe('ToolExecutor - deploy_position serialization', () => {
     vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({ sol: 10, tokens: [] } as any);
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
   it('does not run a second balance check until the first deploy has completed', async () => {
     let releaseFirstDeploy!: () => void;
     const firstDeployFinished = new Promise<void>((resolve) => {
@@ -121,7 +126,7 @@ describe('ToolExecutor - deploy_position serialization', () => {
     await vi.waitFor(() => expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1));
     const second = executeTool('deploy_position', { ...args, pool_address: 'pool-two' });
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await Promise.resolve();
     expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(1);
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1);
     expect(maxInFlightDeploys).toBe(1);
@@ -131,5 +136,26 @@ describe('ToolExecutor - deploy_position serialization', () => {
     expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(2);
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(2);
     expect(maxInFlightDeploys).toBe(1);
+  });
+
+  it('releases the lock when a safety check rejects', async () => {
+    vi.mocked(MeteoraAdapter.getMyPositions)
+      .mockRejectedValueOnce(new Error('safety check failed'))
+      .mockResolvedValue({ positions: [], total_positions: 0 } as any);
+    vi.mocked(MeteoraAdapter.deployPosition).mockResolvedValue({ success: true, position: 'position-two' } as any);
+
+    const args = {
+      pool_address: 'pool-one',
+      amount_y: 0.5,
+      bins_below: 35,
+      bins_above: 0,
+    };
+    const first = executeTool('deploy_position', args);
+    await expect(first).rejects.toThrow('safety check failed');
+
+    await expect(executeTool('deploy_position', { ...args, pool_address: 'pool-two' })).resolves.toMatchObject({
+      success: true,
+    });
+    expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { swapAllTokensToSol } from './ToolExecutor.js';
+import { executeTool, swapAllTokensToSol } from './ToolExecutor.js';
 import * as WalletAdapter from './blockchain/WalletAdapter.js';
+import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js';
 
 // Mock the WalletAdapter functions
 vi.mock('./blockchain/WalletAdapter.js', () => ({
@@ -8,10 +9,28 @@ vi.mock('./blockchain/WalletAdapter.js', () => ({
   swapToken: vi.fn(),
 }));
 
+vi.mock('./blockchain/MeteoraAdapter.js', () => ({
+  getActiveBin: vi.fn(),
+  deployPosition: vi.fn(),
+  getMyPositions: vi.fn(),
+  getWalletPositions: vi.fn(),
+  getPositionPnl: vi.fn(),
+  claimFees: vi.fn(),
+  closePosition: vi.fn(),
+  searchPools: vi.fn(),
+}));
+
+vi.mock('./blockchain/ScreeningAdapter.js', () => ({
+  discoverPools: vi.fn(),
+  getPoolDetail: vi.fn(),
+  getTopCandidates: vi.fn(),
+}));
+
 // Mock logger to avoid noisy output during tests
 vi.mock('../shared/logger.js', () => ({
   log: vi.fn(),
   logAction: vi.fn(),
+  logStructured: vi.fn(),
 }));
 
 describe('ToolExecutor - swapAllTokensToSol', () => {
@@ -57,5 +76,60 @@ describe('ToolExecutor - swapAllTokensToSol', () => {
 
     const result = await swapAllTokensToSol({ skipMints: [] } as any);
     expect(result.total).toBe(0);
+  });
+});
+
+describe('ToolExecutor - deploy_position serialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('DRY_RUN', 'false');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ address: 'pool-one', tvl: 100_000, fee_active_tvl_ratio: { '5m': 1 }, volatility: 1, dlmm_params: { bin_step: 100 } }],
+        }),
+      }),
+    );
+    vi.mocked(MeteoraAdapter.getMyPositions).mockResolvedValue({ positions: [], total_positions: 0 } as any);
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({ sol: 10, tokens: [] } as any);
+  });
+
+  it('does not run a second balance check until the first deploy has completed', async () => {
+    let releaseFirstDeploy!: () => void;
+    const firstDeployFinished = new Promise<void>((resolve) => {
+      releaseFirstDeploy = resolve;
+    });
+    let inFlightDeploys = 0;
+    let maxInFlightDeploys = 0;
+    vi.mocked(MeteoraAdapter.deployPosition).mockImplementation(async () => {
+      inFlightDeploys++;
+      maxInFlightDeploys = Math.max(maxInFlightDeploys, inFlightDeploys);
+      if (inFlightDeploys === 1) await firstDeployFinished;
+      inFlightDeploys--;
+      return { success: true, position: `position-${Date.now()}` } as any;
+    });
+
+    const args = {
+      pool_address: 'pool-one',
+      amount_y: 0.5,
+      bins_below: 35,
+      bins_above: 0,
+    };
+    const first = executeTool('deploy_position', { ...args });
+    await vi.waitFor(() => expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1));
+    const second = executeTool('deploy_position', { ...args, pool_address: 'pool-two' });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(1);
+    expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1);
+    expect(maxInFlightDeploys).toBe(1);
+
+    releaseFirstDeploy();
+    await Promise.all([first, second]);
+    expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(2);
+    expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(2);
+    expect(maxInFlightDeploys).toBe(1);
   });
 });

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -63,6 +63,7 @@ import { blockDev, unblockDev, listBlockedDevs } from '../domain/dev-blocklist.j
 import { addSmartWallet, removeSmartWallet, listSmartWallets, checkSmartWalletsOnPool } from '../domain/smart-wallets.js';
 import { getRecentDecisions } from '../domain/decision-log.js';
 import { normalizeTimeframe, scaleScreeningToTimeframe } from '../shared/utils.js';
+import { Mutex } from '../shared/mutex.js';
 import { notifyDeploy, notifyClose, notifySwap, notifySwapError } from './notifications/TelegramAdapter.js';
 
 // ─── Constants ─────────────────────────────────────────────────
@@ -767,20 +768,10 @@ const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update']);
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-let deployPositionQueue: Promise<void> = Promise.resolve();
+const deployPositionMutex = new Mutex();
 
 async function withDeployPositionLock<T>(operation: () => Promise<T>): Promise<T> {
-  let release!: () => void;
-  const previous = deployPositionQueue;
-  deployPositionQueue = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  await previous;
-  try {
-    return await operation();
-  } finally {
-    release();
-  }
+  return deployPositionMutex.runExclusive(operation);
 }
 
 /**

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -767,6 +767,22 @@ const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update']);
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+let deployPositionQueue: Promise<void> = Promise.resolve();
+
+async function withDeployPositionLock<T>(operation: () => Promise<T>): Promise<T> {
+  let release!: () => void;
+  const previous = deployPositionQueue;
+  deployPositionQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
 /**
  * Swap a base token back to SOL with retry. Jupiter can transiently fail (no route,
  * quote error) and a single attempt silently leaves the token unsold — this retries
@@ -977,6 +993,14 @@ export async function closeAllPositions(skipSwapInput: boolean | { skipSwap?: bo
  * Execute a tool call with safety checks and logging.
  */
 export async function executeTool(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const normalizedName = name.replace(/<.*$/, '').trim();
+  if (normalizedName === 'deploy_position') {
+    return withDeployPositionLock(() => executeToolUnlocked(normalizedName, args));
+  }
+  return executeToolUnlocked(normalizedName, args);
+}
+
+async function executeToolUnlocked(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
   const startTime = Date.now();
 
   // Strip model artifacts like "<|channel|>commentary" appended to tool names

--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -9,6 +9,9 @@ import {
   trackPosition,
   recordClose,
   syncOpenPositions,
+  withStateLock,
+  setPositionInstruction,
+  confirmPeak,
   __setStateFilePath,
 } from './state.js';
 
@@ -173,5 +176,41 @@ describe('state.json corruption handling', () => {
   it('fails fast and throws when state.json contains corrupted JSON', () => {
     fs.writeFileSync(TMP_STATE, '{"positions": { invalid json');
     expect(() => getTrackedPositions()).toThrowError(/Failed to parse JSON file at.*Critical file corrupted/);
+  });
+});
+
+describe('withStateLock concurrency synchronization', () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  it('serializes concurrent async state modifications without losing updates', async () => {
+    trackPosition(deployOpts('PosConcurrent') as any);
+
+    // Run 5 concurrent async state updates with simulated async delays
+    const updates = [1, 2, 3, 4, 5].map((idx) =>
+      withStateLock(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        setPositionInstruction('PosConcurrent', `Instruction-${idx}`);
+        confirmPeak('PosConcurrent', idx * 5, 1);
+      }),
+    );
+
+    await Promise.all(updates);
+
+    const pos = getTrackedPosition('PosConcurrent');
+    expect(pos).not.toBeNull();
+    // Peak PnL should reflect the maximum confirmed peak PnL (25)
+    expect(pos?.peak_pnl_pct).toBe(25);
+    // Instruction was set
+    expect(pos?.instruction).toMatch(/^Instruction-\d$/);
   });
 });

--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -156,3 +156,22 @@ describe('save() persistence failures', () => {
     }
   });
 });
+
+describe('state.json corruption handling', () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  it('fails fast and throws when state.json contains corrupted JSON', () => {
+    fs.writeFileSync(TMP_STATE, '{"positions": { invalid json');
+    expect(() => getTrackedPositions()).toThrowError(/Failed to parse JSON file at.*Critical file corrupted/);
+  });
+});

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -13,7 +13,7 @@
 import { log } from '../shared/logger.js';
 import { dataPath, MAX_RECENT_EVENTS, MAX_INSTRUCTION_LENGTH, SYNC_GRACE_MS } from '../shared/constants.js';
 import { sanitizeStoredText, loadJsonFile, saveJsonFile } from '../shared/utils.js';
-import type { PositionRecord, StateEvent, BinRange, ExitResult, ExitAction, StateSummary } from '../shared/types.js';
+import type { PositionRecord, StateEvent, BinRange, ExitResult, StateSummary } from '../shared/types.js';
 
 export type { PositionRecord } from '../shared/types.js';
 import type { AppConfig } from '../shared/types.js';
@@ -37,11 +37,15 @@ interface StateData {
 }
 
 function load(): StateData {
-  return loadJsonFile<StateData>(STATE_FILE, {
-    positions: {},
-    recentEvents: [],
-    lastUpdated: null,
-  });
+  return loadJsonFile<StateData>(
+    STATE_FILE,
+    {
+      positions: {},
+      recentEvents: [],
+      lastUpdated: null,
+    },
+    { label: 'state', critical: true },
+  );
 }
 
 function save(state: StateData): void {

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -18,7 +18,25 @@ import type { PositionRecord, StateEvent, BinRange, ExitResult, StateSummary } f
 export type { PositionRecord } from '../shared/types.js';
 import type { AppConfig } from '../shared/types.js';
 
+import { Mutex } from '../shared/mutex.js';
+
 let STATE_FILE = dataPath('state.json');
+const stateMutex = new Mutex();
+
+/**
+ * Execute a synchronous or asynchronous transaction exclusively under the state mutex.
+ * Serializes read-modify-write state operations across concurrent async tasks.
+ */
+export async function withStateLock<T>(fn: () => Promise<T> | T): Promise<T> {
+  return stateMutex.runExclusive(fn);
+}
+
+/**
+ * Access the in-process state mutex instance directly.
+ */
+export function getStateMutex(): Mutex {
+  return stateMutex;
+}
 
 /**
  * Test-only seam: redirect the state file so tests don't read/write the real

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './config/defaultUserConfig.js';
 export * from './shared/logger.js';
 export * from './shared/constants.js';
 export * from './shared/utils.js';
+export * from './shared/mutex.js';
 export * from './shared/types.js';
 export * from './adapters/blockchain/WalletAdapter.js';
 export * from './adapters/ToolDefinitions.js';

--- a/packages/core/src/shared/mutex.test.ts
+++ b/packages/core/src/shared/mutex.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { Mutex } from './mutex.js';
+
+describe('Mutex', () => {
+  it('executes tasks sequentially and prevents race conditions', async () => {
+    const mutex = new Mutex();
+    const results: number[] = [];
+
+    const task1 = mutex.runExclusive(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      results.push(1);
+      return 'task1';
+    });
+
+    const task2 = mutex.runExclusive(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      results.push(2);
+      return 'task2';
+    });
+
+    const task3 = mutex.runExclusive(async () => {
+      results.push(3);
+      return 'task3';
+    });
+
+    const [r1, r2, r3] = await Promise.all([task1, task2, task3]);
+
+    expect(r1).toBe('task1');
+    expect(r2).toBe('task2');
+    expect(r3).toBe('task3');
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  it('releases lock even if task throws an error', async () => {
+    const mutex = new Mutex();
+    let secondTaskExecuted = false;
+
+    const failingTask = mutex.runExclusive(async () => {
+      throw new Error('boom');
+    });
+
+    const subsequentTask = mutex.runExclusive(async () => {
+      secondTaskExecuted = true;
+      return 42;
+    });
+
+    await expect(failingTask).rejects.toThrow('boom');
+    const result = await subsequentTask;
+    expect(secondTaskExecuted).toBe(true);
+    expect(result).toBe(42);
+  });
+
+  it('supports manual acquire and release', async () => {
+    const mutex = new Mutex();
+    const sequence: string[] = [];
+
+    const release1 = await mutex.acquire();
+    sequence.push('acquired1');
+
+    const task2 = mutex.runExclusive(async () => {
+      sequence.push('task2');
+    });
+
+    sequence.push('beforeRelease1');
+    release1();
+
+    await task2;
+    expect(sequence).toEqual(['acquired1', 'beforeRelease1', 'task2']);
+  });
+});

--- a/packages/core/src/shared/mutex.ts
+++ b/packages/core/src/shared/mutex.ts
@@ -1,0 +1,50 @@
+/**
+ * @file mutex.ts
+ * @description Lightweight in-process async mutex for serializing asynchronous critical sections.
+ */
+
+export class Mutex {
+  private queue: Promise<void> = Promise.resolve();
+
+  /**
+   * Execute an asynchronous or synchronous callback exclusively under the mutex lock.
+   */
+  async runExclusive<T>(fn: () => Promise<T> | T): Promise<T> {
+    let release: () => void;
+    const waiter = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const previous = this.queue;
+    this.queue = previous.then(
+      () => waiter,
+      () => waiter,
+    );
+
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release!();
+    }
+  }
+
+  /**
+   * Acquire lock manually. Returns a release function that MUST be called when finished.
+   */
+  async acquire(): Promise<() => void> {
+    let release: () => void;
+    const waiter = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const previous = this.queue;
+    this.queue = previous.then(
+      () => waiter,
+      () => waiter,
+    );
+
+    await previous;
+    return release!;
+  }
+}

--- a/packages/core/src/shared/utils.test.ts
+++ b/packages/core/src/shared/utils.test.ts
@@ -89,6 +89,16 @@ describe('loadJsonFile — missing vs corrupt file handling', () => {
     expect(result).toEqual({ fallback: 123 });
   });
 
+  it('throws error when file contains corrupt JSON and critical: true', async () => {
+    const { loadJsonFile } = await import('./utils.js');
+    const target = path.join(tmpDir, 'corrupt-critical.json');
+    fs.writeFileSync(target, '{ broken json');
+
+    expect(() => loadJsonFile(target, { fallback: true }, { label: 'state', critical: true })).toThrowError(
+      /Failed to parse JSON file at.*Critical file corrupted/,
+    );
+  });
+
   it('correctly parses and returns valid JSON', async () => {
     const { loadJsonFile } = await import('./utils.js');
     const target = path.join(tmpDir, 'valid.json');

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -11,7 +11,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { REPO_ROOT } from './constants.js';
 import { log } from './logger.js';
 
 // ─── Path Utilities ────────────────────────────────────────
@@ -120,17 +119,20 @@ export function nonEmptyString(...values: unknown[]): string | null {
 
 // ─── JSON File Utilities ───────────────────────────────────────
 
-export function loadJsonFile<T>(filePath: string, fallback: T, options?: { label?: string; warnOnCorrupt?: boolean }): T {
+export function loadJsonFile<T>(filePath: string, fallback: T, options?: { label?: string; warnOnCorrupt?: boolean; critical?: boolean }): T {
   if (!fs.existsSync(filePath)) return fallback;
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const prefix = options?.label ? `[${options.label}] ` : '';
+    const parseError = err instanceof Error ? err.message : String(err);
+    if (options?.critical) {
+      const msg = `${prefix}Failed to parse JSON file at "${filePath}" (corrupt or unreadable): ${parseError}. Critical file corrupted — failing fast to prevent state loss.`;
+      log('file_error', msg);
+      throw new Error(msg, { cause: err });
+    }
     if (options?.warnOnCorrupt !== false) {
-      const prefix = options?.label ? `[${options.label}] ` : '';
-      log(
-        'file_error',
-        `${prefix}Failed to parse JSON file at "${filePath}" (corrupt or unreadable): ${err?.message || err}. Using default fallback.`,
-      );
+      log('file_error', `${prefix}Failed to parse JSON file at "${filePath}" (corrupt or unreadable): ${parseError}. Using default fallback.`);
     }
     return fallback;
   }

--- a/packages/daemon/src/Daemon.smart-wallet-screening.test.ts
+++ b/packages/daemon/src/Daemon.smart-wallet-screening.test.ts
@@ -18,6 +18,8 @@ import path from 'node:path';
 // so the factory closure has access to this state at hoist time.
 const {
   snapshotState,
+  fsStore,
+  mockDataPath,
   mockGetTrackedPositions,
   mockListSmartWallets,
   mockDiffSmartWalletPositions,
@@ -36,6 +38,8 @@ const {
     content: null as string | null,
     exists: false as boolean,
   },
+  fsStore: {} as Record<string, string>,
+  mockDataPath: vi.fn().mockImplementation((p: string) => path.join('/tmp/test-data', p)),
   mockGetTrackedPositions: vi.fn(),
   mockListSmartWallets: vi.fn(),
   mockDiffSmartWalletPositions: vi.fn(),
@@ -55,13 +59,17 @@ const {
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   const existsSync = vi.fn().mockImplementation((filePath: any) => {
-    if (String(filePath).includes('.smart-wallets-snapshot.json')) {
+    if (String(filePath).includes('.smart-wallets-snapshot')) {
+      const p = String(filePath);
+      if (p in fsStore) return true;
       return snapshotState.exists;
     }
     return actual.existsSync(filePath);
   });
   const readFileSync = vi.fn().mockImplementation((filePath: any, encoding?: any) => {
-    if (String(filePath).includes('.smart-wallets-snapshot.json')) {
+    if (String(filePath).includes('.smart-wallets-snapshot')) {
+      const p = String(filePath);
+      if (p in fsStore) return fsStore[p];
       if (snapshotState.content === null) {
         throw new Error('ENOENT: no such file or directory');
       }
@@ -70,7 +78,9 @@ vi.mock('fs', async () => {
     return actual.readFileSync(filePath, encoding);
   });
   const writeFileSync = vi.fn().mockImplementation((filePath: any, data: any, options?: any) => {
-    if (String(filePath).includes('.smart-wallets-snapshot.json')) {
+    if (String(filePath).includes('.smart-wallets-snapshot')) {
+      const p = String(filePath);
+      fsStore[p] = String(data);
       snapshotState.content = data;
       snapshotState.exists = true;
       return undefined;
@@ -78,14 +88,19 @@ vi.mock('fs', async () => {
     return actual.writeFileSync(filePath, data, options);
   });
   const renameSync = vi.fn().mockImplementation((oldPath: any, newPath: any) => {
-    if (String(oldPath).includes('.smart-wallets-snapshot.json') || String(newPath).includes('.smart-wallets-snapshot.json')) {
+    if (String(oldPath).includes('.smart-wallets-snapshot') || String(newPath).includes('.smart-wallets-snapshot')) {
+      const data = fsStore[String(oldPath)] || snapshotState.content;
+      if (data) {
+        fsStore[String(newPath)] = data;
+      }
       snapshotState.exists = true;
       return undefined;
     }
     return actual.renameSync(oldPath, newPath);
   });
   const unlinkSync = vi.fn().mockImplementation((filePath: any) => {
-    if (String(filePath).includes('.smart-wallets-snapshot.json')) {
+    if (String(filePath).includes('.smart-wallets-snapshot')) {
+      delete fsStore[String(filePath)];
       return undefined;
     }
     return actual.unlinkSync(filePath);
@@ -130,7 +145,7 @@ vi.mock('@etemaro/core', () => ({
   },
   computeDeployAmount: mockComputeDeployAmount,
   getDataDir: mockGetDataDir,
-  dataPath: (p: string) => path.join('/tmp/test-data', p),
+  dataPath: (p: string) => mockDataPath(p),
   sharedDataPath: (p: string) => path.join('/tmp/test-data', p),
   configPath: (p: string) => path.join('/tmp/test-config', p),
   log: mockLog,
@@ -261,6 +276,10 @@ function createMockAdapters(): DaemonAdapters {
 function resetSnapshot() {
   snapshotState.content = null;
   snapshotState.exists = false;
+  for (const key of Object.keys(fsStore)) {
+    delete fsStore[key];
+  }
+  mockDataPath.mockImplementation((p: string) => path.join('/tmp/test-data', p));
 }
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────
@@ -674,5 +693,33 @@ describe('runSmartWalletScreening — maxPositions enforcement', () => {
 
     // Restore config
     coreModule.config.risk.maxPositions = originalConfig.risk.maxPositions;
+  });
+
+  // ── Case 15: Migration fallback from legacy unsuffixed snapshot ──
+  it('migrates legacy unsuffixed snapshot to agent-suffixed snapshot when agent snapshot is missing', async () => {
+    mockDataPath.mockImplementation((p: string) => path.join('/tmp/test-data', '.smart-wallets-snapshot-agt_1.json'));
+    const legacyPath = path.join(mockGetDataDir(), '.smart-wallets-snapshot.json');
+    fsStore[legacyPath] = JSON.stringify({
+      initialized: true,
+      positions: [{ position: 'legacy-p1', pool: 'legacy-pool1' }],
+    });
+
+    mockGetTrackedPositions.mockReturnValue([]);
+    mockListSmartWallets.mockReturnValue({
+      wallets: [{ address: 'w1', type: 'lp' }],
+    });
+    mockGetWalletPositions.mockResolvedValue({
+      positions: [walletPos('legacy-p1', 'legacy-pool1')],
+    });
+    mockDiffSmartWalletPositions.mockReturnValue({
+      isFirstRun: false,
+      newPositions: [],
+      uniquePools: [],
+      nextSnapshot: { initialized: true, positions: [{ position: 'legacy-p1', pool: 'legacy-pool1' }] },
+    });
+
+    const result = await daemon.runSmartWalletScreening({ liveMessage: null, deployAmount: 1 });
+    expect(result).toBe('No new positions detected by smart wallets.');
+    expect(fsStore['/tmp/test-data/.smart-wallets-snapshot-agt_1.json']).toContain('legacy-p1');
   });
 });

--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -165,4 +165,82 @@ describe('Daemon — Concurrency & Mutex Guards', () => {
     expect(adapters.meteora.getMyPositions).toHaveBeenCalledTimes(1);
     expect(runScreeningSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('atomically prevents concurrent runManagementCycle executions', async () => {
+    let resolveFirst: any;
+    adapters.meteora.getMyPositions = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    // Start cycle 1
+    const p1 = daemon.runManagementCycle({ silent: true });
+    // Attempt concurrent cycle 2 immediately
+    const p2 = daemon.runManagementCycle({ silent: true });
+
+    // p2 should immediately return null because lock is held synchronously
+    const res2 = await p2;
+    expect(res2).toBeNull();
+
+    // Resolve cycle 1
+    resolveFirst({ total_positions: 0, positions: [] });
+    const res1 = await p1;
+    expect(res1).toContain('No open positions');
+
+    // Lock is now released, a subsequent call succeeds
+    adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    const res3 = await daemon.runManagementCycle({ silent: true });
+    expect(res3).toContain('No open positions');
+  });
+
+  it('atomically prevents concurrent runScreeningCycle executions', async () => {
+    let resolvePositions: any;
+    adapters.meteora.getMyPositions = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePositions = resolve;
+        }),
+    );
+
+    // Start screening 1
+    const p1 = daemon.runScreeningCycle({ silent: true });
+    // Attempt concurrent screening 2 immediately
+    const p2 = daemon.runScreeningCycle({ silent: true });
+
+    // p2 should immediately return null because screeningBusy lock is held synchronously
+    const res2 = await p2;
+    expect(res2).toBeNull();
+
+    // Resolve screening 1 pre-checks
+    resolvePositions({ total_positions: 5, positions: [] }); // exceeds max positions, skips
+    const res1 = await p1;
+    expect(res1).toContain('max positions reached');
+
+    // Lock is released after completion
+    expect((daemon as any).screeningBusy).toBe(false);
+  });
+
+  it('releases lock cleanly even when runManagementCycle throws', async () => {
+    adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({
+      total_positions: 1,
+      positions: [{ position: 'pos_1', pool: 'pool_1', pair: 'SOL-USDC' }],
+    });
+    adapters.domain.recordPositionSnapshot = vi.fn().mockImplementation(() => {
+      throw new Error('State explosion');
+    });
+
+    const res = await daemon.runManagementCycle({ silent: true });
+    expect(res).toContain('Management cycle failed: State explosion');
+    expect((daemon as any).managementBusy).toBe(false);
+  });
+
+  it('releases lock cleanly even when runScreeningCycle throws', async () => {
+    adapters.meteora.getMyPositions = vi.fn().mockRejectedValue(new Error('Screening RPC explosion'));
+
+    const res = await daemon.runScreeningCycle({ silent: true });
+    expect(res).toContain('Screening cycle failed: Screening RPC explosion');
+    expect((daemon as any).screeningBusy).toBe(false);
+  });
 });

--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -135,4 +135,34 @@ describe('Daemon — Concurrency & Mutex Guards', () => {
     }
     expect((daemon as any).managementBusy).toBe(true);
   });
+
+  it('calls getMyPositions only once during runManagementCycle and calculates remaining positions in memory', async () => {
+    const mockPositions = [
+      {
+        position: 'pos_1',
+        pool: 'pool_1',
+        pair: 'SOL-USDC',
+        pnl_pct: -55.0, // triggers stop loss close (default stopLossPct is -50)
+        unclaimed_fees_usd: 0,
+        total_value_usd: 100,
+        in_range: true,
+      },
+    ];
+
+    adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({
+      total_positions: 1,
+      positions: mockPositions,
+    });
+    adapters.toolExecutor.executeTool = vi.fn().mockResolvedValue({ success: true });
+    const runScreeningSpy = vi.spyOn(daemon, 'runScreeningCycle').mockResolvedValue(null);
+
+    // Set cooldown to past so screening can trigger
+    (daemon as any).screeningLastTriggered = 0;
+
+    await daemon.runManagementCycle({ silent: true });
+
+    // getMyPositions should only be called once at start of cycle, NOT at the end
+    expect(adapters.meteora.getMyPositions).toHaveBeenCalledTimes(1);
+    expect(runScreeningSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -569,7 +569,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
           this.managementBusy = true;
           try {
             const actMap = new Map([[p.position, { action: 'CLOSE', rule, reason }]]);
-            const rpt = await this.executeManagementActions([p], actMap, {});
+            const { report: rpt } = await this.executeManagementActions([p], actMap, {});
             log('state', `[PnL poll] ${p.pair}: ${rpt || 'closed'}`);
           } catch (e: any) {
             log('cron_error', `Poll-triggered close failed: ${e.message}`);
@@ -710,9 +710,10 @@ Summarize the current portfolio health, total fees earned, and performance of al
     actionPositions: any[],
     actionMap: Map<string, any>,
     { liveMessage = null as any, cur = '$' } = {},
-  ): Promise<string> {
+  ): Promise<{ report: string; closedCount: number }> {
     const lines: string[] = [];
     const instructionPositions: any[] = [];
+    let closedCount = 0;
 
     const mechanical = actionPositions.filter((p: any) => actionMap.get(p.position).action !== 'INSTRUCTION');
     if (mechanical.length) {
@@ -733,6 +734,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
           .executeTool('close_position', { position_address: p.position, reason })
           .catch((e: any) => ({ error: e.message }));
         const ok = res?.success !== false && !res?.error && !res?.blocked;
+        if (ok) closedCount++;
         await liveMessage?.toolFinish('close_position', res, ok);
         lines.push(`${p.pair}: ${ok ? `closed (${reason})` : `close FAILED — ${res?.error || res?.reason || 'unknown'}`}`);
       } else if (act.action === 'CLAIM') {
@@ -784,6 +786,9 @@ After evaluating, write a brief one-line result per position.
             await liveMessage?.toolStart(name);
           },
           onToolFinish: async ({ name, result, success }: any) => {
+            if (name === 'close_position' && success !== false && !result?.error && !result?.blocked) {
+              closedCount++;
+            }
             await liveMessage?.toolFinish(name, result, success);
           },
         },
@@ -791,7 +796,7 @@ After evaluating, write a brief one-line result per position.
       if (content) lines.push(content);
     }
 
-    return lines.join('\n');
+    return { report: lines.join('\n'), closedCount };
   }
 
   async runManagementCycle({ silent = false } = {}): Promise<string | null> {
@@ -902,19 +907,20 @@ After evaluating, write a brief one-line result per position.
         return a.action !== 'STAY';
       });
 
+      let closedCount = 0;
       if (actionPositions.length > 0) {
-        const execReport = await this.executeManagementActions(actionPositions, actionMap, { liveMessage, cur });
+        const { report: execReport, closedCount: closed } = await this.executeManagementActions(actionPositions, actionMap, { liveMessage, cur });
+        closedCount = closed;
         if (execReport) mgmtReport += `\n\n${execReport}`;
       } else {
         log('cron', 'Management: all positions STAY — skipping');
         await liveMessage?.note('No tool actions needed.');
       }
 
-      // Trigger screening after management
-      const afterPositions = await this.adapters.meteora.getMyPositions({ force: true }).catch(() => null);
-      const afterCount = afterPositions?.positions?.length ?? 0;
-      if (afterCount < config.risk.maxPositions && Date.now() - this.screeningLastTriggered > screeningCooldownMs) {
-        log('cron', `Post-management: ${afterCount}/${config.risk.maxPositions} positions — triggering screening`);
+      // Trigger screening after management if positions slots are available
+      const remainingCount = Math.max(0, positions.length - closedCount);
+      if (remainingCount < config.risk.maxPositions && Date.now() - this.screeningLastTriggered > screeningCooldownMs) {
+        log('cron', `Post-management: ${remainingCount}/${config.risk.maxPositions} positions — triggering screening`);
         this.runScreeningCycle().catch((e: any) => log('cron_error', `Triggered screening failed: ${e.message}`));
       }
     } catch (error: any) {

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -284,6 +284,51 @@ export class Daemon {
   private latestCandidates: any[] = [];
   private latestCandidatesAt: string | null = null;
 
+  /**
+   * Synchronous atomic check-and-set lock acquisition for daemon async cycles.
+   * Prevents overlapping timer ticks or event-loop delays from entering guarded sections concurrently.
+   */
+  private acquireLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): boolean {
+    switch (lockName) {
+      case 'management':
+        if (this.managementBusy || this.pnlPollBusy) return false;
+        this.managementBusy = true;
+        return true;
+      case 'screening':
+        if (this.screeningBusy) return false;
+        this.screeningBusy = true;
+        return true;
+      case 'pnlPoll':
+        if (this.managementBusy || this.screeningBusy || this.pnlPollBusy) return false;
+        this.pnlPollBusy = true;
+        return true;
+      case 'opportunityPoll':
+        if (this.screeningBusy || this.managementBusy || this.pnlPollBusy || this.opportunityPollBusy) return false;
+        this.opportunityPollBusy = true;
+        return true;
+    }
+  }
+
+  /**
+   * Synchronous lock release helper.
+   */
+  private releaseLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): void {
+    switch (lockName) {
+      case 'management':
+        this.managementBusy = false;
+        break;
+      case 'screening':
+        this.screeningBusy = false;
+        break;
+      case 'pnlPoll':
+        this.pnlPollBusy = false;
+        break;
+      case 'opportunityPoll':
+        this.opportunityPollBusy = false;
+        break;
+    }
+  }
+
   // Countdown timer
   private countdownInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -480,17 +525,12 @@ export class Daemon {
     this.stopCronJobs(); // stop any running tasks before (re)starting
     this.adapters.domain.validateActiveStrategy();
 
-    const mgmtTask = cron.schedule(`*/${Math.max(1, config.schedule.managementIntervalMin)} * * * *`, async () => {
-      if (this.managementBusy || this.pnlPollBusy) return;
-      this.managementLastRun = Date.now();
-      await this.runManagementCycle();
-    });
+    const mgmtTask = cron.schedule(`*/${Math.max(1, config.schedule.managementIntervalMin)} * * * *`, () => this.runManagementCycle());
 
     const screenTask = cron.schedule(`*/${Math.max(1, config.schedule.screeningIntervalMin)} * * * *`, () => this.runScreeningCycle());
 
     const healthTask = cron.schedule(`0 * * * *`, async () => {
-      if (this.managementBusy || this.pnlPollBusy) return;
-      this.managementBusy = true;
+      if (!this.acquireLock('management')) return;
       log('cron', 'Starting health check');
       try {
         await agentLoop(
@@ -509,7 +549,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
       } catch (error: any) {
         log('cron_error', `Health check failed: ${error.message}`);
       } finally {
-        this.managementBusy = false;
+        this.releaseLock('management');
       }
     });
 
@@ -536,9 +576,8 @@ Summarize the current portfolio health, total fees earned, and performance of al
     const confirmTicks = Math.max(1, Number(config.pnl.confirmTicks ?? 2));
 
     this.pnlPollInterval = setInterval(async () => {
-      if (this.managementBusy || this.screeningBusy || this.pnlPollBusy) return;
       if (getTrackedPositions(true).length === 0) return;
-      this.pnlPollBusy = true;
+      if (!this.acquireLock('pnlPoll')) return;
       try {
         const result = await this.adapters.meteora.getMyPositions({ force: true, silent: true }).catch(() => null);
         if (!result?.positions?.length) return;
@@ -566,6 +605,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
 
           log('state', `[PnL poll] ${signal} confirmed (${confirmTicks} ticks): ${p.pair} — ${reason} — closing directly`);
           // Hold the management lock so the cron cycle can't double-act on this position.
+          const wasManagementBusy = this.managementBusy;
           this.managementBusy = true;
           try {
             const actMap = new Map([[p.position, { action: 'CLOSE', rule, reason }]]);
@@ -574,14 +614,14 @@ Summarize the current portfolio health, total fees earned, and performance of al
           } catch (e: any) {
             log('cron_error', `Poll-triggered close failed: ${e.message}`);
           } finally {
-            this.managementBusy = false;
+            this.managementBusy = wasManagementBusy;
           }
           break; // one action per tick
         }
       } catch (e: any) {
         log('cron_error', `PnL poll failed: ${e.message}`);
       } finally {
-        this.pnlPollBusy = false;
+        this.releaseLock('pnlPoll');
       }
     }, pnlPollMs);
 
@@ -591,10 +631,9 @@ Summarize the current portfolio health, total fees earned, and performance of al
       const oppCooldownMs = 5 * 60 * 1000;
 
       this.opportunityPollInterval = setInterval(async () => {
-        if (this.screeningBusy || this.managementBusy || this.pnlPollBusy || this.opportunityPollBusy) return;
-        if (Date.now() - this.screeningLastTriggered < oppCooldownMs) return;
-        this.opportunityPollBusy = true;
+        if (!this.acquireLock('opportunityPoll')) return;
         try {
+          if (Date.now() - this.screeningLastTriggered < oppCooldownMs) return;
           const [positions, balance] = await Promise.all([
             this.adapters.meteora.getMyPositions({ force: true, silent: true }).catch(() => null),
             this.adapters.wallet.getWalletBalances().catch(() => null),
@@ -644,7 +683,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
         } catch (e: any) {
           log('cron_error', `Opportunity poll failed: ${e.message}`);
         } finally {
-          this.opportunityPollBusy = false;
+          this.releaseLock('opportunityPoll');
         }
       }, oppMs);
     }
@@ -800,8 +839,7 @@ After evaluating, write a brief one-line result per position.
   }
 
   async runManagementCycle({ silent = false } = {}): Promise<string | null> {
-    if (this.managementBusy || this.pnlPollBusy) return null;
-    this.managementBusy = true;
+    if (!this.acquireLock('management')) return null;
     this.managementLastRun = Date.now();
     log('cron', 'Starting management cycle');
     let mgmtReport: string | null = null;
@@ -927,7 +965,7 @@ After evaluating, write a brief one-line result per position.
       log('cron_error', `Management cycle failed: ${error.message}`);
       mgmtReport = `Management cycle failed: ${error.message}`;
     } finally {
-      this.managementBusy = false;
+      this.releaseLock('management');
       if (!silent && this.adapters.telegram.isEnabled()) {
         if (mgmtReport) {
           if (liveMessage) await liveMessage.finalize(stripThink(mgmtReport)).catch(() => {});
@@ -979,11 +1017,10 @@ After evaluating, write a brief one-line result per position.
   }
 
   async runScreeningCycle({ silent = false } = {}): Promise<string | null> {
-    if (this.screeningBusy) {
+    if (!this.acquireLock('screening')) {
       log('cron', 'Screening skipped — previous cycle still running');
       return null;
     }
-    this.screeningBusy = true;
     this.screeningLastTriggered = Date.now();
 
     let prePositions: any, preBalance: any;
@@ -1003,7 +1040,6 @@ After evaluating, write a brief one-line result per position.
           summary: 'Screening skipped',
           reason: `Max positions reached (${prePositions.total_positions}/${config.risk.maxPositions})`,
         });
-        this.screeningBusy = false;
         return screenReport;
       }
       const minRequired = config.management.deployAmountSol + config.management.gasReserve;
@@ -1017,33 +1053,25 @@ After evaluating, write a brief one-line result per position.
           summary: 'Screening skipped',
           reason: `Insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)})`,
         });
-        this.screeningBusy = false;
         return screenReport;
       }
-    } catch (e: any) {
-      log('cron_error', `Screening pre-check failed: ${e.message}`);
-      screenReport = `Screening pre-check failed: ${e.message}`;
-      this.screeningBusy = false;
-      return screenReport;
-    }
-    if (!silent && this.adapters.telegram.isEnabled()) {
-      liveMessage = await this.adapters.telegram.createLiveMessage('🔍 Screening Cycle', 'Scanning candidates...');
-    }
-    this.screeningLastRun = Date.now();
 
-    if (config.screening.entrySource === 'smart_wallets') {
-      try {
-        screenReport = await this.runSmartWalletScreening({ liveMessage, deployAmount: computeDeployAmount(preBalance.sol) });
-      } catch (e: any) {
-        log('cron_error', `Smart wallet screening failed: ${e.message}`);
-        screenReport = `Smart wallet screening failed: ${e.message}`;
+      if (!silent && this.adapters.telegram.isEnabled()) {
+        liveMessage = await this.adapters.telegram.createLiveMessage('🔍 Screening Cycle', 'Scanning candidates...');
       }
-      this.screeningBusy = false;
-      return screenReport;
-    }
+      this.screeningLastRun = Date.now();
 
-    log('cron', `Starting screening cycle [model: ${config.llm.screeningModel}]`);
-    try {
+      if (config.screening.entrySource === 'smart_wallets') {
+        try {
+          screenReport = await this.runSmartWalletScreening({ liveMessage, deployAmount: computeDeployAmount(preBalance.sol) });
+        } catch (e: any) {
+          log('cron_error', `Smart wallet screening failed: ${e.message}`);
+          screenReport = `Smart wallet screening failed: ${e.message}`;
+        }
+        return screenReport;
+      }
+
+      log('cron', `Starting screening cycle [model: ${config.llm.screeningModel}]`);
       const currentBalance = preBalance;
       const deployAmount = computeDeployAmount(currentBalance.sol);
       log('cron', `Computed deploy amount: ${deployAmount} SOL (wallet: ${currentBalance.sol} SOL)`);
@@ -1331,7 +1359,7 @@ IMPORTANT:
       log('cron_error', `Screening cycle failed: ${error.message}`);
       screenReport = `Screening cycle failed: ${error.message}`;
     } finally {
-      this.screeningBusy = false;
+      this.releaseLock('screening');
       if (!silent && this.adapters.telegram.isEnabled()) {
         if (screenReport) {
           if (liveMessage) await liveMessage.finalize(stripThink(screenReport)).catch(() => {});

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -1361,14 +1361,25 @@ IMPORTANT:
       return 'No smart LP wallets tracked.';
     }
 
-    // 2. Load snapshot
+    // 2. Load snapshot (with migration fallback from legacy unsuffixed snapshot)
     const snapshotPath = dataPath('.smart-wallets-snapshot.json');
+    const legacySnapshotPath = path.join(getDataDir(), '.smart-wallets-snapshot.json');
     let snapshot: domain.SmartWalletSnapshot | null = null;
     if (fs.existsSync(snapshotPath)) {
       try {
         snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
       } catch (e: any) {
         log('cron_error', `[SmartWallets] Failed to load snapshot: ${e.message}`);
+      }
+    } else if (snapshotPath !== legacySnapshotPath && fs.existsSync(legacySnapshotPath)) {
+      try {
+        snapshot = JSON.parse(fs.readFileSync(legacySnapshotPath, 'utf8'));
+        if (snapshot) {
+          saveJsonFile(snapshotPath, snapshot);
+          log('cron', `[SmartWallets] Migrated legacy snapshot to agent snapshot: ${snapshotPath}`);
+        }
+      } catch (e: any) {
+        log('cron_error', `[SmartWallets] Failed to load legacy snapshot: ${e.message}`);
       }
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,10 +52,14 @@ echo "Found latest release: $LATEST_RELEASE"
 echo "Installing Etemaro CLI via npm..."
 if command -v npm >/dev/null 2>&1; then
     npm install -g @etemaro/cli
-    echo "Etemaro CLI installed successfully!"
-    echo "Run 'etemaro help' to get started."
+    echo "Etemaro CLI installed."
+    echo ""
+    echo "Next (first-time setup, ~1 minute):"
+    echo "  etemaro init"
+    echo "Then:"
+    echo "  etemaro start --dry-run"
 else
     echo "Error: npm is required to install Etemaro CLI globally."
-    echo "Please install Node.js and npm first: https://nodejs.org/"
+    echo "Install Node.js 22+ first: https://nodejs.org/"
     exit 1
 fi


### PR DESCRIPTION
## Summary / Problem

Closes #187. Concurrent screening and opportunity triggers could independently pass the wallet balance and gas reserve checks before attempting deployments, allowing both transactions to proceed when funds covered only one deployment.

## Changes

- Serialize `deploy_position` safety checks and execution through the shared `executeTool` entry point.
- Add a regression test covering two near-simultaneous deploy requests and confirming that only one deployment is in flight.

## Tests

- `corepack pnpm test` — PASS (24 files, 143 tests)
- `corepack pnpm build` — PASS (existing CJS `import.meta` warnings only)
- `corepack pnpm typecheck` — PASS
- `corepack pnpm lint` — PASS
- `corepack pnpm exec prettier --check packages/core/src/adapters/ToolExecutor.ts packages/core/src/adapters/ToolExecutor.test.ts` — PASS
- `git diff --check` — PASS

## Compatibility / Known limitations

The public `executeTool` API and non-deploy behavior are unchanged. The regression test uses mocked adapters; no live Solana transaction was submitted.

## Issue link

https://github.com/romankurnovskii/etemaro/issues/187
