### PR TITLE
fix(swap): prevent skipping unpriced tokens on position close and batch sweeps

### DIFF
--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -70,6 +70,30 @@ describe('ToolExecutor - swapAllTokensToSol', () => {
     })
   })
 
+  it('should swap unpriced tokens (usd: null) when balance > 0', async () => {
+    const mockBalances = {
+      tokens: [
+        { mint: 'So11111111111111111111111111111111111111112', symbol: 'SOL', balance: 10, usd: 1500 },
+        { mint: 'UNPRICED11111111111111111111111111111111111', symbol: 'UNP', balance: 500, usd: null },
+        { mint: 'ZERO1111111111111111111111111111111111111111', symbol: 'ZERO', balance: 0, usd: null },
+      ],
+    }
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({ success: true, tx: 'test-tx-unpriced' } as any)
+
+    const result = await swapAllTokensToSol([])
+
+    expect(result.total).toBe(3)
+    expect(result.skipped).toBe(2) // SOL, ZERO balance
+    expect(result.successful).toBe(1) // UNP swapped
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: 'UNPRICED11111111111111111111111111111111111',
+      output_mint: 'SOL',
+      amount: 500,
+    })
+  })
+
   it('should accept object input { skipMints: [] } without throwing error', async () => {
     const mockBalances = { tokens: [] }
     vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
@@ -165,5 +189,47 @@ describe('ToolExecutor - deploy_position serialization', () => {
       success: true,
     })
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ToolExecutor - close_position auto-swap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('DRY_RUN', 'false')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('auto-swaps unpriced base token (usd: null) back to SOL upon close', async () => {
+    const baseMint = 'BASE_TOKEN_1111111111111111111111111111111'
+    vi.mocked(MeteoraAdapter.closePosition).mockResolvedValue({
+      success: true,
+      position: 'pos-123',
+      base_mint: baseMint,
+    } as any)
+
+    const mockBalances = {
+      sol_price: 150,
+      tokens: [{ mint: baseMint, symbol: 'BASE', balance: 2500, usd: null }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: true,
+      tx: 'swap-tx-hash',
+      amount_out: '0.15',
+    } as any)
+
+    const result = (await executeTool('close_position', { position_address: 'pos-123' })) as any
+
+    expect(result.success).toBe(true)
+    expect(result.auto_swapped).toBe(true)
+    expect(result.sol_received).toBe('0.15')
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: baseMint,
+      output_mint: 'SOL',
+      amount: 2500,
+    })
   })
 })

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { config } from '../config/Config.js'
 import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js'
 import * as WalletAdapter from './blockchain/WalletAdapter.js'
