### PR TITLE
feat(cli): first-run init so curl install can start in ~1 minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,51 +20,28 @@ Etemaro runs continuous screening and management cycles, deploying capital into 
 
 ---
 
-## Prerequisites & Credentials
+## Run the agent
 
-Before running Etemaro, ensure you have:
-
-- **Node.js**: `>= 22.0.0`
-- **Required Credentials**:
-  - `WALLET_PRIVATE_KEY` — Solana wallet base58 private key (for deploying/closing positions)
-  - `LLM_API_KEY` — API key for OpenAI, OpenRouter, or an OpenAI-compatible provider
-  - `JUPITER_API_KEY` — Jupiter swap API key ([get one here](https://developers.jup.ag/portal/))
-
----
-
-## Getting Started
-
-> 💡 **Have questions?** Most common user questions, setup troubleshooting, multi-instance deployment steps, and PnL metric definitions are covered in **[docs/QA.md](docs/QA.md)**.
-
-### ⚡ 1-Line Quick Install (CLI)
+Need **Node.js 22+**. Then two commands:
 
 ```bash
-# Install Etemaro CLI globally (macOS / Linux)
 curl -fsSL https://etemaro.com/install.sh | sh
+etemaro init
 ```
 
-_Or install via npm / Homebrew:_
+`etemaro init` is first-time setup (~1 minute). It creates `~/.config/etemaro`, checks for a wallet key and an LLM key, and tells you what is missing. Jupiter is only needed later for live swaps.
+
+When the checklist is green:
 
 ```bash
-npm install -g @etemaro/cli
-# or: brew install romankurnovskii/awesome-brew/etemaro
-```
-
-### 🚀 30-Second Quickstart
-
-```bash
-# 1. Provide your Solana wallet private key (in a .env file or export)
-export WALLET_PRIVATE_KEY="your_base58_solana_private_key"
-
-# 2. Check live wallet balances
-etemaro balance
-
-# 3. Simulate and test strategies (dry-run mode, no real transactions)
 etemaro start --dry-run
-
-# 4. Start autonomous agent in live trading mode
-etemaro start
 ```
+
+Live mode (real trades): add `JUPITER_API_KEY`, then `etemaro start`.
+
+_Or install via `npm install -g @etemaro/cli` / `brew install romankurnovskii/awesome-brew/etemaro`._
+
+> Common questions: **[docs/QA.md](docs/QA.md)**.
 
 ---
 
@@ -98,25 +75,15 @@ pnpm run dev
 
 ---
 
-## Server Deployment
+## Server
 
-**Option A: PM2 (Production Process Manager)**
-
-```bash
-npm run build
-npm run pm2:start    # Start daemon under PM2 with auto-restart
-npm run pm2:logs     # Tail live logs
-```
-
-**Option B: Docker**
+Same two commands on a VPS. Keep the process running with tmux, systemd, or:
 
 ```bash
-# Development (hot reload, mounts source)
-docker compose -f docker-compose.dev.yml up --build
-
-# Production (on remote server, .env already present)
-docker compose -f docker-compose.prod.yml up -d --build --force-recreate --remove-orphans
+nohup etemaro start --dry-run >> ~/.config/etemaro/data/agent.out 2>&1 &
 ```
+
+Clone + PM2 / Docker is **[source setup](#developer--source-setup)** above.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ Etemaro uses a strict schema-validated configuration system (Version 3): every r
               └────────────────────────┘     ALL required fields must be present.
 ```
 
-> Initialize the configuration file before starting: `pnpm cli init` (or `etemaro init`).
+> First-time setup: `etemaro init` (creates `~/.config/etemaro` and checks wallet + LLM keys). From a source clone you can also run `pnpm cli init`.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,134 +1,60 @@
 # Getting Started with Etemaro
 
-A simple guide to run your first autonomous LP agent on Solana.
-
----
+Two commands. About a minute.
 
 ## 1. Install
 
-### Option A: 1-Line Install (CLI — Recommended)
+Need Node.js 22+.
 
 ```bash
 curl -fsSL https://etemaro.com/install.sh | sh
 ```
 
-_Or via npm:_
+_Or:_ `npm install -g @etemaro/cli`
+
+**Desktop (macOS):** `brew tap romankurnovskii/awesome-brew && brew install --cask romankurnovskii/awesome-brew/etemaro`
+
+**From source:** `git clone https://github.com/romankurnovskii/etemaro && cd etemaro && pnpm install`
+
+## 2. First-time setup
 
 ```bash
-npm install -g @etemaro/cli
+etemaro init
 ```
 
-### Option B: Desktop App (macOS)
+This creates `~/.config/etemaro` and checks the only two keys needed to start in dry-run:
+
+| Variable             | What it is                                              |
+| -------------------- | ------------------------------------------------------- |
+| `WALLET_PRIVATE_KEY` | Solana wallet base58 key (or `etemaro generate-wallet`) |
+| `LLM_API_KEY`        | OpenRouter / OpenAI / compatible LLM key                |
+
+On a terminal it will prompt. On a server without a TTY, paste the keys into `~/.config/etemaro/.env` and run `etemaro init` again.
+
+Jupiter, Telegram, and strategy JSON are **not** part of first setup. Add `JUPITER_API_KEY` only when you go live.
+
+Desktop users: paste keys in **Settings → Environment Variables** instead of the CLI.
+
+## 3. Start
 
 ```bash
-brew tap romankurnovskii/awesome-brew
-brew trust --cask romankurnovskii/awesome-brew/etemaro
-brew install romankurnovskii/awesome-brew/etemaro --cask
+etemaro start --dry-run
 ```
 
-_(Windows and Linux builds are also available on [GitHub Releases](https://github.com/romankurnovskii/etemaro/releases))_
+Default strategy is `bid_ask` with `dryRun: true`. Screening every 30 minutes, management every 10.
 
-### Option C: Developer / Source Setup
-
-```bash
-git clone https://github.com/romankurnovskii/etemaro
-cd etemaro
-pnpm install
-```
-
----
-
-## 2. Create a Telegram Bot (optional but recommended)
-
-This lets you control and monitor the agent from your phone.
-
-1. Open Telegram and search for **@BotFather**.
-2. Send `/newbot`, follow the prompts, and copy the **token** (looks like `123456:ABC-DEF...`).
-3. Send any message to your new bot (required to activate it).
-4. To get your **chat ID**:
-   - Open in a browser: `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates`
-   - Look for `"chat":{"id":123456789,...}` — that number is your chat ID.
-   - (Or use @userinfobot in Telegram.)
-
----
-
-## 3. Configure Environment Variables
-
-Initialize your configuration files and fill in your values:
-
-```bash
-pnpm cli init
-```
-
-Edit `.env` and set:
-
-> **Desktop App users**: skip manual `.env` editing — you can add these values directly in the app under **Settings → Environment Variables**. The GUI stores them as process envs at runtime.
-
-| Variable                    | What it is                                     | Where to get it                                           |
-| --------------------------- | ---------------------------------------------- | --------------------------------------------------------- |
-| `WALLET_PRIVATE_KEY`        | Your Solana wallet key (base58 string)         | Export from Phantom / Solflare wallet settings            |
-| `JUPITER_API_KEY`           | Jupiter swap API key                           | https://developers.jup.ag/portal/                         |
-| `LLM_API_KEY`               | Your AI model API key                          | OpenRouter, OpenAI, or any OpenAI-compatible provider     |
-| `LLM_BASE_URL`              | AI model endpoint                              | `https://openrouter.ai/api/v1` (default) or your provider |
-| `LLM_MODEL`                 | Model name                                     | e.g. `openrouter/healer-alpha` or `gpt-4o`                |
-| `TELEGRAM_BOT_TOKEN`        | Bot token from BotFather                       | Step 2 above                                              |
-| `TELEGRAM_CHAT_ID`          | Your Telegram chat ID                          | Step 2 above                                              |
-| `TELEGRAM_ALLOWED_USER_IDS` | Restrict bot access to specific Telegram users | Leave empty to allow anyone who knows the bot             |
-
----
-
-## 4. Choose Your First Strategy
-
-Open `config/user-config.json` and look at the `strategy` section:
-
-```json
-"strategy": {
-  "strategy": "bid_ask",
-  "minBinsBelow": 35,
-  "maxBinsBelow": 69,
-  "defaultBinsBelow": 69
-}
-```
-
-**Default: `bid_ask`** — places liquidity on both sides of the current price. This is a safe, standard LP strategy.
-
-If you want something simpler, change `"strategy"` to `"spot"` to place liquidity centered around the current price only.
-
-Keep `dryRun: true` while testing — this simulates trades without spending real SOL.
-
----
-
-## 5. Run the Agent
-
-```bash
-# Test first (no real transactions)
-npm run dev
-
-# When ready, go live
-npm start
-```
-
-You will see a REPL prompt with countdown timers:
+When you are ready for live trades: set `JUPITER_API_KEY`, then `etemaro start`.
 
 ```
 [manage: 8m 12s | screen: 24m 3s]
 >
 ```
 
-The agent will automatically:
-
-- **Screen** for new pools every 30 minutes
-- **Manage** open positions every 10 minutes
-
-If Telegram is configured, you will receive notifications for every deploy, close, and swap.
-
----
-
-## Quick Health Check
+## Quick health check
 
 ```bash
-npm run balance    # Check wallet SOL balance
-npm run positions  # See open positions
+etemaro balance
+etemaro positions
 ```
 
 ---

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -48,24 +48,12 @@ The agent loop, role-based tool access, and tool-execution safety checks are doc
 ### First-time Setup
 
 ```bash
-# 1. Clone and install
-git clone https://github.com/romankurnovskii/etemaro
-cd etemaro
-npm install
-
-# 2. Initialize configuration (.env + user-config.json)
-pnpm cli init
-
-# 3. Edit .env and enter your credentials:
-#   - WALLET_PRIVATE_KEY (Solana wallet private key)
-#   - LLM_API_KEY (OpenAI / OpenRouter API key)
-#   - JUPITER_API_KEY (Jupiter swap API key)
-#   - TELEGRAM_BOT_TOKEN & TELEGRAM_CHAT_ID (optional)
-
-# 3. Test in dry-run mode
-npm run dev
-# This starts the REPL + cron but skips all on-chain transactions
+curl -fsSL https://etemaro.com/install.sh | sh
+etemaro init
+etemaro start --dry-run
 ```
+
+From a source clone: `pnpm install` then `pnpm cli init` and `pnpm run dev`.
 
 ### Day-to-Day Operations
 

--- a/packages/cli/src/Cli.test.ts
+++ b/packages/cli/src/Cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveGlobalFlagValue } from './Cli.js';
+import { applyCliRuntimeFlags, resolveGlobalFlagValue } from './Cli.js';
 
 describe('resolveGlobalFlagValue', () => {
   it('returns the value following the long flag', () => {
@@ -24,5 +24,19 @@ describe('resolveGlobalFlagValue', () => {
 
   it('extends forward to find the value past the subcommand', () => {
     expect(resolveGlobalFlagValue(['balance', '--data-dir', '/tmp/d'], '--data-dir', '-d')).toBe('/tmp/d');
+  });
+});
+
+describe('applyCliRuntimeFlags', () => {
+  it('sets DRY_RUN when --dry-run is present', () => {
+    const env: Record<string, string | undefined> = {};
+    applyCliRuntimeFlags({ 'dry-run': true }, env);
+    expect(env.DRY_RUN).toBe('true');
+  });
+
+  it('does not set DRY_RUN when the flag is absent', () => {
+    const env: Record<string, string | undefined> = { DRY_RUN: 'false' };
+    applyCliRuntimeFlags({}, env);
+    expect(env.DRY_RUN).toBe('false');
   });
 });

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -11,11 +11,20 @@
  * @sideEffects One-shot tool execution and console JSON output
  */
 
-import dotenv from 'dotenv';
-dotenv.config({ override: true });
 import fs from 'fs';
 import path from 'path';
+import readline from 'node:readline/promises';
+import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
 import { parseArgs } from 'util';
+import {
+  assessSetup,
+  formatInitMessage,
+  loadRuntimeDotenv,
+  maybePromptSecrets,
+  parseEnvFile,
+  upsertEnvVars,
+  writeRuntimeSkeleton,
+} from './firstSetup.js';
 // Type-only imports to help tsc
 type CoreExports = typeof import('@etemaro/core');
 type DaemonExports = typeof import('@etemaro/daemon');
@@ -138,6 +147,7 @@ export interface CliAdapters {
     getPerformanceSummary: () => any;
   };
   daemon?: {
+    start?: (options?: { tty?: boolean }) => Promise<void>;
     runScreeningCycle: (opts?: { silent?: boolean }) => Promise<string | null>;
     runManagementCycle: (opts?: { silent?: boolean }) => Promise<string | null>;
     startCronJobs: () => void;
@@ -322,6 +332,9 @@ Shows pending Discord signal queue from the discord-listener process.
 Output: { count, pending, processed, signals: [{id, symbol, pool, author, channel, queued_at, rug_score, status}] }
 \`\`\`
 
+### etemaro init [--dir <path>]
+First-time setup (~1 minute). Creates runtime files and checks wallet + LLM keys.
+
 ### etemaro start [--dry-run]
 Starts the autonomous agent with cron jobs (management + screening).
 
@@ -397,10 +410,13 @@ export class Cli {
         limit: { type: 'string' },
         dir: { type: 'string' },
         label: { type: 'string' },
+        yes: { type: 'boolean' },
       },
       allowPositionals: true,
       strict: false,
     });
+
+    applyCliRuntimeFlags(flags as Record<string, unknown>, process.env);
 
     switch (subcommand) {
       case 'generate-wallet':
@@ -481,63 +497,41 @@ export class Cli {
 
   // ─── Command Handlers ──────────────────────────────────────────
 
-  private handleInit(flags: Record<string, any>): void {
+  private async handleInit(flags: Record<string, any>): Promise<void> {
     const targetDir = typeof flags.dir === 'string' && flags.dir.trim().length > 0 ? path.resolve(flags.dir) : this.etemaroDir;
-    const configDir = path.join(targetDir, 'config');
-    const dataDir = path.join(targetDir, 'data');
-
-    fs.mkdirSync(targetDir, { recursive: true });
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.mkdirSync(dataDir, { recursive: true });
-
-    // .env
-    const envFile = path.join(targetDir, '.env');
-    let envCreated = false;
-    if (!fs.existsSync(envFile)) {
-      const template = `# etemaro process environment variables
-WALLET_PRIVATE_KEY=""
-HELIUS_API_KEY=""
-RPC_URL="https://pump.helius-rpc.com"
-LLM_API_KEY=""
-LLM_BASE_URL="https://openrouter.ai/api/v1"
-LLM_MODEL="anthropic/claude-3.5-sonnet"
-TELEGRAM_BOT_TOKEN=""
-TELEGRAM_CHAT_ID=""
-TELEGRAM_ALLOWED_USER_IDS=""
-JUPITER_API_KEY=""
-`;
-      fs.writeFileSync(envFile, template);
-      envCreated = true;
-    }
-
-    // config/user-config.json
-    const userConfigFile = path.join(configDir, 'user-config.json');
-    let configCreated = false;
-    if (!fs.existsSync(userConfigFile)) {
-      fs.writeFileSync(userConfigFile, defaultUserConfigStr + '\n');
-      configCreated = true;
-    }
-
-    // data/strategy-library.shared.json
-    const sharedStrategyFile = path.join(dataDir, 'strategy-library.shared.json');
-    let strategyCreated = false;
-    if (!fs.existsSync(sharedStrategyFile)) {
-      const sharedData = { strategies: DEFAULT_STRATEGIES };
-      fs.writeFileSync(sharedStrategyFile, JSON.stringify(sharedData, null, 2) + '\n');
-      strategyCreated = true;
-    }
-
-    // SKILL.md
+    const skeleton = writeRuntimeSkeleton(targetDir, {
+      defaultUserConfigStr,
+      defaultStrategies: DEFAULT_STRATEGIES,
+    });
     this.writeSkillMd();
 
-    out({
-      success: true,
-      directory: targetDir,
-      env: { path: envFile, created: envCreated },
-      config: { path: userConfigFile, created: configCreated },
-      strategyLibrary: { path: sharedStrategyFile, created: strategyCreated },
-      message: 'Etemaro runtime directory initialized successfully.',
+    const envFile = skeleton.env.path;
+    const fileEnv = fs.existsSync(envFile) ? parseEnvFile(fs.readFileSync(envFile, 'utf8')) : {};
+    let status = assessSetup({ ...fileEnv, ...process.env });
+
+    const interactive = process.stdin.isTTY === true && flags.yes !== true;
+    const updates = await maybePromptSecrets({
+      interactive,
+      status,
+      ask: askTty,
     });
+    if (Object.keys(updates).length > 0) {
+      const next = upsertEnvVars(fs.readFileSync(envFile, 'utf8'), updates);
+      fs.writeFileSync(envFile, next);
+      for (const [key, value] of Object.entries(updates)) process.env[key] = value;
+      status = assessSetup({ ...parseEnvFile(next), ...process.env });
+    }
+
+    const text = formatInitMessage({
+      directory: targetDir,
+      firstRun: skeleton.env.created || skeleton.config.created,
+      status,
+    });
+    process.stdout.write(text + '\n');
+    if (typeof flags.dir === 'string' && flags.dir.trim()) {
+      process.stdout.write(`\nCustom dir: export ETEMARO_HOME="${targetDir}" before etemaro start\n`);
+    }
+    process.exit(status.readyForDryRun ? 0 : 1);
   }
 
   private handleGenerateWallet(flags: Record<string, any>): void {
@@ -798,10 +792,10 @@ JUPITER_API_KEY=""
     out(await this.adapters.domain.studyTopLPers({ pool_address: flags.pool, limit }));
   }
 
-  private handleStart(): void {
-    if (!this.adapters.daemon) die('Start command requires daemon adapter');
+  private async handleStart(): Promise<void> {
+    if (!this.adapters.daemon?.start) die('Start command requires daemon adapter');
     process.stderr.write('[etemaro] Starting autonomous agent...\n');
-    this.adapters.daemon.startCronJobs();
+    await this.adapters.daemon.start({ tty: process.stdout.isTTY === true });
   }
 
   private async handleLessons(argv: string[], sub2: string | undefined, flags: Record<string, any>): Promise<void> {
@@ -940,6 +934,28 @@ export function resolveGlobalFlagValue(argv: string[], flag: string, alias?: str
   return value;
 }
 
+/** Apply CLI flags that must be visible to core before any tool runs. */
+export function applyCliRuntimeFlags(flags: Record<string, unknown>, env: NodeJS.Dict<string> = process.env): void {
+  if (flags['dry-run'] === true) env.DRY_RUN = 'true';
+}
+
+function defaultEtemaroHome(): string {
+  const fromEnv = process.env.ETEMARO_HOME?.trim();
+  if (fromEnv) return path.resolve(fromEnv);
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const xdg = process.env.XDG_CONFIG_HOME || (home ? path.join(home, '.config') : '');
+  return path.join(xdg, 'etemaro');
+}
+
+async function askTty(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: stdinStream, output: stdoutStream });
+  try {
+    return (await rl.question(question)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
 
@@ -948,6 +964,7 @@ async function main() {
   if (configPathArg) process.env.USER_CONFIG_PATH = path.resolve(configPathArg);
   if (dataDirArg) process.env.ETEMARO_DATA_DIR = path.resolve(dataDirArg);
 
+  loadRuntimeDotenv(defaultEtemaroHome());
   await loadCore();
 
   const agentLoopDeps = {

--- a/packages/cli/src/firstSetup.test.ts
+++ b/packages/cli/src/firstSetup.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { assessSetup, formatInitMessage, loadRuntimeDotenv, maybePromptSecrets, upsertEnvVars, writeRuntimeSkeleton } from './firstSetup.js';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'etemaro-init-'));
+}
+
+describe('assessSetup', () => {
+  it('is not ready when wallet and llm keys are missing', () => {
+    const status = assessSetup({});
+    expect(status.wallet).toBe(false);
+    expect(status.llm).toBe(false);
+    expect(status.readyForDryRun).toBe(false);
+    expect(status.readyForLive).toBe(false);
+  });
+
+  it('treats blank and env-ref values as missing', () => {
+    const status = assessSetup({
+      WALLET_PRIVATE_KEY: '  ',
+      LLM_API_KEY: 'env.LLM_API_KEY',
+      JUPITER_API_KEY: '""',
+    });
+    expect(status.wallet).toBe(false);
+    expect(status.llm).toBe(false);
+    expect(status.jupiter).toBe(false);
+  });
+
+  it('is ready for dry-run with only wallet and llm keys', () => {
+    const status = assessSetup({
+      WALLET_PRIVATE_KEY: 'base58wallet',
+      LLM_API_KEY: 'sk-or-v1-test',
+    });
+    expect(status.readyForDryRun).toBe(true);
+    expect(status.readyForLive).toBe(false);
+    expect(status.jupiter).toBe(false);
+  });
+
+  it('is ready for live when jupiter key is also set', () => {
+    const status = assessSetup({
+      WALLET_PRIVATE_KEY: 'base58wallet',
+      LLM_API_KEY: 'sk-or-v1-test',
+      JUPITER_API_KEY: 'jup-key',
+    });
+    expect(status.readyForLive).toBe(true);
+  });
+});
+
+describe('formatInitMessage', () => {
+  it('prints a first-time setup banner and the next command', () => {
+    const text = formatInitMessage({
+      directory: '/tmp/etemaro',
+      firstRun: true,
+      status: assessSetup({}),
+    });
+    expect(text).toContain('first-time setup');
+    expect(text).toContain('/tmp/etemaro');
+    expect(text).toContain('Wallet');
+    expect(text).toContain('LLM');
+    expect(text).toContain('etemaro start --dry-run');
+  });
+
+  it('says setup is complete when dry-run creds are present', () => {
+    const text = formatInitMessage({
+      directory: '/tmp/etemaro',
+      firstRun: false,
+      status: assessSetup({
+        WALLET_PRIVATE_KEY: 'k',
+        LLM_API_KEY: 'k',
+      }),
+    });
+    expect(text).toContain('Setup complete');
+    expect(text).toContain('etemaro start --dry-run');
+    expect(text).not.toContain('first-time setup');
+  });
+});
+
+describe('writeRuntimeSkeleton', () => {
+  it('creates .env, config, and data on a fresh directory', () => {
+    const dir = tmpDir();
+    const result = writeRuntimeSkeleton(dir, {
+      defaultUserConfigStr: '{"_version":3}',
+      defaultStrategies: [{ id: 'spot' }],
+    });
+    expect(result.env.created).toBe(true);
+    expect(result.config.created).toBe(true);
+    expect(fs.existsSync(path.join(dir, '.env'))).toBe(true);
+    expect(fs.readFileSync(path.join(dir, '.env'), 'utf8')).toContain('WALLET_PRIVATE_KEY');
+    expect(fs.existsSync(path.join(dir, 'config', 'user-config.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'data', 'strategy-library.shared.json'))).toBe(true);
+  });
+
+  it('does not overwrite an existing .env', () => {
+    const dir = tmpDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.env'), 'WALLET_PRIVATE_KEY="keep-me"\n');
+    const result = writeRuntimeSkeleton(dir, {
+      defaultUserConfigStr: '{}',
+      defaultStrategies: [],
+    });
+    expect(result.env.created).toBe(false);
+    expect(fs.readFileSync(path.join(dir, '.env'), 'utf8')).toContain('keep-me');
+  });
+});
+
+describe('upsertEnvVars', () => {
+  it('fills empty quoted values in place', () => {
+    const next = upsertEnvVars('WALLET_PRIVATE_KEY=""\nLLM_API_KEY=""\n', {
+      WALLET_PRIVATE_KEY: 'abc',
+    });
+    expect(next).toContain('WALLET_PRIVATE_KEY="abc"');
+    expect(next).toContain('LLM_API_KEY=""');
+  });
+});
+
+describe('loadRuntimeDotenv', () => {
+  it('loads home .env first, then cwd .env', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, '.env'), 'WALLET_PRIVATE_KEY="from-home"\n');
+    const calls: Array<Record<string, unknown>> = [];
+    loadRuntimeDotenv(dir, (opts) => {
+      calls.push(opts ?? {});
+      return { parsed: {} } as any;
+    });
+    expect(calls[0]).toEqual({ path: path.join(dir, '.env') });
+    expect(calls[1]).toEqual({ override: true });
+  });
+});
+
+describe('maybePromptSecrets', () => {
+  it('prompts only for missing wallet and llm keys', async () => {
+    const asked: string[] = [];
+    const updates = await maybePromptSecrets({
+      interactive: true,
+      status: assessSetup({}),
+      ask: async (q) => {
+        asked.push(q);
+        if (q.toLowerCase().includes('wallet')) return 'wallet-key';
+        if (q.toLowerCase().includes('llm')) return 'llm-key';
+        return '';
+      },
+    });
+    expect(asked).toHaveLength(2);
+    expect(updates).toEqual({ WALLET_PRIVATE_KEY: 'wallet-key', LLM_API_KEY: 'llm-key' });
+  });
+
+  it('skips prompts when not interactive', async () => {
+    const updates = await maybePromptSecrets({
+      interactive: false,
+      status: assessSetup({}),
+      ask: async () => {
+        throw new Error('should not prompt');
+      },
+    });
+    expect(updates).toEqual({});
+  });
+});

--- a/packages/cli/src/firstSetup.test.ts
+++ b/packages/cli/src/firstSetup.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { assessSetup, formatInitMessage, loadRuntimeDotenv, maybePromptSecrets, upsertEnvVars, writeRuntimeSkeleton } from './firstSetup.js';
+import {
+  assessSetup,
+  formatInitMessage,
+  loadRuntimeDotenv,
+  maybePromptSecrets,
+  parseEnvFile,
+  upsertEnvVars,
+  writeRuntimeSkeleton,
+} from './firstSetup.js';
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'etemaro-init-'));
@@ -112,6 +120,13 @@ describe('upsertEnvVars', () => {
     });
     expect(next).toContain('WALLET_PRIVATE_KEY="abc"');
     expect(next).toContain('LLM_API_KEY=""');
+  });
+
+  it('escapes backslashes before quotes so values round-trip', () => {
+    const raw = 'a\\b"c';
+    const next = upsertEnvVars('WALLET_PRIVATE_KEY=""\n', { WALLET_PRIVATE_KEY: raw });
+    expect(next).toContain('WALLET_PRIVATE_KEY="a\\\\b\\"c"');
+    expect(parseEnvFile(next).WALLET_PRIVATE_KEY).toBe(raw);
   });
 });
 

--- a/packages/cli/src/firstSetup.ts
+++ b/packages/cli/src/firstSetup.ts
@@ -1,0 +1,176 @@
+/**
+ * First-run operator setup: create runtime dirs, check the two keys needed
+ * for dry-run, print a short next command. Jupiter is live-only.
+ */
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+export interface SetupStatus {
+  wallet: boolean;
+  llm: boolean;
+  jupiter: boolean;
+  readyForDryRun: boolean;
+  readyForLive: boolean;
+}
+
+export interface SkeletonResult {
+  directory: string;
+  env: { path: string; created: boolean };
+  config: { path: string; created: boolean };
+  strategyLibrary: { path: string; created: boolean };
+}
+
+const ENV_TEMPLATE = `# etemaro — first-run environment
+WALLET_PRIVATE_KEY=""
+LLM_API_KEY=""
+LLM_BASE_URL="https://openrouter.ai/api/v1"
+LLM_MODEL="anthropic/claude-3.5-sonnet"
+JUPITER_API_KEY=""
+HELIUS_API_KEY=""
+RPC_URL="https://pump.helius-rpc.com"
+TELEGRAM_BOT_TOKEN=""
+TELEGRAM_CHAT_ID=""
+TELEGRAM_ALLOWED_USER_IDS=""
+`;
+
+function present(value: string | undefined): boolean {
+  if (!value) return false;
+  const v = value.trim().replace(/^["']|["']$/g, '');
+  if (!v) return false;
+  if (v.startsWith('env.')) return false;
+  return true;
+}
+
+export function assessSetup(env: NodeJS.Dict<string>): SetupStatus {
+  const wallet = present(env.WALLET_PRIVATE_KEY);
+  const llm = present(env.LLM_API_KEY);
+  const jupiter = present(env.JUPITER_API_KEY);
+  return {
+    wallet,
+    llm,
+    jupiter,
+    readyForDryRun: wallet && llm,
+    readyForLive: wallet && llm && jupiter,
+  };
+}
+
+export function formatInitMessage(opts: { directory: string; firstRun: boolean; status: SetupStatus }): string {
+  const { directory, firstRun, status } = opts;
+  const heading = firstRun ? 'Etemaro first-time setup  (~1 minute)' : 'Etemaro setup check';
+  const mark = (ok: boolean) => (ok ? 'x' : ' ');
+  const lines = [
+    heading,
+    '',
+    firstRun ? 'Dry-run is on by default. No live trades yet.' : 'Checking wallet and LLM credentials.',
+    `Runtime: ${directory}`,
+    '',
+    `  [${mark(status.wallet)}] Wallet   WALLET_PRIVATE_KEY`,
+    `  [${mark(status.llm)}] LLM      LLM_API_KEY`,
+    `  [${mark(status.jupiter)}] Jupiter  JUPITER_API_KEY  (live swaps only)`,
+    '',
+  ];
+  if (status.readyForDryRun) {
+    lines.push(firstRun ? 'Setup complete.' : 'Setup complete');
+    lines.push('');
+    lines.push('Next:');
+    lines.push('  etemaro start --dry-run');
+  } else {
+    lines.push(`Add the missing keys in ${path.join(directory, '.env')}`);
+    lines.push('then run:');
+    lines.push('  etemaro start --dry-run');
+  }
+  return lines.join('\n');
+}
+
+export function writeRuntimeSkeleton(directory: string, opts: { defaultUserConfigStr: string; defaultStrategies: unknown }): SkeletonResult {
+  const configDir = path.join(directory, 'config');
+  const dataDir = path.join(directory, 'data');
+  fs.mkdirSync(directory, { recursive: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+
+  const envFile = path.join(directory, '.env');
+  let envCreated = false;
+  if (!fs.existsSync(envFile)) {
+    fs.writeFileSync(envFile, ENV_TEMPLATE);
+    envCreated = true;
+  }
+
+  const userConfigFile = path.join(configDir, 'user-config.json');
+  let configCreated = false;
+  if (!fs.existsSync(userConfigFile)) {
+    fs.writeFileSync(userConfigFile, opts.defaultUserConfigStr.endsWith('\n') ? opts.defaultUserConfigStr : opts.defaultUserConfigStr + '\n');
+    configCreated = true;
+  }
+
+  const sharedStrategyFile = path.join(dataDir, 'strategy-library.shared.json');
+  let strategyCreated = false;
+  if (!fs.existsSync(sharedStrategyFile)) {
+    fs.writeFileSync(sharedStrategyFile, JSON.stringify({ strategies: opts.defaultStrategies }, null, 2) + '\n');
+    strategyCreated = true;
+  }
+
+  return {
+    directory,
+    env: { path: envFile, created: envCreated },
+    config: { path: userConfigFile, created: configCreated },
+    strategyLibrary: { path: sharedStrategyFile, created: strategyCreated },
+  };
+}
+
+export function upsertEnvVars(fileContents: string, updates: Record<string, string>): string {
+  let next = fileContents;
+  for (const [key, value] of Object.entries(updates)) {
+    const line = `${key}="${value.replace(/"/g, '\\"')}"`;
+    const re = new RegExp(`^${key}=.*$`, 'm');
+    if (re.test(next)) next = next.replace(re, line);
+    else next += (next.endsWith('\n') ? '' : '\n') + line + '\n';
+  }
+  return next;
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export async function maybePromptSecrets(opts: {
+  interactive: boolean;
+  status: SetupStatus;
+  ask: (question: string) => Promise<string>;
+}): Promise<Record<string, string>> {
+  if (!opts.interactive) return {};
+  const updates: Record<string, string> = {};
+  if (!opts.status.wallet) {
+    const wallet = (await opts.ask('Wallet private key (base58). Paste, or Enter to skip: ')).trim();
+    if (wallet) updates.WALLET_PRIVATE_KEY = wallet;
+  }
+  if (!opts.status.llm) {
+    const llm = (await opts.ask('LLM API key (OpenRouter / OpenAI). Paste, or Enter to skip: ')).trim();
+    if (llm) updates.LLM_API_KEY = llm;
+  }
+  return updates;
+}
+
+type DotenvLoad = (opts?: { path?: string; override?: boolean }) => unknown;
+
+export function loadRuntimeDotenv(homeDir: string, dotenvLoad: DotenvLoad = dotenv.config): void {
+  const envPath = path.join(homeDir, '.env');
+  if (fs.existsSync(envPath)) {
+    dotenvLoad({ path: envPath });
+  }
+  dotenvLoad({ override: true });
+}

--- a/packages/cli/src/firstSetup.ts
+++ b/packages/cli/src/firstSetup.ts
@@ -119,10 +119,18 @@ export function writeRuntimeSkeleton(directory: string, opts: { defaultUserConfi
   };
 }
 
+function escapeEnvValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function unescapeEnvValue(value: string): string {
+  return value.replace(/\\([\\"])/g, '$1');
+}
+
 export function upsertEnvVars(fileContents: string, updates: Record<string, string>): string {
   let next = fileContents;
   for (const [key, value] of Object.entries(updates)) {
-    const line = `${key}="${value.replace(/"/g, '\\"')}"`;
+    const line = `${key}="${escapeEnvValue(value)}"`;
     const re = new RegExp(`^${key}=.*$`, 'm');
     if (re.test(next)) next = next.replace(re, line);
     else next += (next.endsWith('\n') ? '' : '\n') + line + '\n';
@@ -140,7 +148,7 @@ export function parseEnvFile(content: string): Record<string, string> {
     const key = line.slice(0, eq).trim();
     let value = line.slice(eq + 1).trim();
     if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
+      value = unescapeEnvValue(value.slice(1, -1));
     }
     out[key] = value;
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,10 +52,14 @@ echo "Found latest release: $LATEST_RELEASE"
 echo "Installing Etemaro CLI via npm..."
 if command -v npm >/dev/null 2>&1; then
     npm install -g @etemaro/cli
-    echo "Etemaro CLI installed successfully!"
-    echo "Run 'etemaro help' to get started."
+    echo "Etemaro CLI installed."
+    echo ""
+    echo "Next (first-time setup, ~1 minute):"
+    echo "  etemaro init"
+    echo "Then:"
+    echo "  etemaro start --dry-run"
 else
     echo "Error: npm is required to install Etemaro CLI globally."
-    echo "Please install Node.js and npm first: https://nodejs.org/"
+    echo "Install Node.js 22+ first: https://nodejs.org/"
     exit 1
 fi


### PR DESCRIPTION
## Summary

Operator onboarding is two commands after Node 22:

```bash
curl -fsSL https://etemaro.com/install.sh | sh
etemaro init
```

`etemaro init` is first-time setup (~1 minute). It creates `~/.config/etemaro`, checks wallet + LLM keys only, and prints `etemaro start --dry-run`. Jupiter, Telegram, clone, and pnpm are not part of first run.

Also makes that next command true: load home `.env`, honor `--dry-run`, and boot `Daemon.start()` from the CLI.

## Test plan

- [x] `pnpm exec vitest run` — 163 tests
- [x] `pnpm --filter @etemaro/cli typecheck`
- [ ] Manual: `etemaro init` on a TTY prompts for missing wallet/LLM, writes `~/.config/etemaro/.env`
- [ ] Manual: `etemaro init --yes` on a non-TTY prints the checklist and exits 1 until keys are set
- [ ] Manual: `etemaro start --dry-run` after green checklist