### PR TITLE
fix(daemon): decouple PnL suspect check from local state to prevent false stop-loss closes (#135)

### DIFF
--- a/packages/core/src/domain/state.test.ts
+++ b/packages/core/src/domain/state.test.ts
@@ -12,6 +12,8 @@ import {
   withStateLock,
   setPositionInstruction,
   confirmPeak,
+  isPnlSuspect,
+  updatePnlAndCheckExits,
   __setStateFilePath,
 } from './state.js';
 
@@ -214,3 +216,98 @@ describe('withStateLock concurrency synchronization', () => {
     expect(pos?.instruction).toMatch(/^Instruction-\d$/);
   });
 });
+
+describe('isPnlSuspect', () => {
+  it('returns true when pnl_pct_suspicious flag is set', () => {
+    expect(isPnlSuspect({ pnl_pct_suspicious: true, pnl_pct: 10 })).toBe(true);
+  });
+
+  it('returns false when pnl_pct is null or undefined', () => {
+    expect(isPnlSuspect({ pnl_pct: null, total_value_usd: 100 })).toBe(false);
+    expect(isPnlSuspect({ pnl_pct: undefined, total_value_usd: 100 })).toBe(false);
+  });
+
+  it('returns false for normal negative PnL above -90%', () => {
+    expect(isPnlSuspect({ pnl_pct: -15, total_value_usd: 100 })).toBe(false);
+    expect(isPnlSuspect({ pnl_pct: -89.9, total_value_usd: 100 })).toBe(false);
+  });
+
+  it('flags PnL <= -90% as suspect when position retains USD value without local state', () => {
+    // Untracked position on-chain during RPC glitch: trackedAmountSol is null/undefined
+    expect(isPnlSuspect({ pnl_pct: -99.5, total_value_usd: 45.2 }, null)).toBe(true);
+    expect(isPnlSuspect({ pnl_pct: -95, total_value_true_usd: 10.0 }, undefined)).toBe(true);
+  });
+
+  it('flags PnL <= -90% as suspect when position retains SOL value', () => {
+    expect(isPnlSuspect({ pnl_pct: -99, amount_sol: 0.5 })).toBe(true);
+    expect(isPnlSuspect({ pnl_pct: -99 }, 0.5)).toBe(true);
+  });
+
+  it('returns false for PnL <= -90% when position has zero remaining value', () => {
+    expect(isPnlSuspect({ pnl_pct: -99.9, total_value_usd: 0, amount_sol: 0 }, 0)).toBe(false);
+  });
+});
+
+describe('updatePnlAndCheckExits suspect PnL handling', () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE);
+  });
+
+  it('skips stop-loss exit when deep negative PnL is suspect', () => {
+    trackPosition(deployOpts('PosSuspect') as any);
+    const result = updatePnlAndCheckExits(
+      'PosSuspect',
+      {
+        pnl_pct: -99,
+        total_value_usd: 50,
+        in_range: true,
+      },
+      {
+        stopLossPct: -10,
+        takeProfitPct: 5,
+        trailingTakeProfit: false,
+        trailingTriggerPct: 3,
+        trailingDropPct: 1,
+        outOfRangeWaitMinutes: 30,
+        outOfRangeBinsToClose: 5,
+        minFeePerTvl24h: 1,
+      } as any,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('triggers stop-loss exit for normal negative PnL exceeding threshold', () => {
+    trackPosition(deployOpts('PosNormalStop') as any);
+    const result = updatePnlAndCheckExits(
+      'PosNormalStop',
+      {
+        pnl_pct: -15,
+        total_value_usd: 50,
+        in_range: true,
+      },
+      {
+        stopLossPct: -10,
+        takeProfitPct: 5,
+        trailingTakeProfit: false,
+        trailingTriggerPct: 3,
+        trailingDropPct: 1,
+        outOfRangeWaitMinutes: 30,
+        outOfRangeBinsToClose: 5,
+        minFeePerTvl24h: 1,
+      } as any,
+    );
+    expect(result).toEqual({
+      action: 'STOP_LOSS',
+      reason: 'Stop loss: PnL -15.00% <= -10%',
+    });
+  });
+});
+

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -406,6 +406,41 @@ interface PositionData {
   in_range: boolean;
   fee_per_tvl_24h?: number | null;
   age_minutes?: number | null;
+  total_value_usd?: number | null;
+  total_value_true_usd?: number | null;
+  amount_sol?: number | null;
+}
+
+/**
+ * Detects whether a position's PnL reading is suspicious (e.g. RPC pricing glitch or Jupiter outage).
+ * A deep negative PnL (<= -90%) is flagged as suspect if the position retains measurable value (> $0.01 or > 0 SOL),
+ * regardless of whether local state tracking is present.
+ */
+export function isPnlSuspect(
+  position: {
+    pnl_pct?: number | null;
+    pnl_pct_suspicious?: boolean;
+    total_value_usd?: number | null;
+    total_value_true_usd?: number | null;
+    amount_sol?: number | null;
+    pair?: string;
+    position?: string;
+  },
+  trackedAmountSol?: number | null,
+): boolean {
+  if (position.pnl_pct_suspicious) return true;
+  if (position.pnl_pct == null) return false;
+  if (position.pnl_pct > -90) return false;
+  const totalValue = position.total_value_usd ?? position.total_value_true_usd ?? 0;
+  const solValue = position.amount_sol ?? trackedAmountSol ?? 0;
+  if (totalValue > 0.01 || solValue > 0) {
+    log(
+      'cron_warn',
+      `Suspect PnL for ${position.pair || position.position || 'position'}: ${position.pnl_pct}% but position still has value ($${totalValue || `${solValue} SOL`}) — skipping PnL rules`,
+    );
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -444,8 +479,17 @@ export function updatePnlAndCheckExits(position_address: string, positionData: P
 
   if (changed) save(state);
 
+  const pnlSuspect = isPnlSuspect(
+    {
+      ...positionData,
+      position: position_address,
+      pair: pos.pool_name || pos.pool,
+    },
+    pos.amount_sol,
+  );
+
   // ── Stop loss ──────────────────────────────────────────────────
-  if (!pnl_pct_suspicious && currentPnlPct != null && mgmtConfig.stopLossPct != null && currentPnlPct <= mgmtConfig.stopLossPct) {
+  if (!pnlSuspect && currentPnlPct != null && mgmtConfig.stopLossPct != null && currentPnlPct <= mgmtConfig.stopLossPct) {
     return {
       action: 'STOP_LOSS',
       reason: `Stop loss: PnL ${currentPnlPct.toFixed(2)}% <= ${mgmtConfig.stopLossPct}%`,
@@ -453,7 +497,7 @@ export function updatePnlAndCheckExits(position_address: string, positionData: P
   }
 
   // ── Trailing TP ────────────────────────────────────────────────
-  if (!pnl_pct_suspicious && pos.trailing_active) {
+  if (!pnlSuspect && pos.trailing_active) {
     const dropFromPeak = pos.peak_pnl_pct - currentPnlPct!;
     if (dropFromPeak >= mgmtConfig.trailingDropPct) {
       return {

--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Daemon, type DaemonAdapters } from './Daemon.js';
+import { Daemon, getDeterministicCloseRule, type DaemonAdapters } from './Daemon.js';
 
 function createMockAdapters(): DaemonAdapters {
   return {
@@ -316,4 +316,64 @@ REJECTED
     await expect((daemon as any).sendTelegramSafe('Test message')).resolves.toBeNull();
   });
 });
+
+describe('getDeterministicCloseRule suspect PnL handling', () => {
+  const mgmtConfig: any = {
+    stopLossPct: -10,
+    takeProfitPct: 20,
+    outOfRangeBinsToClose: 5,
+    outOfRangeWaitMinutes: 30,
+    minFeePerTvl24h: 1,
+  };
+
+  it('skips stop loss close rule when untracked position has deep negative PnL but retains value', () => {
+    // Position is active on-chain, not tracked in state.json, but has USD value during an RPC glitch
+    const rule = getDeterministicCloseRule(
+      {
+        position: 'PosUntrackedGlitch',
+        pair: 'SOL/USDC',
+        pnl_pct: -99.9,
+        total_value_usd: 25.0,
+      },
+      mgmtConfig,
+    );
+    expect(rule).toBeNull();
+  });
+
+  it('triggers stop loss close rule when untracked position has legitimate negative PnL exceeding threshold', () => {
+    const rule = getDeterministicCloseRule(
+      {
+        position: 'PosUntrackedRealLoss',
+        pair: 'SOL/USDC',
+        pnl_pct: -15.0,
+        total_value_usd: 25.0,
+      },
+      mgmtConfig,
+    );
+    expect(rule).toEqual({
+      action: 'CLOSE',
+      rule: 1,
+      reason: 'stop loss (pnl=-15.00% threshold=-10%)',
+    });
+  });
+
+  it('triggers stop loss close rule when deep negative PnL has zero value', () => {
+    const rule = getDeterministicCloseRule(
+      {
+        position: 'PosRuggedZeroValue',
+        pair: 'RUG/SOL',
+        pnl_pct: -99.9,
+        total_value_usd: 0,
+        amount_sol: 0,
+      },
+      mgmtConfig,
+    );
+    expect(rule).toEqual({
+      action: 'CLOSE',
+      rule: 1,
+      reason: 'stop loss (pnl=-99.90% threshold=-10%)',
+    });
+  });
+});
+
 

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -44,6 +44,7 @@ import {
   updatePnlAndCheckExits,
   confirmPeak,
   registerExitSignal,
+  isPnlSuspect,
   getLastBriefingDate,
   setLastBriefingDate,
   meteora,
@@ -138,17 +139,7 @@ interface DeterministicCloseResult {
 
 export function getDeterministicCloseRule(position: any, managementConfig: typeof config.management): DeterministicCloseResult | null {
   const tracked = getTrackedPosition(position.position);
-  const pnlSuspect = (() => {
-    // Couldn't-price-this-tick flag (e.g. Jupiter outage) — never act on PnL rules.
-    if (position.pnl_pct_suspicious) return true;
-    if (position.pnl_pct == null) return false;
-    if (position.pnl_pct > -90) return false;
-    if (tracked?.amount_sol && (position.total_value_usd ?? 0) > 0.01) {
-      log('cron_warn', `Suspect PnL for ${position.pair}: ${position.pnl_pct}% but position still has value — skipping PnL rules`);
-      return true;
-    }
-    return false;
-  })();
+  const pnlSuspect = isPnlSuspect(position, tracked?.amount_sol);
 
   if (!pnlSuspect && position.pnl_pct != null && position.pnl_pct <= managementConfig.stopLossPct) {
     return {


### PR DESCRIPTION
## Summary
Decouples suspect PnL detection (`<= -90%` during RPC pricing glitches / oracle outages) from local `tracked` state requirements. When a position on-chain retains measurable value (`total_value_usd > 0.01` or `amount_sol > 0`), deep negative PnL readings are correctly flagged as suspect and skip stop-loss / trailing TP rules, even if the position record is missing from local `state.json`.

Closes #135

## Root Cause & Gap Analysis
- **Why/When it happened**: In `Daemon.ts:146` and `state.ts:448`, suspect PnL detection required `tracked?.amount_sol` to check whether deep negative PnL (`<= -90%`) was a pricing anomaly. When local state was missing or untracked, `tracked?.amount_sol` evaluated to `undefined`, bypassing the suspect check and causing deterministic Rule 1 (stop loss) to fire on erroneous RPC ticks.
- **Musk Algorithm Simplification**: Created a single canonical `isPnlSuspect` helper in core domain to check value retention directly from position data (`total_value_usd > 0.01` or `amount_sol > 0`), eliminating brittle local state dependency.
- **Why we missed it**: Prior unit tests for `getDeterministicCloseRule` and `updatePnlAndCheckExits` had fully populated local tracked records or normal PnL ranges.

## Acceptance Criteria Checklist
- [x] AC1: Export `isPnlSuspect` helper in `@etemaro/core` domain layer.
- [x] AC2: `getDeterministicCloseRule` in `Daemon.ts` uses `isPnlSuspect`, skipping stop loss on deep negative PnL when position has value without local state.
- [x] AC3: `updatePnlAndCheckExits` in `state.ts` uses `isPnlSuspect`, preventing false stop-loss exits.
- [x] AC4: Comprehensive unit tests in `state.test.ts` and `Daemon.test.ts` verifying suspect PnL handling.
- [x] AC5: Full test suite (27 files, 208 tests) and typecheck passing cleanly.

## Testing Plan
- [x] **State Unit Tests**: `pnpm vitest run packages/core/src/domain/state.test.ts` (15 passing).
- [x] **Daemon Unit Tests**: `pnpm vitest run packages/daemon/src/Daemon.test.ts` (15 passing).
- [x] **Full Suite**: `pnpm typecheck && pnpm test` (all 27 test files passing).