### PR TITLE
fix(core): harden loadJsonFile with critical fail-fast for state.json (#183)

### DIFF
--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -156,3 +156,22 @@ describe('save() persistence failures', () => {
     }
   });
 });
+
+describe('state.json corruption handling', () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  it('fails fast and throws when state.json contains corrupted JSON', () => {
+    fs.writeFileSync(TMP_STATE, '{"positions": { invalid json');
+    expect(() => getTrackedPositions()).toThrowError(/Failed to parse JSON file at.*Critical file corrupted/);
+  });
+});

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -13,7 +13,7 @@
 import { log } from '../shared/logger.js';
 import { dataPath, MAX_RECENT_EVENTS, MAX_INSTRUCTION_LENGTH, SYNC_GRACE_MS } from '../shared/constants.js';
 import { sanitizeStoredText, loadJsonFile, saveJsonFile } from '../shared/utils.js';
-import type { PositionRecord, StateEvent, BinRange, ExitResult, ExitAction, StateSummary } from '../shared/types.js';
+import type { PositionRecord, StateEvent, BinRange, ExitResult, StateSummary } from '../shared/types.js';
 
 export type { PositionRecord } from '../shared/types.js';
 import type { AppConfig } from '../shared/types.js';
@@ -37,11 +37,15 @@ interface StateData {
 }
 
 function load(): StateData {
-  return loadJsonFile<StateData>(STATE_FILE, {
-    positions: {},
-    recentEvents: [],
-    lastUpdated: null,
-  });
+  return loadJsonFile<StateData>(
+    STATE_FILE,
+    {
+      positions: {},
+      recentEvents: [],
+      lastUpdated: null,
+    },
+    { label: 'state', critical: true },
+  );
 }
 
 function save(state: StateData): void {

--- a/packages/core/src/shared/utils.test.ts
+++ b/packages/core/src/shared/utils.test.ts
@@ -89,6 +89,16 @@ describe('loadJsonFile — missing vs corrupt file handling', () => {
     expect(result).toEqual({ fallback: 123 });
   });
 
+  it('throws error when file contains corrupt JSON and critical: true', async () => {
+    const { loadJsonFile } = await import('./utils.js');
+    const target = path.join(tmpDir, 'corrupt-critical.json');
+    fs.writeFileSync(target, '{ broken json');
+
+    expect(() => loadJsonFile(target, { fallback: true }, { label: 'state', critical: true })).toThrowError(
+      /Failed to parse JSON file at.*Critical file corrupted/,
+    );
+  });
+
   it('correctly parses and returns valid JSON', async () => {
     const { loadJsonFile } = await import('./utils.js');
     const target = path.join(tmpDir, 'valid.json');

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -11,7 +11,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { REPO_ROOT } from './constants.js';
 import { log } from './logger.js';
 
 // ─── Path Utilities ────────────────────────────────────────
@@ -120,17 +119,20 @@ export function nonEmptyString(...values: unknown[]): string | null {
 
 // ─── JSON File Utilities ───────────────────────────────────────
 
-export function loadJsonFile<T>(filePath: string, fallback: T, options?: { label?: string; warnOnCorrupt?: boolean }): T {
+export function loadJsonFile<T>(filePath: string, fallback: T, options?: { label?: string; warnOnCorrupt?: boolean; critical?: boolean }): T {
   if (!fs.existsSync(filePath)) return fallback;
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const prefix = options?.label ? `[${options.label}] ` : '';
+    const parseError = err instanceof Error ? err.message : String(err);
+    if (options?.critical) {
+      const msg = `${prefix}Failed to parse JSON file at "${filePath}" (corrupt or unreadable): ${parseError}. Critical file corrupted — failing fast to prevent state loss.`;
+      log('file_error', msg);
+      throw new Error(msg, { cause: err });
+    }
     if (options?.warnOnCorrupt !== false) {
-      const prefix = options?.label ? `[${options.label}] ` : '';
-      log(
-        'file_error',
-        `${prefix}Failed to parse JSON file at "${filePath}" (corrupt or unreadable): ${err?.message || err}. Using default fallback.`,
-      );
+      log('file_error', `${prefix}Failed to parse JSON file at "${filePath}" (corrupt or unreadable): ${parseError}. Using default fallback.`);
     }
     return fallback;
   }


### PR DESCRIPTION
## Summary
Hardens `loadJsonFile()` to fail fast when encountering corrupted JSON in critical files (such as `state.json`), preventing the daemon from silently wiping tracked positions and state.

Closes #183

## Root Cause & Gap Analysis
- **Why/When it happened**: `loadJsonFile()` treated missing files and malformed JSON identically, falling back to `{ positions: {} }` without throwing. In the event of a disk glitch or interrupted write, state tracking would silently reset to empty.
- **Why we missed it**: Unit tests only asserted that corrupted non-critical JSON files returned fallback values without throwing.

## Acceptance Criteria Checklist
- [x] AC1: `loadJsonFile` returns `fallback` cleanly when `!fs.existsSync(filePath)` without logging or throwing.
- [x] AC2: When `critical: true` is passed and `JSON.parse` fails on an existing corrupt file, `loadJsonFile` logs `file_error` and throws a fatal descriptive `Error` with `{ cause: err }`.
- [x] AC3: When `critical` is omitted or `false`, `loadJsonFile` logs `file_error` and returns `fallback`.
- [x] AC4: `state.ts` specifies `critical: true` and `label: 'state'` in `load()`.
- [x] AC5: Unit tests verify missing file fallback, non-critical corrupt fallback with warning, and critical corrupt throw.

## Testing Plan
- [x] **Automated Tests**: Unit tests in `utils.test.ts` and `state.test.ts` pass (149/149 total).
- [x] **Typecheck & Build**: Clean typecheck and build across monorepo workspace.