### PR TITLE
feat(notifications): alert user via Telegram on persistent RPC and transaction failures

### DIFF
--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -63,7 +63,7 @@ import { addSmartWallet, removeSmartWallet, listSmartWallets, checkSmartWalletsO
 import { getRecentDecisions } from '../domain/decision-log.js';
 import { normalizeTimeframe, scaleScreeningToTimeframe } from '../shared/utils.js';
 import { Mutex } from '../shared/mutex.js';
-import { notifyDeploy, notifyClose, notifySwap, notifySwapError } from './notifications/TelegramAdapter.js';
+import { notifyDeploy, notifyClose, notifySwap, notifySwapError, notifyTransactionError } from './notifications/TelegramAdapter.js';
 
 // ─── Constants ─────────────────────────────────────────────────
 
@@ -1055,44 +1055,78 @@ async function executeToolUnlocked(name: string, args: Record<string, unknown> =
           log('telegram_warn', `Failed to send swap notification: ${err?.message || err}`);
         });
       } else if (name === 'deploy_position') {
-        notifyDeploy({
-          pair: (result as any).pool_name || (args as any).pool_name || (args.pool_address as string)?.slice(0, 8),
-          amountSol: (args.amount_y as number) ?? (args.amount_sol as number) ?? 0,
-          position: (result as any).position,
-          tx: (result as any).txs?.[0] ?? (result as any).tx,
-          priceRange: (result as any).price_range,
-          rangeCoverage: (result as any).range_coverage,
-          binStep: (result as any).bin_step,
-          baseFee: (result as any).base_fee,
-        }).catch((err: any) => {
-          log('telegram_warn', `Failed to send deploy notification: ${err?.message || err}`);
-        });
-      } else if (name === 'close_position') {
-        notifyClose({
-          pair: (result as any).pool_name || (args.position_address as string)?.slice(0, 8),
-          pnlUsd: (result as any).pnl_usd ?? 0,
-          pnlPct: (result as any).pnl_pct ?? 0,
-        }).catch((err: any) => {
-          log('telegram_warn', `Failed to send close notification: ${err?.message || err}`);
-        });
-        // Note low-yield closes in pool memory so screener avoids redeploying
-        if ((args.reason as string) && (args.reason as string).toLowerCase().includes('yield')) {
-          const poolAddr = (result as any).pool || args.pool_address;
-          if (poolAddr)
-            addPoolNote({ pool_address: poolAddr, note: `Closed: low yield (fee/TVL below threshold) at ${new Date().toISOString().slice(0, 10)}` });
+        const isSuccess = (result as any)?.success !== false && !(result as any)?.error && !(result as any)?.blocked;
+        if (!isSuccess) {
+          notifyTransactionError({
+            type: 'deploy',
+            pair: (result as any)?.pool_name || (args as any)?.pool_name || (args.pool_address as string)?.slice(0, 8),
+            reason: (result as any)?.error || (result as any)?.reason || 'Deployment execution failed',
+          }).catch((err: any) => {
+            log('telegram_warn', `Failed to send deploy error notification: ${err?.message || err}`);
+          });
+        } else {
+          notifyDeploy({
+            pair: (result as any).pool_name || (args as any).pool_name || (args.pool_address as string)?.slice(0, 8),
+            amountSol: (args.amount_y as number) ?? (args.amount_sol as number) ?? 0,
+            position: (result as any).position,
+            tx: (result as any).txs?.[0] ?? (result as any).tx,
+            priceRange: (result as any).price_range,
+            rangeCoverage: (result as any).range_coverage,
+            binStep: (result as any).bin_step,
+            baseFee: (result as any).base_fee,
+          }).catch((err: any) => {
+            log('telegram_warn', `Failed to send deploy notification: ${err?.message || err}`);
+          });
         }
-        // Auto-swap base token back to SOL unless user said to hold (retried).
-        if (!args.skip_swap && (result as any).base_mint) {
-          const { swapped, result: swapResult } = await swapBaseToSolWithRetry((result as any).base_mint, 'after close');
-          if (swapped) {
-            (result as any).auto_swapped = true;
-            (result as any).auto_swap_note =
-              `Base token already auto-swapped back to SOL (${(result as any).base_mint.slice(0, 8)} → SOL). Do NOT call swap_token again.`;
-            if ((swapResult as any)?.amount_out) (result as any).sol_received = (swapResult as any).amount_out;
+      } else if (name === 'close_position') {
+        const isSuccess = (result as any)?.success !== false && !(result as any)?.error && !(result as any)?.blocked;
+        if (!isSuccess) {
+          notifyTransactionError({
+            type: 'close',
+            pair: (result as any)?.pool_name || (args.position_address as string)?.slice(0, 8),
+            position: args.position_address as string,
+            reason: (result as any)?.error || (result as any)?.reason || 'Position close failed',
+          }).catch((err: any) => {
+            log('telegram_warn', `Failed to send close error notification: ${err?.message || err}`);
+          });
+        } else {
+          notifyClose({
+            pair: (result as any).pool_name || (args.position_address as string)?.slice(0, 8),
+            pnlUsd: (result as any).pnl_usd ?? 0,
+            pnlPct: (result as any).pnl_pct ?? 0,
+          }).catch((err: any) => {
+            log('telegram_warn', `Failed to send close notification: ${err?.message || err}`);
+          });
+          // Note low-yield closes in pool memory so screener avoids redeploying
+          if ((args.reason as string) && (args.reason as string).toLowerCase().includes('yield')) {
+            const poolAddr = (result as any).pool || args.pool_address;
+            if (poolAddr)
+              addPoolNote({ pool_address: poolAddr, note: `Closed: low yield (fee/TVL below threshold) at ${new Date().toISOString().slice(0, 10)}` });
+          }
+          // Auto-swap base token back to SOL unless user said to hold (retried).
+          if (!args.skip_swap && (result as any).base_mint) {
+            const { swapped, result: swapResult } = await swapBaseToSolWithRetry((result as any).base_mint, 'after close');
+            if (swapped) {
+              (result as any).auto_swapped = true;
+              (result as any).auto_swap_note =
+                `Base token already auto-swapped back to SOL (${(result as any).base_mint.slice(0, 8)} → SOL). Do NOT call swap_token again.`;
+              if ((swapResult as any)?.amount_out) (result as any).sol_received = (swapResult as any).amount_out;
+            }
           }
         }
-      } else if (name === 'claim_fees' && config.management.autoSwapAfterClaim && (result as any).base_mint) {
-        await swapBaseToSolWithRetry((result as any).base_mint, 'after claim');
+      } else if (name === 'claim_fees') {
+        const isSuccess = (result as any)?.success !== false && !(result as any)?.error && !(result as any)?.blocked;
+        if (!isSuccess) {
+          notifyTransactionError({
+            type: 'claim',
+            position: args.position_address as string,
+            reason: (result as any)?.error || (result as any)?.reason || 'Fee claim failed',
+          }).catch((err: any) => {
+            log('telegram_warn', `Failed to send claim error notification: ${err?.message || err}`);
+          });
+        } else if (config.management.autoSwapAfterClaim && (result as any).base_mint) {
+          await swapBaseToSolWithRetry((result as any).base_mint, 'after claim');
+        }
       }
     }
 
@@ -1107,6 +1141,23 @@ async function executeToolUnlocked(name: string, args: Record<string, unknown> =
       duration_ms: duration,
       success: false,
     });
+
+    if (['deploy_position', 'close_position', 'claim_fees', 'swap_token'].includes(name)) {
+      const typeMap: Record<string, 'deploy' | 'close' | 'claim' | 'swap'> = {
+        deploy_position: 'deploy',
+        close_position: 'close',
+        claim_fees: 'claim',
+        swap_token: 'swap',
+      };
+      notifyTransactionError({
+        type: typeMap[name] || 'confirm',
+        pair: (args.pool_name || args.pool_address) as string,
+        position: args.position_address as string,
+        reason: error.message,
+      }).catch((err: any) => {
+        log('telegram_warn', `Failed to send tool exception notification: ${err?.message || err}`);
+      });
+    }
 
     return {
       error: error.message,

--- a/packages/core/src/adapters/notifications/NotificationSink.ts
+++ b/packages/core/src/adapters/notifications/NotificationSink.ts
@@ -19,7 +19,7 @@ import { log } from '../../shared/logger.js';
 
 // ─── Types ────────────────────────────────────────────────────────
 
-export type NotificationType = 'deploy' | 'close' | 'swap' | 'swap_error' | 'oor' | 'briefing' | 'message';
+export type NotificationType = 'deploy' | 'close' | 'swap' | 'swap_error' | 'oor' | 'briefing' | 'message' | 'rpc_error' | 'tx_error';
 
 export interface DesktopNotification {
   /** ISO-8601 UTC timestamp */

--- a/packages/core/src/adapters/notifications/TelegramAdapter.test.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { notifySwap, notifySwapError, summarizeToolResult } from './TelegramAdapter.js';
+import {
+  notifySwap,
+  notifySwapError,
+  notifyRpcError,
+  notifyTransactionError,
+  resetRpcErrorThrottle,
+  summarizeToolResult,
+} from './TelegramAdapter.js';
 import * as NotificationSink from './NotificationSink.js';
 
 vi.mock('./NotificationSink.js', () => ({
@@ -82,5 +89,52 @@ describe('TelegramAdapter notifications', () => {
     });
 
     expect(NotificationSink.notify).toHaveBeenCalledWith('swap_error', '⚠️', 'Auto-swap failed: Council → SOL', 'Reason: Slippage exceeded');
+  });
+
+  it('notifyRpcError formats alert and throttles repeated alerts within 5 minutes', async () => {
+    resetRpcErrorThrottle();
+
+    await notifyRpcError({
+      operation: 'Management Cycle',
+      error: 'Solana RPC rate limited (429)',
+      endpoint: 'https://api.mainnet-beta.solana.com',
+    });
+
+    expect(NotificationSink.notify).toHaveBeenCalledTimes(1);
+    expect(NotificationSink.notify).toHaveBeenCalledWith(
+      'rpc_error',
+      '⚠️',
+      'RPC/Network Error: Management Cycle',
+      expect.stringContaining('Solana RPC rate limited (429)'),
+    );
+
+    // Call again immediately for same operation -> should be throttled (no second notify call)
+    await notifyRpcError({
+      operation: 'Management Cycle',
+      error: 'Solana RPC rate limited (429)',
+    });
+    expect(NotificationSink.notify).toHaveBeenCalledTimes(1);
+
+    // Call for different operation -> should alert
+    await notifyRpcError({
+      operation: 'Screening Cycle',
+      error: 'Timeout fetching candidates',
+    });
+    expect(NotificationSink.notify).toHaveBeenCalledTimes(2);
+  });
+
+  it('notifyTransactionError formats failure alert for failed transaction execution', async () => {
+    await notifyTransactionError({
+      type: 'deploy',
+      pair: 'SOL/USDC',
+      reason: 'Transaction simulation failed: Custom program error 0x1',
+    });
+
+    expect(NotificationSink.notify).toHaveBeenCalledWith(
+      'tx_error',
+      '❌',
+      'Transaction Failed: DEPLOY | SOL/USDC',
+      expect.stringContaining('Custom program error 0x1'),
+    );
   });
 });

--- a/packages/core/src/adapters/notifications/TelegramAdapter.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.ts
@@ -636,6 +636,66 @@ export async function notifyOutOfRange({ pair, minutesOOR }: NotifyOutOfRangeArg
   await sendPlain(`⚠️ Out of Range ${pair}\n` + body);
 }
 
+interface NotifyRpcErrorArgs {
+  operation: string;
+  error: string;
+  endpoint?: string;
+}
+
+const _lastRpcErrorAlerts: Record<string, number> = {};
+const RPC_ALERT_THROTTLE_MS = 5 * 60 * 1000; // 5 minutes per operation
+
+export function resetRpcErrorThrottle(): void {
+  for (const key of Object.keys(_lastRpcErrorAlerts)) {
+    delete _lastRpcErrorAlerts[key];
+  }
+}
+
+/**
+ * Notifies the user on Telegram when all RPC / API retry attempts fail.
+ * Throttles duplicate alerts to once every 5 minutes per unique operation.
+ */
+export async function notifyRpcError({ operation, error, endpoint }: NotifyRpcErrorArgs): Promise<void> {
+  if (hasActiveLiveMessage()) return;
+  const now = Date.now();
+  const lastAlert = _lastRpcErrorAlerts[operation] || 0;
+  if (now - lastAlert < RPC_ALERT_THROTTLE_MS) return;
+  _lastRpcErrorAlerts[operation] = now;
+
+  const endpointStr = endpoint ? `\nEndpoint: ${endpoint}` : '';
+  const body = `Operation: ${operation}\nError: ${error.slice(0, 300)}${endpointStr}\n(All retry attempts failed)`;
+  notify('rpc_error', '⚠️', `RPC/Network Error: ${operation}`, body);
+  await sendPlain(`⚠️ RPC / Network Failure\n${body}`);
+}
+
+interface NotifyTransactionErrorArgs {
+  type: 'deploy' | 'close' | 'claim' | 'swap' | 'confirm';
+  pair?: string;
+  position?: string;
+  tx?: string;
+  reason: string;
+}
+
+/**
+ * Notifies the user on Telegram when an on-chain transaction execution or confirmation fails.
+ */
+export async function notifyTransactionError({
+  type,
+  pair,
+  position,
+  tx,
+  reason,
+}: NotifyTransactionErrorArgs): Promise<void> {
+  if (hasActiveLiveMessage()) return;
+  const typeLabel = type.toUpperCase();
+  const pairStr = pair ? ` | ${pair}` : '';
+  const posStr = position ? `\nPosition: ${position.slice(0, 8)}...` : '';
+  const txStr = tx ? `\nTx: ${tx.slice(0, 16)}...` : '';
+  const body = `Type: ${typeLabel}${pairStr}${posStr}${txStr}\nReason: ${reason.slice(0, 300)}`;
+  notify('tx_error', '❌', `Transaction Failed: ${typeLabel}${pairStr}`, body);
+  await sendPlain(`❌ Transaction Failed (${typeLabel})\n${body}`);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -89,6 +89,14 @@ export interface DaemonAdapters {
     editMessageWithButtons: (text: string, messageId: number, buttons: any[]) => Promise<any>;
     answerCallbackQuery: (queryId: string, text?: string) => Promise<any>;
     notifyOutOfRange: (data: { pair: string; minutesOOR: number }) => Promise<any>;
+    notifyRpcError?: (data: { operation: string; error: string; endpoint?: string }) => Promise<any>;
+    notifyTransactionError?: (data: {
+      type: 'deploy' | 'close' | 'claim' | 'swap' | 'confirm';
+      pair?: string;
+      position?: string;
+      tx?: string;
+      reason: string;
+    }) => Promise<any>;
     isEnabled: () => boolean;
     createLiveMessage: (title: string, body: string) => Promise<any>;
   };
@@ -687,6 +695,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
           this.runScreeningCycle({ silent: true }).catch((e: any) => log('cron_error', `Opportunity-triggered screening failed: ${e.message}`));
         } catch (e: any) {
           log('cron_error', `Opportunity poll failed: ${e.message}`);
+          this.adapters.telegram.notifyRpcError?.({ operation: 'Opportunity Poller', error: e.message }).catch(() => null);
         } finally {
           this.releaseLock('opportunityPoll');
         }
@@ -972,6 +981,7 @@ After evaluating, write a brief one-line result per position.
     } catch (error: any) {
       log('cron_error', `Management cycle failed: ${error.message}`);
       mgmtReport = `Management cycle failed: ${error.message}`;
+      this.adapters.telegram.notifyRpcError?.({ operation: 'Management Cycle', error: error.message }).catch(() => null);
     } finally {
       this.releaseLock('management');
       if (!silent && this.adapters.telegram.isEnabled()) {
@@ -1386,6 +1396,7 @@ IMPORTANT:
     } catch (error: any) {
       log('cron_error', `Screening cycle failed: ${error.message}`);
       screenReport = `Screening cycle failed: ${error.message}`;
+      this.adapters.telegram.notifyRpcError?.({ operation: 'Screening Cycle', error: error.message }).catch(() => null);
     } finally {
       this.releaseLock('screening');
       if (!silent && this.adapters.telegram.isEnabled()) {


### PR DESCRIPTION
## Summary
- Added `notifyRpcError` and `notifyTransactionError` to [TelegramAdapter.ts](file:///Users/r/dev/github/etemaro/packages/core/src/adapters/notifications/TelegramAdapter.ts) with 5-minute deduplication/throttling to prevent spam during prolonged network/RPC outages.
- Added structured desktop notifications for `rpc_error` and `tx_error` in [NotificationSink.ts](file:///Users/r/dev/github/etemaro/packages/core/src/adapters/notifications/NotificationSink.ts).
- Integrated transaction failure alerting into [ToolExecutor.ts](file:///Users/r/dev/github/etemaro/packages/core/src/adapters/ToolExecutor.ts) across `deploy_position`, `close_position`, `claim_fees`, and `swap_token`.
- Wired persistent RPC and cycle failure alerts into daemon lifecycle methods (`runManagementCycle`, `runScreeningCycle`, `opportunityPollInterval`) in [Daemon.ts](file:///Users/r/dev/github/etemaro/packages/daemon/src/Daemon.ts).
- Added unit test suite in [TelegramAdapter.test.ts](file:///Users/r/dev/github/etemaro/packages/core/src/adapters/notifications/TelegramAdapter.test.ts) covering formatting and throttling.

## Verification
- All 28 test suites and 220 unit tests passed cleanly.
- `npm run typecheck` passed across all 5 workspace projects with zero errors.