### PR TITLE
fix: serialize deploy safety checks across triggers

### DIFF
--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { executeTool, swapAllTokensToSol } from './ToolExecutor.js';
 import * as WalletAdapter from './blockchain/WalletAdapter.js';
 import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js';
@@ -96,6 +96,11 @@ describe('ToolExecutor - deploy_position serialization', () => {
     vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({ sol: 10, tokens: [] } as any);
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
   it('does not run a second balance check until the first deploy has completed', async () => {
     let releaseFirstDeploy!: () => void;
     const firstDeployFinished = new Promise<void>((resolve) => {
@@ -121,7 +126,7 @@ describe('ToolExecutor - deploy_position serialization', () => {
     await vi.waitFor(() => expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1));
     const second = executeTool('deploy_position', { ...args, pool_address: 'pool-two' });
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await Promise.resolve();
     expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(1);
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1);
     expect(maxInFlightDeploys).toBe(1);
@@ -131,5 +136,26 @@ describe('ToolExecutor - deploy_position serialization', () => {
     expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(2);
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(2);
     expect(maxInFlightDeploys).toBe(1);
+  });
+
+  it('releases the lock when a safety check rejects', async () => {
+    vi.mocked(MeteoraAdapter.getMyPositions)
+      .mockRejectedValueOnce(new Error('safety check failed'))
+      .mockResolvedValue({ positions: [], total_positions: 0 } as any);
+    vi.mocked(MeteoraAdapter.deployPosition).mockResolvedValue({ success: true, position: 'position-two' } as any);
+
+    const args = {
+      pool_address: 'pool-one',
+      amount_y: 0.5,
+      bins_below: 35,
+      bins_above: 0,
+    };
+    const first = executeTool('deploy_position', args);
+    await expect(first).rejects.toThrow('safety check failed');
+
+    await expect(executeTool('deploy_position', { ...args, pool_address: 'pool-two' })).resolves.toMatchObject({
+      success: true,
+    });
+    expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { swapAllTokensToSol } from './ToolExecutor.js';
+import { executeTool, swapAllTokensToSol } from './ToolExecutor.js';
 import * as WalletAdapter from './blockchain/WalletAdapter.js';
+import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js';
 
 // Mock the WalletAdapter functions
 vi.mock('./blockchain/WalletAdapter.js', () => ({
@@ -8,10 +9,28 @@ vi.mock('./blockchain/WalletAdapter.js', () => ({
   swapToken: vi.fn(),
 }));
 
+vi.mock('./blockchain/MeteoraAdapter.js', () => ({
+  getActiveBin: vi.fn(),
+  deployPosition: vi.fn(),
+  getMyPositions: vi.fn(),
+  getWalletPositions: vi.fn(),
+  getPositionPnl: vi.fn(),
+  claimFees: vi.fn(),
+  closePosition: vi.fn(),
+  searchPools: vi.fn(),
+}));
+
+vi.mock('./blockchain/ScreeningAdapter.js', () => ({
+  discoverPools: vi.fn(),
+  getPoolDetail: vi.fn(),
+  getTopCandidates: vi.fn(),
+}));
+
 // Mock logger to avoid noisy output during tests
 vi.mock('../shared/logger.js', () => ({
   log: vi.fn(),
   logAction: vi.fn(),
+  logStructured: vi.fn(),
 }));
 
 describe('ToolExecutor - swapAllTokensToSol', () => {
@@ -57,5 +76,60 @@ describe('ToolExecutor - swapAllTokensToSol', () => {
 
     const result = await swapAllTokensToSol({ skipMints: [] } as any);
     expect(result.total).toBe(0);
+  });
+});
+
+describe('ToolExecutor - deploy_position serialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('DRY_RUN', 'false');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ address: 'pool-one', tvl: 100_000, fee_active_tvl_ratio: { '5m': 1 }, volatility: 1, dlmm_params: { bin_step: 100 } }],
+        }),
+      }),
+    );
+    vi.mocked(MeteoraAdapter.getMyPositions).mockResolvedValue({ positions: [], total_positions: 0 } as any);
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({ sol: 10, tokens: [] } as any);
+  });
+
+  it('does not run a second balance check until the first deploy has completed', async () => {
+    let releaseFirstDeploy!: () => void;
+    const firstDeployFinished = new Promise<void>((resolve) => {
+      releaseFirstDeploy = resolve;
+    });
+    let inFlightDeploys = 0;
+    let maxInFlightDeploys = 0;
+    vi.mocked(MeteoraAdapter.deployPosition).mockImplementation(async () => {
+      inFlightDeploys++;
+      maxInFlightDeploys = Math.max(maxInFlightDeploys, inFlightDeploys);
+      if (inFlightDeploys === 1) await firstDeployFinished;
+      inFlightDeploys--;
+      return { success: true, position: `position-${Date.now()}` } as any;
+    });
+
+    const args = {
+      pool_address: 'pool-one',
+      amount_y: 0.5,
+      bins_below: 35,
+      bins_above: 0,
+    };
+    const first = executeTool('deploy_position', { ...args });
+    await vi.waitFor(() => expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1));
+    const second = executeTool('deploy_position', { ...args, pool_address: 'pool-two' });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(1);
+    expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1);
+    expect(maxInFlightDeploys).toBe(1);
+
+    releaseFirstDeploy();
+    await Promise.all([first, second]);
+    expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(2);
+    expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(2);
+    expect(maxInFlightDeploys).toBe(1);
   });
 });

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -63,6 +63,7 @@ import { blockDev, unblockDev, listBlockedDevs } from '../domain/dev-blocklist.j
 import { addSmartWallet, removeSmartWallet, listSmartWallets, checkSmartWalletsOnPool } from '../domain/smart-wallets.js';
 import { getRecentDecisions } from '../domain/decision-log.js';
 import { normalizeTimeframe, scaleScreeningToTimeframe } from '../shared/utils.js';
+import { Mutex } from '../shared/mutex.js';
 import { notifyDeploy, notifyClose, notifySwap, notifySwapError } from './notifications/TelegramAdapter.js';
 
 // ─── Constants ─────────────────────────────────────────────────
@@ -767,20 +768,10 @@ const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update']);
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-let deployPositionQueue: Promise<void> = Promise.resolve();
+const deployPositionMutex = new Mutex();
 
 async function withDeployPositionLock<T>(operation: () => Promise<T>): Promise<T> {
-  let release!: () => void;
-  const previous = deployPositionQueue;
-  deployPositionQueue = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  await previous;
-  try {
-    return await operation();
-  } finally {
-    release();
-  }
+  return deployPositionMutex.runExclusive(operation);
 }
 
 /**

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -767,6 +767,22 @@ const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update']);
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+let deployPositionQueue: Promise<void> = Promise.resolve();
+
+async function withDeployPositionLock<T>(operation: () => Promise<T>): Promise<T> {
+  let release!: () => void;
+  const previous = deployPositionQueue;
+  deployPositionQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
 /**
  * Swap a base token back to SOL with retry. Jupiter can transiently fail (no route,
  * quote error) and a single attempt silently leaves the token unsold — this retries
@@ -977,6 +993,14 @@ export async function closeAllPositions(skipSwapInput: boolean | { skipSwap?: bo
  * Execute a tool call with safety checks and logging.
  */
 export async function executeTool(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const normalizedName = name.replace(/<.*$/, '').trim();
+  if (normalizedName === 'deploy_position') {
+    return withDeployPositionLock(() => executeToolUnlocked(normalizedName, args));
+  }
+  return executeToolUnlocked(normalizedName, args);
+}
+
+async function executeToolUnlocked(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
   const startTime = Date.now();
 
   // Strip model artifacts like "<|channel|>commentary" appended to tool names


### PR DESCRIPTION
## Summary\n\nCloses #187.\n\nThis PR serializes deploy_position safety checks and execution across screening and opportunity-triggered calls. It also addresses review feedback from PR #196 by using the shared mutex, cleaning test stubs, and removing timing-sensitive assertions.\n\n## Changes\n\n- Reuse Mutex from @etemaro/core so deploy lock release is guaranteed after success or rejection.\n- Add regression coverage for concurrent deploy serialization and lock recovery after a rejected safety check.\n- Restore stubbed environment variables and globals after each test.\n- Replace the fixed 20ms delay with a deterministic promise checkpoint.\n\n## Compatibility\n\nNo public API or persisted data format changes. Deploy calls retain their existing behavior while concurrent calls now execute their safety checks and transactions sequentially.\n\n## Validation\n\n- pnpm exec vitest run packages/core/src/adapters/ToolExecutor.test.ts — 4/4 passed\n- pnpm typecheck — passed\n- pnpm build — passed\n- pnpm exec eslint --no-warn-ignored packages/core/src/adapters/ToolExecutor.ts packages/core/src/adapters/ToolExecutor.test.ts — 0 errors; existing warnings\n- pnpm exec prettier --check packages/core/src/adapters/ToolExecutor.ts packages/core/src/adapters/ToolExecutor.test.ts — passed\n- pnpm exec vitest run --passWithNoTests — 175/176 passed\n\nThe full suite has one pre-existing failure in packages/daemon/src/Daemon.smart-wallet-screening.test.ts:723, where the expected snapshot fixture value is undefined. No live Solana transaction was submitted; adapter calls are mocked in the regression tests.\n\nPR #196 contains an accidental merge-history expansion and is superseded by this clean linear PR.