### PR TITLE
feat(domain): persist structured per-candidate LLM screening reasoning to decision log (#189)

### DIFF
--- a/packages/core/src/application/prompt-builder.ts
+++ b/packages/core/src/application/prompt-builder.ts
@@ -146,6 +146,9 @@ DEPLOY RULES:
 - Bin steps must be [80-125].
 - Pick ONE pool only when conviction is real. If only one weak candidate survives, skip and explain why none qualify.
 
+CANDIDATE EVALUATION & VERDICTS:
+- In your final report (both DEPLOYED and NO DEPLOY), always include the REJECTED section with a concise verdict for each evaluated candidate that was not deployed (e.g. "- TOKEN/SOL: <why rejected/not selected>").
+
 ${weightsSummary ? `${weightsSummary}\nPrioritize candidates whose strongest attributes align with high-weight signals.\n\n` : ''}${lessons ? `LESSONS LEARNED:\n${lessons}\n` : ''}Timestamp: ${new Date().toISOString()}
 `;
   } else {

--- a/packages/core/src/domain/decision-log.test.ts
+++ b/packages/core/src/domain/decision-log.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, } from 'vitest';
+import {
+  appendDecision,
+  getRecentDecisions,
+  getDecisionSummary,
+  parseRejectedCandidates,
+} from './decision-log.js';
+
+describe('decision-log domain', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-log-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('parseRejectedCandidates', () => {
+    it('parses bulleted candidates under REJECTED header', () => {
+      const report = `
+🚀 DEPLOYED
+
+BONK/SOL
+PoolAddress123
+
+WHY THIS WON
+Strong organic volume and high smart wallet presence.
+
+REJECTED
+- PEPE/SOL: high dev holding and PVP conflict
+- WIF/SOL: low fee/active TVL ratio
+- DOGE/SOL: weak narrative and bot concentration
+`;
+      const rejected = parseRejectedCandidates(report);
+      expect(rejected).toEqual([
+        'PEPE/SOL: high dev holding and PVP conflict',
+        'WIF/SOL: low fee/active TVL ratio',
+        'DOGE/SOL: weak narrative and bot concentration',
+      ]);
+    });
+
+    it('parses numbered or bulleted list under ⛔ NO DEPLOY', () => {
+      const report = `
+⛔ NO DEPLOY
+
+Cycle finished with no valid entry.
+
+BEST LOOKING CANDIDATE
+MOON/SOL
+
+WHY SKIPPED
+Only one surviving candidate but volume was insufficient.
+
+REJECTED
+1. MOON/SOL: volume below threshold
+2. SUN/SOL: PVP hard filter
+• STAR/SOL: bot holders exceeded limit
+`;
+      const rejected = parseRejectedCandidates(report);
+      expect(rejected).toEqual([
+        'MOON/SOL: volume below threshold',
+        'SUN/SOL: PVP hard filter',
+        'STAR/SOL: bot holders exceeded limit',
+      ]);
+    });
+
+    it('returns empty array when REJECTED section is absent or empty', () => {
+      expect(parseRejectedCandidates('')).toEqual([]);
+      expect(parseRejectedCandidates('Some random text without header')).toEqual([]);
+      expect(
+        parseRejectedCandidates(`
+REJECTED
+<none>
+`),
+      ).toEqual([]);
+    });
+  });
+
+  describe('appendDecision & getRecentDecisions', () => {
+    it('stores structured decision with extended reason and rejected list', () => {
+      const longReason = 'A'.repeat(1200);
+      const rejected = [
+        'ALPHA/SOL: rejected due to high bot concentration (85%)',
+        'BETA/SOL: rejected due to PVP symbol conflict',
+      ];
+
+      const decision = appendDecision({
+        type: 'no_deploy',
+        actor: 'SCREENER',
+        summary: 'LLM chose no deploy',
+        reason: longReason,
+        rejected,
+      });
+
+      expect(decision.type).toBe('no_deploy');
+      expect(decision.actor).toBe('SCREENER');
+      expect(decision.reason?.length).toBe(1200);
+      expect(decision.rejected).toEqual(rejected);
+
+      const recent = getRecentDecisions(5);
+      expect(recent.length).toBeGreaterThanOrEqual(1);
+      expect(recent[0]?.id).toBe(decision.id);
+      expect(recent[0]?.rejected).toEqual(rejected);
+    });
+
+    it('formats human-readable summary including rejected candidate rationale', () => {
+      appendDecision({
+        type: 'no_deploy',
+        actor: 'SCREENER',
+        pool_name: 'TEST/SOL',
+        summary: 'Screening finished without deploy',
+        reason: 'No pools met threshold',
+        rejected: ['TOKEN_A: low volume', 'TOKEN_B: high bots'],
+      });
+
+      const summary = getDecisionSummary(1);
+      expect(summary).toContain('[SCREENER] NO_DEPLOY TEST/SOL');
+      expect(summary).toContain('rejected: TOKEN_A: low volume | TOKEN_B: high bots');
+    });
+  });
+});

--- a/packages/core/src/domain/decision-log.ts
+++ b/packages/core/src/domain/decision-log.ts
@@ -1,16 +1,4 @@
-/**
- * @file decision-log.ts
- * @description Append-only JSON log of structured agent decisions (deploy, close, skip, no_deploy, note).
- *
- * @features
- * - appendDecision stores sanitized decisions capped at MAX_DECISIONS
- * - getRecentDecisions returns the N most recent entries
- * - getDecisionSummary produces a compact human-readable digest
- *
- * @dependencies none (pure file I/O)
- * @sideEffects Reads and writes decision-log.json
- */
-import { log } from '../shared/logger.js';
+
 import { dataPath, MAX_DECISIONS } from '../shared/constants.js';
 import { loadJsonFile, saveJsonFile } from '../shared/utils.js';
 import type { Decision, DecisionType } from '../shared/types.js';
@@ -32,6 +20,29 @@ function save(data: DecisionLogData): void {
 function sanitize(value: unknown, maxLen = 280): string | null {
   if (value == null) return null;
   return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLen) || null;
+}
+
+/**
+ * Extracts candidate rejections from LLM reports formatted with a `REJECTED` section.
+ */
+export function parseRejectedCandidates(content: string): string[] {
+  if (!content) return [];
+  const rejectedMatch = content.match(
+    /(?:^|\n)\s*(?:###?\s*)?REJECTED\s*:?\s*\n([\s\S]*?)(?:\n\s*(?:###?|[A-Z][A-Z\s]{3,}:|$))/i,
+  );
+  if (!rejectedMatch || !rejectedMatch[1]) return [];
+  const lines = rejectedMatch[1].split('\n');
+  const rejected: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // Strip leading bullet point: -, *, •, or numbering 1.
+    const clean = trimmed.replace(/^[-*•\d.]+\s*/, '').trim();
+    if (clean && !clean.startsWith('(') && clean.toLowerCase() !== '<none>' && clean.toLowerCase() !== 'none') {
+      rejected.push(clean);
+    }
+  }
+  return rejected;
 }
 
 interface AppendDecisionEntry {
@@ -58,10 +69,10 @@ export function appendDecision(entry: AppendDecisionEntry): Decision {
     pool_name: sanitize(entry.pool_name || entry.pool, 120),
     position: entry.position || null,
     summary: sanitize(entry.summary),
-    reason: sanitize(entry.reason, 500),
+    reason: sanitize(entry.reason, 2048),
     risks: Array.isArray(entry.risks) ? (entry.risks.map((r) => sanitize(r, 140)).filter(Boolean) as string[]) : [],
     metrics: entry.metrics || {},
-    rejected: Array.isArray(entry.rejected) ? (entry.rejected.map((r) => sanitize(r, 180)).filter(Boolean) as string[]) : [],
+    rejected: Array.isArray(entry.rejected) ? (entry.rejected.map((r) => sanitize(r, 300)).filter(Boolean) as string[]) : [],
   };
   data.decisions.unshift(decision);
   data.decisions = data.decisions.slice(0, MAX_DECISIONS);

--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -243,4 +243,61 @@ describe('Daemon — Concurrency & Mutex Guards', () => {
     expect(res).toContain('Screening cycle failed: Screening RPC explosion');
     expect((daemon as any).screeningBusy).toBe(false);
   });
+
+  it('parses and persists structured rejected candidate rationales on NO DEPLOY screening decision', async () => {
+    adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ total_positions: 0, positions: [] });
+    adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({ sol: 10, tokens: [] });
+    adapters.screening.getTopCandidates = vi.fn().mockResolvedValue({
+      candidates: [
+        { pool: 'pool_1', name: 'TOKEN1/SOL', base: { mint: 'mint_1' }, bin_step: 100 },
+        { pool: 'pool_2', name: 'TOKEN2/SOL', base: { mint: 'mint_2' }, bin_step: 100 },
+      ],
+      filtered_examples: [{ name: 'EARLY_FILTERED/SOL', reason: 'volume too low' }],
+    });
+    adapters.domain.parseRejectedCandidates = (content: string) => {
+      if (content.includes('TOKEN1/SOL: low fees')) {
+        return ['TOKEN1/SOL: low fees', 'TOKEN2/SOL: PvP conflict'];
+      }
+      return [];
+    };
+
+    const screeningReportContent = `
+⛔ NO DEPLOY
+
+Cycle finished with no valid entry.
+
+BEST LOOKING CANDIDATE
+TOKEN1/SOL
+
+WHY SKIPPED
+Candidates failed qualitative thresholds.
+
+REJECTED
+- TOKEN1/SOL: low fees
+- TOKEN2/SOL: PvP conflict
+`;
+
+    vi.spyOn(await import('@etemaro/core'), 'agentLoop').mockResolvedValueOnce({
+      content: screeningReportContent,
+      steps: [],
+      toolCalls: [],
+      finalAnswer: screeningReportContent,
+    } as any);
+
+    const res = await daemon.runScreeningCycle({ silent: true });
+    expect(res).toContain('⛔ NO DEPLOY');
+    expect(adapters.domain.appendDecision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'no_deploy',
+        actor: 'SCREENER',
+        summary: 'LLM chose no deploy',
+        rejected: expect.arrayContaining([
+          'TOKEN1/SOL: low fees',
+          'TOKEN2/SOL: PvP conflict',
+          'EARLY_FILTERED/SOL: volume too low',
+        ]),
+      }),
+    );
+  });
 });
+

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -20,7 +20,6 @@ import path from 'path';
 import {
   config,
   computeDeployAmount,
-  reloadScreeningThresholds,
   getDataDir,
   dataPath,
   sharedDataPath,
@@ -38,8 +37,6 @@ import {
   log,
   agentLoop,
   type AgentLoopDeps,
-  type AgentLoopResult,
-  buildSystemPrompt,
   type AgentMessage,
   getTrackedPosition,
   getTrackedPositions,
@@ -49,8 +46,6 @@ import {
   registerExitSignal,
   getLastBriefingDate,
   setLastBriefingDate,
-  getStateSummary,
-  type PositionRecord,
   meteora,
   wallet,
   screening,
@@ -128,6 +123,7 @@ export interface DaemonAdapters {
     stageSignals: (pool: string, signals: Record<string, unknown>) => void;
     getWeightsSummary: () => string;
     appendDecision: (entry: any) => void;
+    parseRejectedCandidates?: (content: string) => string[];
   };
   agentLoopDeps: AgentLoopDeps;
 }
@@ -1303,6 +1299,9 @@ STEPS:
 
    WHY THIS WON
    <2-4 concise sentences on why this pool won, key risks, and why it still beat the alternatives>
+
+   REJECTED
+   <short flat list of all other evaluated candidates and why they were not chosen, one per line e.g. "- TOKEN/SOL: reason">
 5. If no pool qualifies, report in this exact format instead:
    ⛔ NO DEPLOY
 
@@ -1315,7 +1314,7 @@ STEPS:
    <2-4 concise sentences explaining why nothing was good enough>
 
    REJECTED
-   <short flat list of top candidate names and why they were skipped>
+   <short flat list of all evaluated candidate names and why they were skipped, one per line e.g. "- TOKEN/SOL: reason">
 IMPORTANT:
 - Keep the whole report compact and highly scannable for Telegram.
       `,
@@ -1340,19 +1339,30 @@ IMPORTANT:
         },
       );
       screenReport = content;
