### PR TITLE
fix(cli): resolve lessons.json via dataPath instead of process.cwd() (#193)

### DIFF
--- a/packages/cli/src/Cli.test.ts
+++ b/packages/cli/src/Cli.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { applyCliRuntimeFlags, resolveGlobalFlagValue } from './Cli.js';
+import fs from 'node:fs';
+import { describe, it, expect, vi } from 'vitest';
+import { dataPath, LESSONS_FILENAME } from '@etemaro/core';
+import { Cli, loadCore, applyCliRuntimeFlags, resolveGlobalFlagValue } from './Cli.js';
 
 describe('resolveGlobalFlagValue', () => {
   it('returns the value following the long flag', () => {
@@ -40,3 +42,48 @@ describe('applyCliRuntimeFlags', () => {
     expect(env.DRY_RUN).toBe('false');
   });
 });
+
+describe('Cli handleEvolve', () => {
+  it('reads performance data from dataPath(LESSONS_FILENAME)', async () => {
+    await loadCore();
+
+    const mockEvolveThresholds = vi.fn().mockReturnValue({ changes: { minTvl: 1000 }, rationale: 'better yield' });
+    const adapters: any = {
+      domain: {
+        evolveThresholds: mockEvolveThresholds,
+      },
+    };
+
+    const cli = new Cli(adapters);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    const mockStdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const lessonsPath = dataPath(LESSONS_FILENAME);
+    const originalExists = fs.existsSync;
+    const originalReadFile = fs.readFileSync;
+
+    const existsSpy = vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      if (p === lessonsPath) return true;
+      return originalExists(p);
+    });
+    const readSpy = vi.spyOn(fs, 'readFileSync').mockImplementation((p, ...args) => {
+      if (p === lessonsPath) {
+        return JSON.stringify({ performance: [{ pnl_usd: 10 }] });
+      }
+      return originalReadFile(p, ...args);
+    });
+
+    try {
+      (cli as any).handleEvolve();
+      expect(mockEvolveThresholds).toHaveBeenCalledWith([{ pnl_usd: 10 }], expect.anything());
+      expect(mockStdout).toHaveBeenCalled();
+    } finally {
+      mockExit.mockRestore();
+      mockStdout.mockRestore();
+      existsSpy.mockRestore();
+      readSpy.mockRestore();
+    }
+  }, 15000);
+});
+
+

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -68,7 +68,7 @@ let DaemonCtor: DaemonExports['Daemon'] = null as any;
  * Load core and daemon modules after environment is prepared.
  * Must be called before using any core functionality.
  */
-async function loadCore(): Promise<void> {
+export async function loadCore(): Promise<void> {
   const [coreMod, daemonMod] = await Promise.all([import('@etemaro/core'), import('@etemaro/daemon')]);
   // Assign core exports
   config = coreMod.config;
@@ -365,7 +365,7 @@ export class Cli {
 
   constructor(adapters: CliAdapters) {
     this.adapters = adapters;
-    this.etemaroDir = getEtemaroDir();
+    this.etemaroDir = typeof getEtemaroDir === 'function' ? getEtemaroDir() : defaultEtemaroHome();
   }
 
   // ─── Lifecycle ─────────────────────────────────────────────────
@@ -819,7 +819,7 @@ export class Cli {
   }
 
   private handleEvolve(): void {
-    const lessonsFile = path.join(process.cwd(), 'lessons.json');
+    const lessonsFile = dataPath(LESSONS_FILENAME);
     let perfData: any[] = [];
     if (fs.existsSync(lessonsFile)) {
       try {
@@ -898,6 +898,7 @@ export class Cli {
 
 function isCliTarget(filePath: string | undefined): boolean {
   if (!filePath) return false;
+  if (process.env.VITEST || process.env.NODE_ENV === 'test') return false;
   const lower = filePath.toLowerCase();
   return (
     lower.endsWith('cli.ts') ||


### PR DESCRIPTION
## Summary
Fixes `Cli.ts` to resolve `lessons.json` via the central `dataPath(LESSONS_FILENAME)` helper rather than `path.join(process.cwd(), 'lessons.json')`, ensuring performance data is located correctly regardless of the directory from which the CLI is executed.

Closes #193

## Root Cause & Gap Analysis
- **Why/When it happened**: `handleEvolve()` directly constructed a path with `process.cwd()` instead of delegating to `dataPath(LESSONS_FILENAME)`. When running CLI subcommands outside the root directory or with custom data directories, performance data was not found.
- **Why we missed it**: Existing unit tests either ran from the project root or mocked domain methods without verifying the file path queried during execution.

## Acceptance Criteria Checklist
- [x] AC1: `handleEvolve()` resolves `lessons.json` via `dataPath(LESSONS_FILENAME)`.
- [x] AC2: Added unit test verifying `lessons.json` resolution from `dataPath`.
- [x] AC3: Guard `isCliTarget` against running `main()` during test-runner execution.
- [x] AC4: Typecheck and full test suite passing (27 test files, 190 tests).

## Testing Plan
- [x] **Automated Tests**: Ran `pnpm vitest run packages/cli/src/Cli.test.ts` (9 passing).
- [x] **Typecheck & Linter**: Ran `pnpm typecheck` and `biome check` cleanly.
- [x] **Full Suite**: Ran `pnpm test` (all 27 test files passing).