-import { executeTool, swapAllTokensToSol } from './ToolExecutor.js'
+import { executeTool, swapAllTokensToSol, swapBaseToSolWithRetry } from './ToolExecutor.js'
 
 // Mock the WalletAdapter functions
 vi.mock('./blockchain/WalletAdapter.js', () => ({
@@ -94,12 +95,200 @@ describe('ToolExecutor - swapAllTokensToSol', () => {
     })
   })
 
+  it('should swap unpriced tokens (usd: undefined) when balance > 0', async () => {
+    const mockBalances = {
+      tokens: [{ mint: 'UNDEF111111111111111111111111111111111111111', symbol: 'UNDEF', balance: 250, usd: undefined }],
+    }
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({ success: true, tx: 'test-tx-undef' } as any)
+
+    const result = await swapAllTokensToSol([])
+
+    expect(result.total).toBe(1)
+    expect(result.skipped).toBe(0)
+    expect(result.successful).toBe(1)
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: 'UNDEF111111111111111111111111111111111111111',
+      output_mint: 'SOL',
+      amount: 250,
+    })
+  })
+
+  it('should correctly handle dust threshold boundaries ($0.019 skipped vs $0.02 swapped)', async () => {
+    const mockBalances = {
+      tokens: [
+        { mint: 'DUST_BELOW111111111111111111111111111111111', symbol: 'DUST1', balance: 100, usd: 0.019 },
+        { mint: 'DUST_EXACT111111111111111111111111111111111', symbol: 'EXACT', balance: 200, usd: 0.02 },
+      ],
+    }
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({ success: true, tx: 'test-tx-boundary' } as any)
+
+    const result = await swapAllTokensToSol([])
+
+    expect(result.total).toBe(2)
+    expect(result.skipped).toBe(1) // usd: 0.019 is skipped as dust (< 0.02)
+    expect(result.successful).toBe(1) // usd: 0.02 is NOT skipped and successfully swapped
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1)
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: 'DUST_EXACT111111111111111111111111111111111',
+      output_mint: 'SOL',
+      amount: 200,
+    })
+  })
+
   it('should accept object input { skipMints: [] } without throwing error', async () => {
     const mockBalances = { tokens: [] }
     vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
 
     const result = await swapAllTokensToSol({ skipMints: [] } as any)
     expect(result.total).toBe(0)
+  })
+})
+
+describe('ToolExecutor - swapBaseToSolWithRetry', () => {
+  const originalDelay = config.management.autoSwapRetryDelayMs
+  const originalAttempts = config.management.autoSwapRetryAttempts
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    config.management.autoSwapRetryDelayMs = 0
+    config.management.autoSwapRetryAttempts = 3
+  })
+
+  afterEach(() => {
+    config.management.autoSwapRetryDelayMs = originalDelay
+    config.management.autoSwapRetryAttempts = originalAttempts
+  })
+
+  it('swaps unpriced tokens (usd: null) when balance > 0', async () => {
+    const baseMint = 'UNPRICED_TOKEN_MINT_11111111111111111111'
+    const mockBalances = {
+      tokens: [{ mint: baseMint, symbol: 'UNP', balance: 1200, usd: null }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: true,
+      tx: 'tx-unp-123',
+      amount_out: '0.08',
+    } as any)
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test unpriced')
+
+    expect(res.swapped).toBe(true)
+    expect(res.result).toMatchObject({ success: true, tx: 'tx-unp-123' })
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1)
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: baseMint,
+      output_mint: 'SOL',
+      amount: 1200,
+    })
+  })
+
+  it('swaps unpriced tokens (usd: undefined) when balance > 0', async () => {
+    const baseMint = 'UNDEF_TOKEN_MINT_1111111111111111111111'
+    const mockBalances = {
+      tokens: [{ mint: baseMint, symbol: 'UND', balance: 850, usd: undefined }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: true,
+      tx: 'tx-und-123',
+      amount_out: '0.05',
+    } as any)
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test undefined usd')
+
+    expect(res.swapped).toBe(true)
+    expect(res.result).toMatchObject({ success: true, tx: 'tx-und-123' })
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: baseMint,
+      output_mint: 'SOL',
+      amount: 850,
+    })
+  })
+
+  it('skips swap when token balance <= 0', async () => {
+    const baseMint = 'ZERO_TOKEN_MINT_1111111111111111111111'
+    const mockBalances = {
+      tokens: [{ mint: baseMint, symbol: 'ZERO', balance: 0, usd: null }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test zero balance')
+
+    expect(res.swapped).toBe(false)
+    expect(res.result).toBeNull()
+    expect(WalletAdapter.swapToken).not.toHaveBeenCalled()
+  })
+
+  it('correctly handles $0.05 dust threshold boundary ($0.049 skipped vs $0.05 swapped)', async () => {
+    const dustMint = 'DUST_MINT_1111111111111111111111111111'
+    const validMint = 'VALID_MINT_111111111111111111111111111'
+
+    // 1. Below threshold: usd = 0.049 (should skip)
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValueOnce({
+      tokens: [{ mint: dustMint, symbol: 'DUST', balance: 100, usd: 0.049 }],
+    } as any)
+
+    const dustRes = await swapBaseToSolWithRetry(dustMint, 'test dust')
+    expect(dustRes.swapped).toBe(false)
+    expect(WalletAdapter.swapToken).not.toHaveBeenCalled()
+
+    // 2. Exactly at threshold: usd = 0.05 (should NOT skip, should swap)
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValueOnce({
+      tokens: [{ mint: validMint, symbol: 'VALID', balance: 200, usd: 0.05 }],
+    } as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValueOnce({
+      success: true,
+      tx: 'tx-valid-50',
+      amount_out: '0.0003',
+    } as any)
+
+    const validRes = await swapBaseToSolWithRetry(validMint, 'test boundary')
+    expect(validRes.swapped).toBe(true)
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1)
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: validMint,
+      output_mint: 'SOL',
+      amount: 200,
+    })
+  })
+
+  it('retries unpriced token (usd: null) on transient failure and succeeds on attempt 2', async () => {
+    const baseMint = 'RETRY_TOKEN_MINT_111111111111111111111'
+    const mockBalances = {
+      tokens: [{ mint: baseMint, symbol: 'RETRY', balance: 500, usd: null }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+
+    // Attempt 1 fails, Attempt 2 succeeds
+    vi.mocked(WalletAdapter.swapToken)
+      .mockResolvedValueOnce({ success: false, error: 'Slippage exceeded' } as any)
+      .mockResolvedValueOnce({ success: true, tx: 'tx-retry-success', amount_out: '0.04' } as any)
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test retry')
+
+    expect(res.swapped).toBe(true)
+    expect(res.result).toMatchObject({ success: true, tx: 'tx-retry-success' })
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(2)
+  })
+
+  it('records failure and gracefully handles when all retry attempts fail for unpriced token', async () => {
+    const baseMint = 'FAIL_TOKEN_MINT_1111111111111111111111'
+    const mockBalances = {
+      tokens: [{ mint: baseMint, symbol: 'FAIL', balance: 500, usd: null }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({ success: false, error: 'No route found' } as any)
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test all fail')
+
+    expect(res.swapped).toBe(false)
+    expect(res.result).toBeNull()
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(3)
   })
 })
 
@@ -231,5 +420,57 @@ describe('ToolExecutor - close_position auto-swap', () => {
       output_mint: 'SOL',
       amount: 2500,
     })
+  })
+
+  it('auto-swaps unpriced base token (usd: undefined) back to SOL upon close', async () => {
+    const baseMint = 'BASE_UNDEF_TOKEN_1111111111111111111111'
+    vi.mocked(MeteoraAdapter.closePosition).mockResolvedValue({
+      success: true,
+      position: 'pos-456',
+      base_mint: baseMint,
+    } as any)
+
+    const mockBalances = {
+      sol_price: 150,
+      tokens: [{ mint: baseMint, symbol: 'UNDEF', balance: 1000, usd: undefined }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: true,
+      tx: 'swap-tx-undef',
+      amount_out: '0.09',
+    } as any)
+
+    const result = (await executeTool('close_position', { position_address: 'pos-456' })) as any
+
+    expect(result.success).toBe(true)
+    expect(result.auto_swapped).toBe(true)
+    expect(result.sol_received).toBe('0.09')
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith({
+      input_mint: baseMint,
+      output_mint: 'SOL',
+      amount: 1000,
+    })
+  })
+
+  it('does not auto-swap when base token is dust (usd: 0.049)', async () => {
+    const baseMint = 'BASE_DUST_TOKEN_1111111111111111111111'
+    vi.mocked(MeteoraAdapter.closePosition).mockResolvedValue({
+      success: true,
+      position: 'pos-789',
+      base_mint: baseMint,
+    } as any)
+
+    const mockBalances = {
+      sol_price: 150,
+      tokens: [{ mint: baseMint, symbol: 'DUST', balance: 50, usd: 0.049 }],
+    }
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+
+    const result = (await executeTool('close_position', { position_address: 'pos-789' })) as any
+
+    expect(result.success).toBe(true)
+    expect(result.auto_swapped).toBeUndefined()
+    expect(WalletAdapter.swapToken).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -839,9 +839,10 @@ async function withDeployPositionLock<T>(operation: () => Promise<T>): Promise<T
  * fills). Treats both a throw AND result.success===false / missing tx as failure.
  * Returns { swapped, result, token } — swapped=false if nothing to do or all attempts failed.
  */
-async function swapBaseToSolWithRetry(
+export async function swapBaseToSolWithRetry(
   baseMint: string,
   label: string,
+  minUsd: number = 0.05,
 ): Promise<{
   swapped: boolean
   result: Record<string, unknown> | null
@@ -860,8 +861,8 @@ async function swapBaseToSolWithRetry(
       if (!token || token.balance <= 0) {
         return { swapped: attempt > 1, result: null, token: null }
       }
-      // If USD value is known and strictly below dust threshold (< $0.05), skip swap
-      if (typeof token.usd === 'number' && token.usd > 0 && token.usd < 0.05) {
+      // If USD value is known and strictly below dust threshold (< minUsd), skip swap
+      if (typeof token.usd === 'number' && token.usd > 0 && token.usd < minUsd) {
         return { swapped: attempt > 1, result: null, token: null }
       }
       lastToken = token
@@ -976,7 +977,7 @@ export async function swapAllTokensToSol(skipMintsInput: string[] | { skipMints?
     swapAttempted = true
 
     try {
-      const res = await swapBaseToSolWithRetry(token.mint, 'batch cleanup')
+      const res = await swapBaseToSolWithRetry(token.mint, 'batch cleanup', 0.02)
       if (res.swapped) {
         successful++
         results.push({ mint: token.mint, success: true, result: res.result })

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -857,13 +857,18 @@ async function swapBaseToSolWithRetry(
     try {
       const balances = await getWalletBalances()
       const token = balances.tokens?.find((t: any) => t.mint === baseMint)
-      if (!token || (token.usd ?? 0) < 0.1) {
+      if (!token || token.balance <= 0) {
+        return { swapped: attempt > 1, result: null, token: null }
+      }
+      // If USD value is known and strictly below dust threshold (< $0.05), skip swap
+      if (typeof token.usd === 'number' && token.usd > 0 && token.usd < 0.05) {
         return { swapped: attempt > 1, result: null, token: null }
       }
       lastToken = token
+      const usdDisplay = typeof token.usd === 'number' ? ` ($${token.usd.toFixed(2)})` : ''
       log(
         'executor',
-        `Auto-swapping ${label} ${token.symbol || baseMint.slice(0, 8)} ($${(token.usd ?? 0).toFixed(2)}) back to SOL (attempt ${attempt}/${attempts})`,
+        `Auto-swapping ${label} ${token.symbol || baseMint.slice(0, 8)}${usdDisplay} back to SOL (attempt ${attempt}/${attempts})`,
       )
       const swapResult = await swapToken({ input_mint: baseMint, output_mint: 'SOL', amount: token.balance })
       const sr = swapResult as any
@@ -955,9 +960,10 @@ export async function swapAllTokensToSol(skipMintsInput: string[] | { skipMints?
     total++
     const symbolUpper = (token.symbol || '').toUpperCase()
     const isSolOrUsdc = symbolUpper === 'SOL' || symbolUpper === 'WSOL' || symbolUpper === 'USDC'
-    const isDust = (token.usd ?? 0) < 0.02 // 2 usd cents is still more than SOL network fee
+    const isDust = typeof token.usd === 'number' && token.usd > 0 && token.usd < 0.02
+    const hasBalance = (token.balance ?? 0) > 0
 
-    if (skips.has(token.mint) || isSolOrUsdc || isDust) {
+    if (skips.has(token.mint) || isSolOrUsdc || !hasBalance || isDust) {
       skipped++
       continue
     }


### PR DESCRIPTION
## Summary
Fixes a critical bug where SPL tokens with unpriced USD values (`token.usd: null` or missing price API feeds) were treated as `$0.00` (< $0.10 dust), causing the auto-swap after position close and `swapAllTokensToSol` batch sweeps to silently exit and leave tokens unsold in the wallet.

Closes #228

## Root Cause & Gap Analysis
- **Why/When it happened**: When external price APIs (Jupiter Price API v2) fail, rate-limit, or lack metadata for newly graduated tokens, `getWalletBalances()` leaves `token.usd = null`. In `ToolExecutor.ts`, `(token.usd ?? 0) < 0.1` evaluated to `true`, causing `swapBaseToSolWithRetry` and `swapAllTokensToSol` to treat active tokens as dust and skip swaps silently.
- **Why we missed it**: Prior unit tests only tested tokens with explicit positive USD prices (`usd: 25.5`) or explicit dust prices (`usd: 0.01`). None tested `usd: null` with positive balances.

## Musk Algorithm Simplification
1. **Question Requirement:** USD price should not gate selling LP returned tokens. If `token.balance > 0`, the token must be swapped back to SOL.
2. **Delete/Simplify:** Only skip if `token.balance <= 0` or if `typeof token.usd === 'number'` is explicitly below dust threshold.
3. **Automate:** Added comprehensive unit tests in `ToolExecutor.test.ts`.

## Acceptance Criteria Checklist
- [x] AC1: `swapBaseToSolWithRetry` attempts swap for any token with `token.balance > 0` when `token.usd` is `null` or `undefined`.
- [x] AC2: `swapAllTokensToSol` includes unpriced tokens with positive balance in the sweep.
- [x] AC3: Truly dust tokens (explicitly `usd < 0.02`) and zero-balance tokens are skipped cleanly.
- [x] AC4: Regression unit tests added in `ToolExecutor.test.ts` and all 241 unit/integration tests pass.

## Testing Plan
- [x] **CI / Automated Tests:** `npm test` runs 29 test suites and 241 tests cleanly.
- [x] **Unit Tests:** `packages/core/src/adapters/ToolExecutor.test.ts` covers unpriced tokens for both auto-swap and batch sweeps.