### PR TITLE
refactor(core): generalize connection.ts to named-slot cache and dedupe getPnlConnection

### DIFF
--- a/packages/core/src/adapters/PnLAdapter.ts
+++ b/packages/core/src/adapters/PnLAdapter.ts
@@ -16,6 +16,7 @@ import { config } from '../config/Config.js';
 // State module not yet converted to TS — import from repo root
 // @ts-ignore — state.js has no type declarations yet
 import { getTrackedPosition, markInRange, markOutOfRange, minutesOutOfRange } from '../domain/state.js';
+import { getNamedConnection } from '../shared/connection.js';
 import { log } from '../shared/logger.js';
 import { withRpcRetry } from '../shared/utils.js';
 
@@ -40,12 +41,8 @@ async function loadDlmmSdk(): Promise<any> {
   return _DLMM;
 }
 
-let _pnlConnection: Connection | null = null;
 export function getPnlConnection(): Connection {
-  if (!_pnlConnection) {
-    _pnlConnection = new Connection(config.pnl.rpcUrl, 'confirmed');
-  }
-  return _pnlConnection;
+  return getNamedConnection('pnl', config.pnl?.rpcUrl);
 }
 
 function safeNum(value: unknown): number {

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -4,6 +4,7 @@ import bs58 from 'bs58';
 import { config } from '../config/Config.js';
 import {
   getConnection,
+  getNamedConnection,
   getRpcUrl,
   getWalletAddress,
   getWalletKeypair,
@@ -11,10 +12,12 @@ import {
   resetConnectionState,
   withRpcFailover,
 } from './connection.js';
+import { getPnlConnection } from '../adapters/PnLAdapter.js';
 
 describe('connection module', () => {
   const originalEnv = { ...process.env };
   const originalConnectionConfig = { ...config.connection };
+  const originalPnlConfig = { ...config.pnl };
 
   beforeEach(() => {
     resetConnectionState();
@@ -23,6 +26,7 @@ describe('connection module', () => {
   afterEach(() => {
     process.env = { ...originalEnv };
     config.connection = { ...originalConnectionConfig };
+    config.pnl = { ...originalPnlConfig };
     resetConnectionState();
   });
 
@@ -59,6 +63,48 @@ describe('connection module', () => {
       delete process.env.RPC_URL_2;
 
       expect(getRpcUrl(true)).toBe('https://primary-only.solana.com');
+    });
+  });
+
+  describe('getNamedConnection', () => {
+    it('caches and returns same Connection instance for same slot and URL', () => {
+      const conn1 = getNamedConnection('custom-slot', 'https://custom-rpc.solana.com');
+      const conn2 = getNamedConnection('custom-slot', 'https://custom-rpc.solana.com');
+      expect(conn1).toBe(conn2);
+      expect(conn1.rpcEndpoint).toBe('https://custom-rpc.solana.com');
+    });
+
+    it('recreates Connection instance when URL changes for the slot', () => {
+      const conn1 = getNamedConnection('custom-slot', 'https://custom-rpc-1.solana.com');
+      const conn2 = getNamedConnection('custom-slot', 'https://custom-rpc-2.solana.com');
+      expect(conn1).not.toBe(conn2);
+      expect(conn2.rpcEndpoint).toBe('https://custom-rpc-2.solana.com');
+    });
+
+    it('maintains isolated connections across different named slots', () => {
+      const pnlConn = getNamedConnection('pnl', 'https://pnl.solana.com');
+      const customConn = getNamedConnection('custom', 'https://custom.solana.com');
+      expect(pnlConn).not.toBe(customConn);
+      expect(pnlConn.rpcEndpoint).toBe('https://pnl.solana.com');
+      expect(customConn.rpcEndpoint).toBe('https://custom.solana.com');
+    });
+
+    it('clears all cached named connections on resetConnectionState', () => {
+      const conn1 = getNamedConnection('slot-a', 'https://slot-a.solana.com');
+      resetConnectionState();
+      const conn2 = getNamedConnection('slot-a', 'https://slot-a.solana.com');
+      expect(conn1).not.toBe(conn2);
+    });
+
+    it('getPnlConnection delegates to pnl named slot with dynamic URL support', () => {
+      config.pnl = { ...config.pnl, rpcUrl: 'https://helius-pnl.solana.com' };
+      const conn1 = getPnlConnection();
+      expect(conn1.rpcEndpoint).toBe('https://helius-pnl.solana.com');
+
+      config.pnl = { ...config.pnl, rpcUrl: 'https://updated-helius-pnl.solana.com' };
+      const conn2 = getPnlConnection();
+      expect(conn2.rpcEndpoint).toBe('https://updated-helius-pnl.solana.com');
+      expect(conn1).not.toBe(conn2);
     });
   });
 

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -10,11 +10,12 @@ import { config } from '../config/Config.js';
 import { log } from './logger.js';
 import { isTransientRpcError, withRpcRetry, type RpcRetryOptions } from './utils.js';
 
-let _primaryConnection: Connection | null = null;
-let _primaryRpcUrl: string | null = null;
+interface ConnectionSlot {
+  conn: Connection;
+  url: string;
+}
 
-let _fallbackConnection: Connection | null = null;
-let _fallbackRpcUrl: string | null = null;
+const _connections = new Map<string, ConnectionSlot>();
 
 let _walletKeypair: Keypair | null = null;
 let _walletPrivateKey: string | null = null;
@@ -34,23 +35,28 @@ export function getRpcUrl(fallback = false): string {
 }
 
 /**
+ * Returns a cached Connection instance for a named slot and target RPC endpoint URL.
+ * Dynamically re-initializes if the target URL changes.
+ */
+export function getNamedConnection(slot: string, rpcUrl?: string): Connection {
+  const url = rpcUrl || getRpcUrl(slot === 'fallback');
+  const cached = _connections.get(slot);
+  if (!cached || cached.url !== url) {
+    const conn = new Connection(url, 'confirmed');
+    _connections.set(slot, { conn, url });
+    return conn;
+  }
+  return cached.conn;
+}
+
+/**
  * Returns a cached Connection instance for primary or fallback RPC endpoint.
  * Dynamically re-initializes if configuration changes.
  */
 export function getConnection(fallback = false): Connection {
+  const slot = fallback ? 'fallback' : 'primary';
   const rpc = getRpcUrl(fallback);
-  if (fallback) {
-    if (!_fallbackConnection || _fallbackRpcUrl !== rpc) {
-      _fallbackConnection = new Connection(rpc, 'confirmed');
-      _fallbackRpcUrl = rpc;
-    }
-    return _fallbackConnection;
-  }
-  if (!_primaryConnection || _primaryRpcUrl !== rpc) {
-    _primaryConnection = new Connection(rpc, 'confirmed');
-    _primaryRpcUrl = rpc;
-  }
-  return _primaryConnection;
+  return getNamedConnection(slot, rpc);
 }
 
 /**
@@ -126,10 +132,7 @@ export async function withRpcFailover<T>(
  * Resets cached connection and wallet singletons (primarily used for test isolation).
  */
 export function resetConnectionState(): void {
-  _primaryConnection = null;
-  _primaryRpcUrl = null;
-  _fallbackConnection = null;
-  _fallbackRpcUrl = null;
+  _connections.clear();
   _walletKeypair = null;
   _walletPrivateKey = null;
 }


### PR DESCRIPTION
## Summary
Generalizes `packages/core/src/shared/connection.ts` from hardcoded primary/fallback singleton variables to a Map-based named-slot cache (`Map<string, { conn: Connection; url: string }>`). Exports `getNamedConnection(slot, rpcUrl)` with dynamic URL-change reinitialization, and updates `PnLAdapter.ts`'s `getPnlConnection()` to delegate to it, removing duplicated singleton caching.

Closes #223

## Root Cause & Gap Analysis
- **Why/When it happened**: `PnLAdapter.ts` was implemented with its own standalone `_pnlConnection` singleton variable before centralized connection management was fully established, causing duplication and lacking dynamic URL-update detection & centralized test cleanup.
- **Why we missed it**: Identified during the delta RPC architecture audit (FINDING-017).

## Acceptance Criteria Checklist
- [x] AC1: `connection.ts` manages connections via an internal named-slot map.
- [x] AC2: `connection.ts` exports `getNamedConnection(slot, rpcUrl)`.
- [x] AC3: `getConnection(fallback)` preserves full backward compatibility.
- [x] AC4: `resetConnectionState()` clears all cached slot connections.
- [x] AC5: `PnLAdapter.getPnlConnection()` delegates to `getNamedConnection('pnl', config.pnl?.rpcUrl)`.
- [x] AC6: Unit tests added in `connection.test.ts` verifying slot caching, URL invalidation, and cleanup.
- [x] AC7: Full monorepo test suite (239/239) passes and build is clean.

## Testing Plan
- [x] **Local Test Suite**: `pnpm test` passed across all 29 test suites.
- [x] **Build**: `pnpm build` succeeded across all workspace projects.
- [ ] **CI Verification**: GitHub Actions workflows.