### PR TITLE
feat(core): support fallback RPC endpoint and automatic failover (#212)

### DIFF
--- a/packages/core/src/adapters/blockchain/WalletAdapter.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.ts
@@ -59,7 +59,7 @@ export function generateNewWallet(opts?: { label?: string; configDir?: string })
   return wallet;
 }
 
-import { getConnection, getWalletAddress, getWalletKeypair } from '../../shared/connection.js';
+import { getConnection, getWalletAddress, getWalletKeypair, withRpcFailover } from '../../shared/connection.js';
 import { type WalletBalancesResult } from '../../shared/types.js';
 
 export { getWalletAddress, getWalletKeypair };
@@ -176,15 +176,14 @@ export async function getWalletBalances(options?: { force?: boolean }): Promise<
   const fetchBalances = async (): Promise<WalletBalancesResult> => {
     // ─── 1. Primary Method: Standard Solana RPC + Jupiter Price API ─
     try {
-      const connection = getConnection();
-      const solLamports = await withRpcRetry(
-        () => connection.getBalance(walletPubkey),
+      const solLamports = await withRpcFailover(
+        (conn) => conn.getBalance(walletPubkey),
         { label: 'getBalance' },
       );
       const solBalance = (solLamports || 0) / 1e9;
 
-      const tokenAccounts = await withRpcRetry(
-        () => connection.getParsedTokenAccountsByOwner(walletPubkey, { programId: TOKEN_PROGRAM_ID }),
+      const tokenAccounts = await withRpcFailover(
+        (conn) => conn.getParsedTokenAccountsByOwner(walletPubkey, { programId: TOKEN_PROGRAM_ID }),
         { label: 'getParsedTokenAccountsByOwner' },
       );
 

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -7,7 +7,9 @@ import {
   getRpcUrl,
   getWalletAddress,
   getWalletKeypair,
+  hasFallbackRpc,
   resetConnectionState,
+  withRpcFailover,
 } from './connection.js';
 
 describe('connection module', () => {
@@ -89,6 +91,70 @@ describe('connection module', () => {
 
       expect(getWalletAddress()).toBeNull();
       expect(() => getWalletKeypair()).toThrow(/Wallet private key is not configured/);
+    });
+  });
+
+  describe('hasFallbackRpc and withRpcFailover', () => {
+    it('detects when fallback RPC is configured vs not configured', () => {
+      config.connection = { ...config.connection, rpcUrl2: null };
+      delete process.env.RPC_URL_2;
+      expect(hasFallbackRpc()).toBe(false);
+
+      config.connection = { ...config.connection, rpcUrl2: 'https://fallback.solana.com' };
+      expect(hasFallbackRpc()).toBe(true);
+    });
+
+    it('withRpcFailover succeeds on primary RPC when no error occurs', async () => {
+      config.connection = {
+        ...config.connection,
+        rpcUrl: 'https://primary.solana.com',
+        rpcUrl2: 'https://fallback.solana.com',
+      };
+
+      const result = await withRpcFailover(async (conn) => {
+        expect(conn.rpcEndpoint).toBe('https://primary.solana.com');
+        return 'primary-success';
+      });
+
+      expect(result).toBe('primary-success');
+    });
+
+    it('withRpcFailover fails over to fallback RPC on transient 429 error', async () => {
+      config.connection = {
+        ...config.connection,
+        rpcUrl: 'https://primary.solana.com',
+        rpcUrl2: 'https://fallback.solana.com',
+      };
+
+      let attempts = 0;
+      const result = await withRpcFailover(
+        async (conn) => {
+          attempts++;
+          if (conn.rpcEndpoint === 'https://primary.solana.com') {
+            throw new Error('429 Too Many Requests: rate limit exceeded');
+          }
+          expect(conn.rpcEndpoint).toBe('https://fallback.solana.com');
+          return 'fallback-success';
+        },
+        { initialDelayMs: 1, maxRetries: 1 },
+      );
+
+      expect(result).toBe('fallback-success');
+      expect(attempts).toBeGreaterThan(1);
+    });
+
+    it('withRpcFailover does not catch non-transient errors', async () => {
+      config.connection = {
+        ...config.connection,
+        rpcUrl: 'https://primary.solana.com',
+        rpcUrl2: 'https://fallback.solana.com',
+      };
+
+      await expect(
+        withRpcFailover(async () => {
+          throw new Error('Invalid account public key');
+        }),
+      ).rejects.toThrow('Invalid account public key');
     });
   });
 });

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -7,6 +7,8 @@
 import { Connection, Keypair } from '@solana/web3.js';
 import bs58 from 'bs58';
 import { config } from '../config/Config.js';
+import { log } from './logger.js';
+import { isTransientRpcError, withRpcRetry, type RpcRetryOptions } from './utils.js';
 
 let _primaryConnection: Connection | null = null;
 let _primaryRpcUrl: string | null = null;
@@ -75,6 +77,48 @@ export function getWalletAddress(): string | null {
     return getWalletKeypair().publicKey.toString();
   } catch {
     return null;
+  }
+}
+
+/**
+ * Returns true if a fallback RPC URL is configured.
+ */
+export function hasFallbackRpc(): boolean {
+  return Boolean(config.connection?.rpcUrl2 || process.env.RPC_URL_2);
+}
+
+/**
+ * Executes an asynchronous RPC operation with automatic failover between primary and fallback RPC connections.
+ * If the operation on the primary connection encounters a transient RPC error (429, timeout, 502/503/504),
+ * it seamlessly switches to the fallback connection and retries with backoff.
+ */
+export async function withRpcFailover<T>(
+  fn: (connection: Connection) => Promise<T>,
+  options: RpcRetryOptions = {},
+): Promise<T> {
+  const primaryConn = getConnection(false);
+  if (!hasFallbackRpc()) {
+    return withRpcRetry(() => fn(primaryConn), options);
+  }
+
+  try {
+    return await withRpcRetry(() => fn(primaryConn), {
+      ...options,
+      maxRetries: options.maxRetries ?? 2,
+    });
+  } catch (primaryErr) {
+    if (isTransientRpcError(primaryErr)) {
+      const fallbackConn = getConnection(true);
+      const fallbackUrl = getRpcUrl(true);
+      const errMessage = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      const label = options.label ? ` [${options.label}]` : '';
+      log('rpc_warn', `Primary RPC failed${label} (${errMessage.slice(0, 100)}) — switching to fallback RPC: ${fallbackUrl}`);
+      return await withRpcRetry(() => fn(fallbackConn), {
+        ...options,
+        maxRetries: options.maxRetries ?? 2,
+      });
+    }
+    throw primaryErr;
   }
 }
 


### PR DESCRIPTION
## Summary
Closes #212.

- Implemented `withRpcFailover` and `hasFallbackRpc` in [`connection.ts`](file:///Users/r/dev/github/etemaro/packages/core/src/shared/connection.ts).
- Integrated `withRpcFailover` into [`WalletAdapter.ts`](file:///Users/r/dev/github/etemaro/packages/core/src/adapters/blockchain/WalletAdapter.ts) to automatically switch from primary to secondary RPC on 429 rate limits, timeouts, or node errors.
- Verified configuration propagation for `RPC_URL_2` and `connection.rpcUrl2` across `schema.ts`, `Config.ts`, `defaultUserConfig.ts`, and `.env.example`.
- Added unit tests in [`connection.test.ts`](file:///Users/r/dev/github/etemaro/packages/core/src/shared/connection.test.ts) covering healthy primary execution, automatic fallback failover, and non-transient error handling.

## Root Cause & Gap Analysis
- **Why**: When a primary RPC node suffers rate limiting or transient network degradation, the agent had no unified mechanism to switch to a healthy secondary node.
- **Musk Algorithm Applied**: Instead of complex multi-client pooling or middleware layers, implemented simple, direct `withRpcFailover` wrapping `getConnection(false)` and `getConnection(true)`.

## Acceptance Criteria
- [x] AC1: `RPC_URL_2` / `connection.rpcUrl2` configured and documented in `.env.example` and docs.
- [x] AC2: `hasFallbackRpc()` returns true when fallback is present.
- [x] AC3: `withRpcFailover` seamlessly fails over to fallback RPC on transient 429 / timeout errors.
- [x] AC4: All test suites and typechecks pass.