+      const parsedRejected = this.adapters.domain.parseRejectedCandidates
+        ? this.adapters.domain.parseRejectedCandidates(content)
+        : [];
+      const hardFilterRejected = [
+        ...earlyFilteredExamples.map((entry: any) => `${entry.name}: ${entry.reason}`),
+        ...filteredOut.map((entry: any) => `${entry.name}: ${entry.reason}`),
+      ];
+      const combinedRejected = Array.from(new Set([...parsedRejected, ...hardFilterRejected]));
+
       if (/⛔\s*NO DEPLOY/i.test(content)) {
         this.adapters.domain.appendDecision({
           type: 'no_deploy',
           actor: 'SCREENER',
           summary: 'LLM chose no deploy',
-          reason: stripThink(content).slice(0, 500),
+          reason: stripThink(content).slice(0, 2048),
+          rejected: combinedRejected,
         });
       } else if (!deploySucceeded) {
         this.adapters.domain.appendDecision({
           type: 'no_deploy',
           actor: 'SCREENER',
           summary: deployAttempted ? 'Deploy attempt did not succeed' : 'No successful deploy in screening cycle',
-          reason: stripThink(content).slice(0, 500),
+          reason: stripThink(content).slice(0, 2048),
+          rejected: combinedRejected,
         });
       }
     } catch (error: any) {


### PR DESCRIPTION
## Description

Resolves #189 (FINDING-010 in Architecture Audit).

### Key Changes
1. **Decision Log & Types Enhancement (`packages/core/src/domain/decision-log.ts`)**:
   - Added exported `parseRejectedCandidates(content: string): string[]` helper to parse candidate verdicts from LLM screening reports.
   - Expanded `reason` field cap from 500 characters to 2048 characters to eliminate truncation of screening rationales.
   - Expanded `rejected` entry limit from 180 to 300 characters.
2. **Screening Prompt Update (`packages/core/src/application/prompt-builder.ts`, `packages/daemon/src/Daemon.ts`)**:
   - Instructed SCREENER role and screening loop prompt to explicitly provide the `REJECTED` section in both DEPLOYED and NO DEPLOY reports with a concise verdict for all non-selected candidates evaluated.
3. **Daemon Screening Decision Persistence (`packages/daemon/src/Daemon.ts`)**:
   - Combined hard-filter rejections with parsed LLM rejections and passed them to `appendDecision({ type: 'no_deploy', actor: 'SCREENER', summary, reason, rejected })`.
4. **Unit Tests**:
   - Created comprehensive tests in `packages/core/src/domain/decision-log.test.ts` verifying candidate parsing, decision persistence, long reason preservation, and summary formatting.
   - Added unit test in `packages/daemon/src/Daemon.test.ts` asserting that NO DEPLOY screening cycles pass structured candidate rationales to the decision log.

### Verification
- 189/189 tests passing (`pnpm test`)
- Monorepo build and typecheck clean (`pnpm build`, `pnpm typecheck`)
- `pnpm lint` clean (0 errors)