### PR TITLE
fix(daemon): atomic check-and-set guards for daemon cron intervals (#185)

### DIFF
--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -165,4 +165,82 @@ describe('Daemon — Concurrency & Mutex Guards', () => {
     expect(adapters.meteora.getMyPositions).toHaveBeenCalledTimes(1);
     expect(runScreeningSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('atomically prevents concurrent runManagementCycle executions', async () => {
+    let resolveFirst: any;
+    adapters.meteora.getMyPositions = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    // Start cycle 1
+    const p1 = daemon.runManagementCycle({ silent: true });
+    // Attempt concurrent cycle 2 immediately
+    const p2 = daemon.runManagementCycle({ silent: true });
+
+    // p2 should immediately return null because lock is held synchronously
+    const res2 = await p2;
+    expect(res2).toBeNull();
+
+    // Resolve cycle 1
+    resolveFirst({ total_positions: 0, positions: [] });
+    const res1 = await p1;
+    expect(res1).toContain('No open positions');
+
+    // Lock is now released, a subsequent call succeeds
+    adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    const res3 = await daemon.runManagementCycle({ silent: true });
+    expect(res3).toContain('No open positions');
+  });
+
+  it('atomically prevents concurrent runScreeningCycle executions', async () => {
+    let resolvePositions: any;
+    adapters.meteora.getMyPositions = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePositions = resolve;
+        }),
+    );
+
+    // Start screening 1
+    const p1 = daemon.runScreeningCycle({ silent: true });
+    // Attempt concurrent screening 2 immediately
+    const p2 = daemon.runScreeningCycle({ silent: true });
+
+    // p2 should immediately return null because screeningBusy lock is held synchronously
+    const res2 = await p2;
+    expect(res2).toBeNull();
+
+    // Resolve screening 1 pre-checks
+    resolvePositions({ total_positions: 5, positions: [] }); // exceeds max positions, skips
+    const res1 = await p1;
+    expect(res1).toContain('max positions reached');
+
+    // Lock is released after completion
+    expect((daemon as any).screeningBusy).toBe(false);
+  });
+
+  it('releases lock cleanly even when runManagementCycle throws', async () => {
+    adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({
+      total_positions: 1,
+      positions: [{ position: 'pos_1', pool: 'pool_1', pair: 'SOL-USDC' }],
+    });
+    adapters.domain.recordPositionSnapshot = vi.fn().mockImplementation(() => {
+      throw new Error('State explosion');
+    });
+
+    const res = await daemon.runManagementCycle({ silent: true });
+    expect(res).toContain('Management cycle failed: State explosion');
+    expect((daemon as any).managementBusy).toBe(false);
+  });
+
+  it('releases lock cleanly even when runScreeningCycle throws', async () => {
+    adapters.meteora.getMyPositions = vi.fn().mockRejectedValue(new Error('Screening RPC explosion'));
+
+    const res = await daemon.runScreeningCycle({ silent: true });
+    expect(res).toContain('Screening cycle failed: Screening RPC explosion');
+    expect((daemon as any).screeningBusy).toBe(false);
+  });
 });

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -284,6 +284,51 @@ export class Daemon {
   private latestCandidates: any[] = [];
   private latestCandidatesAt: string | null = null;
 
+  /**
+   * Synchronous atomic check-and-set lock acquisition for daemon async cycles.
+   * Prevents overlapping timer ticks or event-loop delays from entering guarded sections concurrently.
+   */
+  private acquireLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): boolean {
+    switch (lockName) {
+      case 'management':
+        if (this.managementBusy || this.pnlPollBusy) return false;
+        this.managementBusy = true;
+        return true;
+      case 'screening':
+        if (this.screeningBusy) return false;
+        this.screeningBusy = true;
+        return true;
+      case 'pnlPoll':
+        if (this.managementBusy || this.screeningBusy || this.pnlPollBusy) return false;
+        this.pnlPollBusy = true;
+        return true;
+      case 'opportunityPoll':
+        if (this.screeningBusy || this.managementBusy || this.pnlPollBusy || this.opportunityPollBusy) return false;
+        this.opportunityPollBusy = true;
+        return true;
+    }
+  }
+
+  /**
+   * Synchronous lock release helper.
+   */
+  private releaseLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): void {
+    switch (lockName) {
+      case 'management':
+        this.managementBusy = false;
+        break;
+      case 'screening':
+        this.screeningBusy = false;
+        break;
+      case 'pnlPoll':
+        this.pnlPollBusy = false;
+        break;
+      case 'opportunityPoll':
+        this.opportunityPollBusy = false;
+        break;
+    }
+  }
+
   // Countdown timer
   private countdownInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -480,17 +525,12 @@ export class Daemon {
     this.stopCronJobs(); // stop any running tasks before (re)starting
     this.adapters.domain.validateActiveStrategy();
 
-    const mgmtTask = cron.schedule(`*/${Math.max(1, config.schedule.managementIntervalMin)} * * * *`, async () => {
-      if (this.managementBusy || this.pnlPollBusy) return;
-      this.managementLastRun = Date.now();
-      await this.runManagementCycle();
-    });
+    const mgmtTask = cron.schedule(`*/${Math.max(1, config.schedule.managementIntervalMin)} * * * *`, () => this.runManagementCycle());
 
     const screenTask = cron.schedule(`*/${Math.max(1, config.schedule.screeningIntervalMin)} * * * *`, () => this.runScreeningCycle());
 
     const healthTask = cron.schedule(`0 * * * *`, async () => {
-      if (this.managementBusy || this.pnlPollBusy) return;
-      this.managementBusy = true;
+      if (!this.acquireLock('management')) return;
       log('cron', 'Starting health check');
       try {
         await agentLoop(
@@ -509,7 +549,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
       } catch (error: any) {
         log('cron_error', `Health check failed: ${error.message}`);
       } finally {
-        this.managementBusy = false;
+        this.releaseLock('management');
       }
     });
 
@@ -536,9 +576,8 @@ Summarize the current portfolio health, total fees earned, and performance of al
     const confirmTicks = Math.max(1, Number(config.pnl.confirmTicks ?? 2));
 
     this.pnlPollInterval = setInterval(async () => {
-      if (this.managementBusy || this.screeningBusy || this.pnlPollBusy) return;
       if (getTrackedPositions(true).length === 0) return;
-      this.pnlPollBusy = true;
+      if (!this.acquireLock('pnlPoll')) return;
       try {
         const result = await this.adapters.meteora.getMyPositions({ force: true, silent: true }).catch(() => null);
         if (!result?.positions?.length) return;
@@ -566,6 +605,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
 
           log('state', `[PnL poll] ${signal} confirmed (${confirmTicks} ticks): ${p.pair} — ${reason} — closing directly`);
           // Hold the management lock so the cron cycle can't double-act on this position.
+          const wasManagementBusy = this.managementBusy;
           this.managementBusy = true;
           try {
             const actMap = new Map([[p.position, { action: 'CLOSE', rule, reason }]]);
@@ -574,14 +614,14 @@ Summarize the current portfolio health, total fees earned, and performance of al
           } catch (e: any) {
             log('cron_error', `Poll-triggered close failed: ${e.message}`);
           } finally {
-            this.managementBusy = false;
+            this.managementBusy = wasManagementBusy;
           }
           break; // one action per tick
         }
       } catch (e: any) {
         log('cron_error', `PnL poll failed: ${e.message}`);
       } finally {
-        this.pnlPollBusy = false;
+        this.releaseLock('pnlPoll');
       }
     }, pnlPollMs);
 
@@ -591,10 +631,9 @@ Summarize the current portfolio health, total fees earned, and performance of al
       const oppCooldownMs = 5 * 60 * 1000;
 
       this.opportunityPollInterval = setInterval(async () => {
-        if (this.screeningBusy || this.managementBusy || this.pnlPollBusy || this.opportunityPollBusy) return;
-        if (Date.now() - this.screeningLastTriggered < oppCooldownMs) return;
-        this.opportunityPollBusy = true;
+        if (!this.acquireLock('opportunityPoll')) return;
         try {
+          if (Date.now() - this.screeningLastTriggered < oppCooldownMs) return;
           const [positions, balance] = await Promise.all([
             this.adapters.meteora.getMyPositions({ force: true, silent: true }).catch(() => null),
             this.adapters.wallet.getWalletBalances().catch(() => null),
@@ -644,7 +683,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
         } catch (e: any) {
           log('cron_error', `Opportunity poll failed: ${e.message}`);
         } finally {
-          this.opportunityPollBusy = false;
+          this.releaseLock('opportunityPoll');
         }
       }, oppMs);
     }
@@ -800,8 +839,7 @@ After evaluating, write a brief one-line result per position.
   }
 
   async runManagementCycle({ silent = false } = {}): Promise<string | null> {
-    if (this.managementBusy || this.pnlPollBusy) return null;
-    this.managementBusy = true;
+    if (!this.acquireLock('management')) return null;
     this.managementLastRun = Date.now();
     log('cron', 'Starting management cycle');
     let mgmtReport: string | null = null;
@@ -927,7 +965,7 @@ After evaluating, write a brief one-line result per position.
       log('cron_error', `Management cycle failed: ${error.message}`);
       mgmtReport = `Management cycle failed: ${error.message}`;
     } finally {
-      this.managementBusy = false;
+      this.releaseLock('management');
       if (!silent && this.adapters.telegram.isEnabled()) {
         if (mgmtReport) {
           if (liveMessage) await liveMessage.finalize(stripThink(mgmtReport)).catch(() => {});
@@ -979,11 +1017,10 @@ After evaluating, write a brief one-line result per position.
   }
 
   async runScreeningCycle({ silent = false } = {}): Promise<string | null> {
-    if (this.screeningBusy) {
+    if (!this.acquireLock('screening')) {
       log('cron', 'Screening skipped — previous cycle still running');
       return null;
     }
-    this.screeningBusy = true;
     this.screeningLastTriggered = Date.now();
 
     let prePositions: any, preBalance: any;
@@ -1003,7 +1040,6 @@ After evaluating, write a brief one-line result per position.
           summary: 'Screening skipped',
           reason: `Max positions reached (${prePositions.total_positions}/${config.risk.maxPositions})`,
         });
-        this.screeningBusy = false;
         return screenReport;
       }
       const minRequired = config.management.deployAmountSol + config.management.gasReserve;
@@ -1017,33 +1053,25 @@ After evaluating, write a brief one-line result per position.
           summary: 'Screening skipped',
           reason: `Insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)})`,
         });
