### PR TITLE
docs(config): document in-place mutations, env state conventions, and test reset patterns (#192)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,3 +108,13 @@ When `DRY_RUN=true` is set in the environment:
 - **Interceptors**: Inside `MeteoraAdapter.ts`, the functions `deployPosition`, `claimFees`, and `closePosition` check for the dry-run flag.
 - **Mock Responses**: Instead of submitting a transaction payload to the Solana blockchain, the adapter intercepts the call and returns a mock object containing `dry_run: true` and a mock transaction ID.
 - _Note:_ Mock positions are only saved to the local `state.json` registry during the deploy step; they are not simulated dynamically by the management loop since they do not exist on the Solana blockchain.
+
+---
+
+## Configuration Lifecycle & State Isolation
+
+1. **Singleton Pattern**: The configuration is parsed once at application start into an immutable-by-convention `config` singleton exported by `@etemaro/core`.
+2. **In-Place Runtime Mutations**: Dynamic parameter modifications (such as screening threshold reloads via `reloadScreeningThresholds()` or active strategy switching via `setActiveStrategy()`) mutate fields directly on the shared `config` instance, ensuring that all consumers maintain synchronized view without stale module cache references.
+3. **Environment Propagation**: User-defined credentials and URLs in `user-config.json` are conditionally populated into `process.env` using `||=` fallback assignment, ensuring that environment variables passed explicitly via CLI or `.env` take precedence.
+4. **Test Isolation**: Test suites that mutate `process.env` or mock file system configs must snapshot and restore `process.env` in `beforeEach`/`afterEach`, and use `resetConfig()` from `@etemaro/core` to cleanly re-initialize the singleton state between test cases.
+

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -358,3 +358,20 @@ Use the `update_config` tool (Telegram `/setcfg` or agent self-tuning) to change
 ```
 
 Changes are persisted to the active config file immediately and take effect on the next screening cycle.
+
+---
+
+## 6. Configuration Lifecycle & Test Isolation Conventions
+
+### In-Memory Singleton (`config`)
+- Etemaro exports a singleton `config: AppConfig` built on process startup from `user-config.json` and evaluated environment variables.
+- Modules import `config` directly to read active runtime settings.
+- When dynamic settings are updated (e.g. via `reloadScreeningThresholds()` or `setActiveStrategy()`), the in-memory singleton is mutated in-place to keep all references synchronized.
+
+### Environment Variable Fallbacks
+- On config load, `applyUserConfigToEnv` propagates user credentials (RPC URL, Telegram tokens, wallet keys) into `process.env` using `||=` fallback semantics so explicit CLI/shell environment variables maintain precedence.
+
+### Test Isolation Best Practices
+- **Snapshot & Restore**: Test suites that mutate `process.env` (e.g., `USER_CONFIG_PATH`, `RPC_URL`) must snapshot `process.env` in `beforeEach` and restore it in `afterEach`.
+- **`resetConfig()` Helper**: Call `resetConfig()` from `@etemaro/core` in test fixtures whenever simulating different configuration files or environment state. This re-evaluates all defaults and refreshes the singleton without requiring module reloading.
+

--- a/packages/core/src/config/Config.test.ts
+++ b/packages/core/src/config/Config.test.ts
@@ -1,20 +1,8 @@
-/**
- * @file Config.test.ts
- * @description Unit tests for Config module, covering fee/active-TVL scaling and config defaults.
- *
- * @features
- * - Validates scaleScreeningToTimeframe produces correct thresholds per timeframe
- * - Asserts default screening.minFeeActiveTvlRatio matches scaled floor for 5m
- * - Spot-checks a known pool ratio against the current default gate
- * - Verifies minSafeBinsBelow config override works
- *
- * @dependencies vitest
- */
-import fs from 'node:fs';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { config } from './Config.js';
 import { DEFAULT_USER_CONFIG, defaultUserConfigStr } from './defaultUserConfig.js';
-import { configPath, getMinSafeBinsBelow } from '../shared/constants.js';
+import { getMinSafeBinsBelow } from '../shared/constants.js';
 import { scaleScreeningToTimeframe } from '../shared/utils.js';
 import { UserConfigSchema } from './schema.js';
 
@@ -118,6 +106,8 @@ describe('hiveMind agentId support', () => {
   });
 
   afterEach(() => {
+    vi.doUnmock('node:fs');
+    vi.resetModules();
     vi.restoreAllMocks();
   });
 
@@ -166,6 +156,8 @@ describe('fail-closed config load and validation behavior', () => {
     } else {
       process.env.ETEMARO_SKIP_ENV_VALIDATION = originalSkipEnv;
     }
+    vi.doUnmock('node:fs');
+    vi.resetModules();
     vi.restoreAllMocks();
   });
 
@@ -301,5 +293,21 @@ describe('DEFAULT_USER_CONFIG template parity and validation', () => {
     } finally {
       process.env = originalEnv;
     }
+  });
+
+  describe('resetConfig helper', () => {
+    it('resets in-memory config singleton and keeps object reference identical', async () => {
+      const { config, resetConfig } = await import('./Config.js');
+      const originalTimeframe = config.screening.timeframe;
+
+      // Temporarily mutate in place
+      config.screening.timeframe = '1h';
+      expect(config.screening.timeframe).toBe('1h');
+
+      // Call resetConfig to reload
+      const res = resetConfig();
+      expect(res).toBe(config);
+      expect(config.screening.timeframe).toBe(originalTimeframe);
+    });
   });
 });

--- a/packages/core/src/config/Config.ts
+++ b/packages/core/src/config/Config.ts
@@ -12,8 +12,6 @@
 import fs from 'node:fs';
 import type { AppConfig } from '../shared/types.js';
 import {
-  repoPath,
-  dataPath,
   USER_CONFIG_PATH,
   MIN_SAFE_BINS_BELOW,
   TOKEN_MINTS,
@@ -21,7 +19,7 @@ import {
   DEFAULT_LLM_BASE_URL,
 } from '../shared/constants.js';
 import { loadAndValidateConfig, isHelpOrInfoCommand } from './ConfigValidator.js';
-import { DEFAULT_USER_CONFIG, defaultUserConfigStr } from './defaultUserConfig.js';
+import { DEFAULT_USER_CONFIG, } from './defaultUserConfig.js';
 import type { ValidatedUserConfig } from './schema.js';
 import { numericConfig, resolveEnvString } from '../shared/utils.js';
 
@@ -32,6 +30,15 @@ export class ConfigLoadError extends Error {
   }
 }
 
+/**
+ * Applies user config connection and API keys to process.env as fallback values (using ||=).
+ *
+ * NOTE ON ENVIRONMENT MUTATIONS:
+ * In a running daemon process, this propagates user configuration into environment variables
+ * expected by underlying SDKs (e.g. Helius, Telegram, OpenAI).
+ * In automated unit tests, test suites that modify process.env or invoke config reloads
+ * should snapshot process.env in beforeEach and restore it in afterEach to prevent test pollution.
+ */
 function applyUserConfigToEnv(u: ValidatedUserConfig): void {
   const connection = u.connection;
   if (connection?.rpcUrl) process.env.RPC_URL ||= connection?.rpcUrl;
@@ -291,6 +298,9 @@ export function computeDeployAmount(walletSol: number): number {
   return parseFloat(result.toFixed(2));
 }
 
+/**
+ * Dynamically reloads partial screening thresholds from user-config.json into the active config singleton.
+ */
 export function reloadScreeningThresholds(): void {
   try {
     // Dynamic reloading can just re-read the nested schema
@@ -347,6 +357,19 @@ export function reloadScreeningThresholds(): void {
   } catch {
     /* ignore */
   }
+}
+
+/**
+ * Re-reads user configuration from disk, evaluates process.env fallbacks,
+ * and updates the in-memory `config` singleton in-place.
+ *
+ * Use this in unit tests or when switching configuration files at runtime.
+ */
+export function resetConfig(): AppConfig {
+  const fresh = buildConfig();
+  Object.assign(config, fresh);
+  setMinSafeBinsBelowOverride(config.strategy.minSafeBinsBelow);
+  return config;
 }
 
 function resolveField(key: string, value: unknown): unknown {


### PR DESCRIPTION
## Description

Resolves #192 (FINDING-013 in Architecture Audit).

### Key Changes
1. **Config Helper & JSDoc Updates (`packages/core/src/config/Config.ts`)**:
   - Added exported `resetConfig(): AppConfig` to re-read and reload configuration cleanly into the `config` singleton.
   - Added comprehensive JSDoc explaining in-place mutation semantics, environment variable fallback propagation (`applyUserConfigToEnv`), and test isolation expectations.
2. **Architectural & User Documentation (`docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`)**:
   - Added section on Configuration Lifecycle & State Isolation conventions covering singleton mutations, env overrides, and test reset best practices.
3. **Unit Tests & Fixture Isolation (`packages/core/src/config/Config.test.ts`)**:
   - Added test verifying `resetConfig()` resets the in-memory singleton while maintaining object reference parity.
   - Hardened `afterEach` hooks with `vi.doUnmock('node:fs')` and `vi.resetModules()` to prevent module mock pollution across test suites.

### Verification
- 194/194 tests passing (`pnpm test`)
- Monorepo build and typecheck clean (`pnpm build`, `pnpm typecheck`)
- `pnpm lint` clean (0 errors)