-        this.screeningBusy = false;
         return screenReport;
       }
-    } catch (e: any) {
-      log('cron_error', `Screening pre-check failed: ${e.message}`);
-      screenReport = `Screening pre-check failed: ${e.message}`;
-      this.screeningBusy = false;
-      return screenReport;
-    }
-    if (!silent && this.adapters.telegram.isEnabled()) {
-      liveMessage = await this.adapters.telegram.createLiveMessage('🔍 Screening Cycle', 'Scanning candidates...');
-    }
-    this.screeningLastRun = Date.now();
 
-    if (config.screening.entrySource === 'smart_wallets') {
-      try {
-        screenReport = await this.runSmartWalletScreening({ liveMessage, deployAmount: computeDeployAmount(preBalance.sol) });
-      } catch (e: any) {
-        log('cron_error', `Smart wallet screening failed: ${e.message}`);
-        screenReport = `Smart wallet screening failed: ${e.message}`;
+      if (!silent && this.adapters.telegram.isEnabled()) {
+        liveMessage = await this.adapters.telegram.createLiveMessage('🔍 Screening Cycle', 'Scanning candidates...');
       }
-      this.screeningBusy = false;
-      return screenReport;
-    }
+      this.screeningLastRun = Date.now();
 
-    log('cron', `Starting screening cycle [model: ${config.llm.screeningModel}]`);
-    try {
+      if (config.screening.entrySource === 'smart_wallets') {
+        try {
+          screenReport = await this.runSmartWalletScreening({ liveMessage, deployAmount: computeDeployAmount(preBalance.sol) });
+        } catch (e: any) {
+          log('cron_error', `Smart wallet screening failed: ${e.message}`);
+          screenReport = `Smart wallet screening failed: ${e.message}`;
+        }
+        return screenReport;
+      }
+
+      log('cron', `Starting screening cycle [model: ${config.llm.screeningModel}]`);
       const currentBalance = preBalance;
       const deployAmount = computeDeployAmount(currentBalance.sol);
       log('cron', `Computed deploy amount: ${deployAmount} SOL (wallet: ${currentBalance.sol} SOL)`);
@@ -1331,7 +1359,7 @@ IMPORTANT:
       log('cron_error', `Screening cycle failed: ${error.message}`);
       screenReport = `Screening cycle failed: ${error.message}`;
     } finally {
-      this.screeningBusy = false;
+      this.releaseLock('screening');
       if (!silent && this.adapters.telegram.isEnabled()) {
         if (screenReport) {
           if (liveMessage) await liveMessage.finalize(stripThink(screenReport)).catch(() => {});


### PR DESCRIPTION
## Summary
Fixes #185 (FINDING-006 under Epic #179).

Implements synchronous atomic check-and-set lock acquisition (`acquireLock`) and release (`releaseLock`) across all daemon coroutines and cron jobs (`management`, `screening`, `pnlPoll`, `opportunityPoll`, `healthTask`).

### Key Changes
1. **Atomic check-and-set guards**:
   - Added `acquireLock(name)` and `releaseLock(name)` in `Daemon.ts`.
   - Prevents overlapping timer ticks or event-loop delays from entering guarded sections concurrently.
2. **Exception safety & single finally release**:
   - `runManagementCycle()`, `runScreeningCycle()`, `healthTask`, `pnlPollInterval`, and `opportunityPollInterval` now acquire their lock as the first synchronous statement and release in `finally` blocks.
   - Eliminated dispersed manual `this.screeningBusy = false` resets across early returns in `runScreeningCycle`.
3. **Tests**:
   - Added concurrency serialization tests in `packages/daemon/src/Daemon.test.ts` verifying that overlapping calls to `runManagementCycle()` and `runScreeningCycle()` return immediately without entering the critical section.
   - Added tests verifying lock release on errors and successful completions.

### Verification
- 174/174 unit tests passing (`pnpm test`)
- Monorepo build and typecheck clean (`pnpm build && pnpm typecheck`)