### PR TITLE
feat(agent-loop): serialize write tool executions with concurrency queue to prevent RPC/API 429 floods

### DIFF
--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -379,6 +379,43 @@ describe('ToolExecutor - deploy_position serialization', () => {
     })
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1)
   })
+
+  it('serializes concurrent swap_token calls to prevent parallel execution', async () => {
+    let inFlightSwaps = 0
+    let maxInFlightSwaps = 0
+    let releaseFirstSwap!: () => void
+    const firstSwapFinished = new Promise<void>((resolve) => {
+      releaseFirstSwap = resolve
+    })
+
+    vi.mocked(WalletAdapter.swapToken).mockImplementation(async () => {
+      inFlightSwaps++
+      maxInFlightSwaps = Math.max(maxInFlightSwaps, inFlightSwaps)
+      if (inFlightSwaps === 1) await firstSwapFinished
+      inFlightSwaps--
+      return { success: true, tx: `tx-${Date.now()}` } as any
+    })
+
+    const swap1 = executeTool('swap_token', {
+      input_mint: 'TOKEN_A',
+      output_mint: 'SOL',
+      amount: 100,
+    })
+    const swap2 = executeTool('swap_token', {
+      input_mint: 'TOKEN_B',
+      output_mint: 'SOL',
+      amount: 200,
+    })
+
+    await vi.waitFor(() => expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1))
+    expect(maxInFlightSwaps).toBe(1)
+
+    releaseFirstSwap()
+    await Promise.all([swap1, swap2])
+
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(2)
+    expect(maxInFlightSwaps).toBe(1)
+  })
 })
 
 describe('ToolExecutor - close_position auto-swap', () => {

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -2,7 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { config } from '../config/Config.js'
 import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js'
 import * as WalletAdapter from './blockchain/WalletAdapter.js'
-import { executeTool, swapAllTokensToSol, swapBaseToSolWithRetry } from './ToolExecutor.js'
+import {
+  closeAllPositions,
+  executeTool,
+  swapAllTokensToSol,
+  swapBaseToSolWithRetry,
+  WRITE_TOOLS,
+  writeToolsMutex,
+} from './ToolExecutor.js'
 
 // Mock the WalletAdapter functions
 vi.mock('./blockchain/WalletAdapter.js', () => ({
@@ -380,6 +387,45 @@ describe('ToolExecutor - deploy_position serialization', () => {
     expect(MeteoraAdapter.deployPosition).toHaveBeenCalledTimes(1)
   })
 
+  it('defines WRITE_TOOLS containing all mutating tools and locks writeToolsMutex during execution', async () => {
+    expect(WRITE_TOOLS).toEqual(
+      new Set([
+        'deploy_position',
+        'claim_fees',
+        'close_position',
+        'close_all_positions',
+        'swap_token',
+        'swap_all_tokens_to_sol',
+      ]),
+    )
+
+    let lockObserved = false
+    let releaseSwap!: () => void
+    const swapFinished = new Promise<void>((resolve) => {
+      releaseSwap = resolve
+    })
+
+    vi.mocked(WalletAdapter.swapToken).mockImplementation(async () => {
+      lockObserved = writeToolsMutex.isLocked()
+      await swapFinished
+      return { success: true, tx: 'swap-tx' } as any
+    })
+
+    expect(writeToolsMutex.isLocked()).toBe(false)
+    const pendingSwap = executeTool('swap_token', {
+      input_mint: 'TOKEN_A',
+      output_mint: 'SOL',
+      amount: 100,
+    })
+
+    await vi.waitFor(() => expect(writeToolsMutex.isLocked()).toBe(true))
+    releaseSwap()
+    await pendingSwap
+
+    expect(lockObserved).toBe(true)
+    expect(writeToolsMutex.isLocked()).toBe(false)
+  })
+
   it('serializes concurrent swap_token calls to prevent parallel execution', async () => {
     let inFlightSwaps = 0
     let maxInFlightSwaps = 0
@@ -415,6 +461,230 @@ describe('ToolExecutor - deploy_position serialization', () => {
 
     expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(2)
     expect(maxInFlightSwaps).toBe(1)
+  })
+
+  it('serializes concurrent claim_fees calls', async () => {
+    let inFlightClaims = 0
+    let maxInFlightClaims = 0
+    let releaseFirstClaim!: () => void
+    const firstClaimFinished = new Promise<void>((resolve) => {
+      releaseFirstClaim = resolve
+    })
+
+    vi.mocked(MeteoraAdapter.claimFees).mockImplementation(async () => {
+      inFlightClaims++
+      maxInFlightClaims = Math.max(maxInFlightClaims, inFlightClaims)
+      if (inFlightClaims === 1) await firstClaimFinished
+      inFlightClaims--
+      return { success: true, tx: `tx-claim-${Date.now()}` } as any
+    })
+
+    const claim1 = executeTool('claim_fees', { position_address: 'pos-1' })
+    const claim2 = executeTool('claim_fees', { position_address: 'pos-2' })
+
+    await vi.waitFor(() => expect(MeteoraAdapter.claimFees).toHaveBeenCalledTimes(1))
+    expect(maxInFlightClaims).toBe(1)
+
+    releaseFirstClaim()
+    await Promise.all([claim1, claim2])
+
+    expect(MeteoraAdapter.claimFees).toHaveBeenCalledTimes(2)
+    expect(maxInFlightClaims).toBe(1)
+  })
+
+  it('serializes concurrent close_position calls', async () => {
+    let inFlightCloses = 0
+    let maxInFlightCloses = 0
+    let releaseFirstClose!: () => void
+    const firstCloseFinished = new Promise<void>((resolve) => {
+      releaseFirstClose = resolve
+    })
+
+    vi.mocked(MeteoraAdapter.closePosition).mockImplementation(async () => {
+      inFlightCloses++
+      maxInFlightCloses = Math.max(maxInFlightCloses, inFlightCloses)
+      if (inFlightCloses === 1) await firstCloseFinished
+      inFlightCloses--
+      return { success: true, position: 'pos-closed' } as any
+    })
+
+    const close1 = executeTool('close_position', { position_address: 'pos-1', skip_swap: true })
+    const close2 = executeTool('close_position', { position_address: 'pos-2', skip_swap: true })
+
+    await vi.waitFor(() => expect(MeteoraAdapter.closePosition).toHaveBeenCalledTimes(1))
+    expect(maxInFlightCloses).toBe(1)
+
+    releaseFirstClose()
+    await Promise.all([close1, close2])
+
+    expect(MeteoraAdapter.closePosition).toHaveBeenCalledTimes(2)
+    expect(maxInFlightCloses).toBe(1)
+  })
+
+  it('serializes close_all_positions without deadlocking on internal close_position calls', async () => {
+    vi.mocked(MeteoraAdapter.getMyPositions).mockResolvedValue({
+      positions: [
+        { position: 'pos-1', base_mint: 'mint1', pool: 'pool1' },
+        { position: 'pos-2', base_mint: 'mint2', pool: 'pool2' },
+      ],
+      total_positions: 2,
+    } as any)
+
+    vi.mocked(MeteoraAdapter.closePosition).mockResolvedValue({
+      success: true,
+      position: 'pos-closed',
+      base_mint: 'mint1',
+      pool_name: 'pool1',
+    } as any)
+
+    const result = (await executeTool('close_all_positions', { skip_swap: true })) as any
+
+    expect(result).toBeDefined()
+    expect(result.successful).toBe(2)
+    expect(MeteoraAdapter.closePosition).toHaveBeenCalledTimes(2)
+
+    // Also verify direct function invocation works
+    const directResult = await closeAllPositions(true)
+    expect(directResult.successful).toBe(2)
+    expect(MeteoraAdapter.closePosition).toHaveBeenCalledTimes(4)
+  })
+
+  it('serializes swap_all_tokens_to_sol calls', async () => {
+    let inFlightBatchSwaps = 0
+    let maxInFlightBatchSwaps = 0
+    let releaseFirstBatch!: () => void
+    const firstBatchFinished = new Promise<void>((resolve) => {
+      releaseFirstBatch = resolve
+    })
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({
+      tokens: [{ mint: 'TOKEN_XYZ', symbol: 'XYZ', balance: 100, usd: 5 }],
+    } as any)
+
+    vi.mocked(WalletAdapter.swapToken).mockImplementation(async () => {
+      inFlightBatchSwaps++
+      maxInFlightBatchSwaps = Math.max(maxInFlightBatchSwaps, inFlightBatchSwaps)
+      if (inFlightBatchSwaps === 1) await firstBatchFinished
+      inFlightBatchSwaps--
+      return { success: true, tx: 'batch-tx' } as any
+    })
+
+    const batch1 = executeTool('swap_all_tokens_to_sol', {})
+    const batch2 = executeTool('swap_all_tokens_to_sol', {})
+
+    await vi.waitFor(() => expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1))
+    expect(maxInFlightBatchSwaps).toBe(1)
+
+    releaseFirstBatch()
+    await Promise.all([batch1, batch2])
+
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(2)
+    expect(maxInFlightBatchSwaps).toBe(1)
+  })
+
+  it('serializes heterogeneous write tools (swap_token vs deploy_position vs claim_fees)', async () => {
+    let inFlightWrites = 0
+    let maxInFlightWrites = 0
+    let releaseFirstWrite!: () => void
+    const firstWriteFinished = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve
+    })
+
+    vi.mocked(WalletAdapter.swapToken).mockImplementation(async () => {
+      inFlightWrites++
+      maxInFlightWrites = Math.max(maxInFlightWrites, inFlightWrites)
+      if (inFlightWrites === 1) await firstWriteFinished
+      inFlightWrites--
+      return { success: true, tx: 'swap-tx' } as any
+    })
+
+    vi.mocked(MeteoraAdapter.claimFees).mockImplementation(async () => {
+      inFlightWrites++
+      maxInFlightWrites = Math.max(maxInFlightWrites, inFlightWrites)
+      inFlightWrites--
+      return { success: true, tx: 'claim-tx' } as any
+    })
+
+    const write1 = executeTool('swap_token', {
+      input_mint: 'TOKEN_A',
+      output_mint: 'SOL',
+      amount: 10,
+    })
+    const write2 = executeTool('claim_fees', {
+      position_address: 'pos-1',
+    })
+
+    await vi.waitFor(() => expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1))
+    expect(maxInFlightWrites).toBe(1)
+
+    releaseFirstWrite()
+    await Promise.all([write1, write2])
+
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1)
+    expect(MeteoraAdapter.claimFees).toHaveBeenCalledTimes(1)
+    expect(maxInFlightWrites).toBe(1)
+  })
+
+  it('allows concurrent read-only tools without lock contention', async () => {
+    let inFlightReads = 0
+    let maxInFlightReads = 0
+    let releaseReads!: () => void
+    const readsHoldPromise = new Promise<void>((resolve) => {
+      releaseReads = resolve
+    })
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockImplementation(async () => {
+      inFlightReads++
+      maxInFlightReads = Math.max(maxInFlightReads, inFlightReads)
+      await readsHoldPromise
+      inFlightReads--
+      return { sol: 5, tokens: [] } as any
+    })
+
+    const read1 = executeTool('get_wallet_balance', {})
+    const read2 = executeTool('get_wallet_balance', {})
+    const read3 = executeTool('get_wallet_balance', {})
+
+    await vi.waitFor(() => expect(inFlightReads).toBe(3))
+    expect(maxInFlightReads).toBe(3)
+    expect(writeToolsMutex.isLocked()).toBe(false)
+
+    releaseReads()
+    await Promise.all([read1, read2, read3])
+  })
+
+  it('allows read tools to execute concurrently while a write tool holds the mutex (mixed contention)', async () => {
+    let releaseWrite!: () => void
+    const writeHoldPromise = new Promise<void>((resolve) => {
+      releaseWrite = resolve
+    })
+
+    vi.mocked(WalletAdapter.swapToken).mockImplementation(async () => {
+      await writeHoldPromise
+      return { success: true, tx: 'swap-tx' } as any
+    })
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({
+      sol: 10,
+      tokens: [],
+    } as any)
+
+    const pendingWrite = executeTool('swap_token', {
+      input_mint: 'TOKEN_A',
+      output_mint: 'SOL',
+      amount: 50,
+    })
+
+    await vi.waitFor(() => expect(writeToolsMutex.isLocked()).toBe(true))
+
+    // Read tool executes and finishes while the write tool is STILL in-flight
+    const readResult = await executeTool('get_wallet_balance', {})
+    expect(readResult).toBeDefined()
+    expect(writeToolsMutex.isLocked()).toBe(true)
+
+    releaseWrite()
+    await pendingWrite
+    expect(writeToolsMutex.isLocked()).toBe(false)
   })
 })
 

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -452,12 +452,12 @@ const toolMap: Record<string, ToolFn> = {
   close_position: closePosition as unknown as ToolFn,
   close_all_positions: ((args: Record<string, unknown> = {}) => {
     const skipSwap = Boolean(args.skipSwap || args.skip_swap)
-    return closeAllPositions(skipSwap)
+    return closeAllPositionsUnlocked(skipSwap)
   }) as ToolFn,
   get_wallet_balance: getWalletBalances as unknown as ToolFn,
   swap_all_tokens_to_sol: ((args: Record<string, unknown> = {}) => {
     const skipMints = (args.skipMints as string[]) || (args.skip_mints as string[]) || []
-    return swapAllTokensToSol(Array.isArray(skipMints) ? skipMints : [])
+    return swapAllTokensToSolUnlocked(Array.isArray(skipMints) ? skipMints : [])
   }) as ToolFn,
   swap_token: swapToken as unknown as ToolFn,
   get_top_lpers: studyTopLPers as unknown as ToolFn,
@@ -823,7 +823,7 @@ const toolMap: Record<string, ToolFn> = {
 
 // ─── Protected tools ───────────────────────────────────────────
 
-const WRITE_TOOLS = new Set([
+export const WRITE_TOOLS = new Set([
   'deploy_position',
   'claim_fees',
   'close_position',
@@ -831,11 +831,11 @@ const WRITE_TOOLS = new Set([
   'swap_token',
   'swap_all_tokens_to_sol',
 ])
-const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update'])
+export const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update'])
 
-const writeToolsMutex = new Mutex()
+export const writeToolsMutex = new Mutex()
 
-async function withWriteToolsLock<T>(operation: () => Promise<T>): Promise<T> {
+export async function withWriteToolsLock<T>(operation: () => Promise<T>): Promise<T> {
   return writeToolsMutex.runExclusive(operation)
 }
 
@@ -936,6 +936,16 @@ export async function swapAllTokensToSol(skipMintsInput: string[] | { skipMints?
   failed: number
   results: any[]
 }> {
+  return withWriteToolsLock(() => swapAllTokensToSolUnlocked(skipMintsInput))
+}
+
+export async function swapAllTokensToSolUnlocked(skipMintsInput: string[] | { skipMints?: string[] } = []): Promise<{
+  total: number
+  skipped: number
+  successful: number
+  failed: number
+  results: any[]
+}> {
   let skipMints: string[] = []
   if (Array.isArray(skipMintsInput)) {
     skipMints = skipMintsInput
@@ -1020,6 +1030,17 @@ export async function closeAllPositions(
   failed: number
   results: any[]
 }> {
+  return withWriteToolsLock(() => closeAllPositionsUnlocked(skipSwapInput))
+}
+
+export async function closeAllPositionsUnlocked(
+  skipSwapInput: boolean | { skipSwap?: boolean; skip_swap?: boolean } = false,
+): Promise<{
+  total: number
+  successful: number
+  failed: number
+  results: any[]
+}> {
   let skipSwap = false
   if (typeof skipSwapInput === 'boolean') {
     skipSwap = skipSwapInput
@@ -1038,7 +1059,7 @@ export async function closeAllPositions(
 
   for (const pos of positions) {
     try {
-      const res = (await executeTool('close_position', {
+      const res = (await executeToolUnlocked('close_position', {
         position_address: pos.position,
         skip_swap: skipSwap,
         reason: 'close all',

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -823,13 +823,20 @@ const toolMap: Record<string, ToolFn> = {
 
 // ─── Protected tools ───────────────────────────────────────────
 
-const WRITE_TOOLS = new Set(['deploy_position', 'claim_fees', 'close_position', 'swap_token'])
+const WRITE_TOOLS = new Set([
+  'deploy_position',
+  'claim_fees',
+  'close_position',
+  'close_all_positions',
+  'swap_token',
+  'swap_all_tokens_to_sol',
+])
 const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update'])
 
-const deployPositionMutex = new Mutex()
+const writeToolsMutex = new Mutex()
 
-async function withDeployPositionLock<T>(operation: () => Promise<T>): Promise<T> {
-  return deployPositionMutex.runExclusive(operation)
+async function withWriteToolsLock<T>(operation: () => Promise<T>): Promise<T> {
+  return writeToolsMutex.runExclusive(operation)
 }
 
 /**
@@ -1065,8 +1072,8 @@ export async function closeAllPositions(
  */
 export async function executeTool(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
   const normalizedName = name.replace(/<.*$/, '').trim()
-  if (normalizedName === 'deploy_position') {
-    return withDeployPositionLock(() => executeToolUnlocked(normalizedName, args))
+  if (WRITE_TOOLS.has(normalizedName)) {
+    return withWriteToolsLock(() => executeToolUnlocked(normalizedName, args))
   }
   return executeToolUnlocked(normalizedName, args)
 }

--- a/packages/core/src/shared/mutex.ts
+++ b/packages/core/src/shared/mutex.ts
@@ -5,27 +5,24 @@
 
 export class Mutex {
   private queue: Promise<void> = Promise.resolve()
+  private _locked = false
+
+  /**
+   * Return true if the mutex is currently locked.
+   */
+  isLocked(): boolean {
+    return this._locked
+  }
 
   /**
    * Execute an asynchronous or synchronous callback exclusively under the mutex lock.
    */
   async runExclusive<T>(fn: () => Promise<T> | T): Promise<T> {
-    let release!: () => void
-    const waiter = new Promise<void>((resolve) => {
-      release = resolve
-    })
-
-    const previous = this.queue
-    this.queue = previous.then(
-      () => waiter,
-      () => waiter,
-    )
-
-    await previous
+    const release = await this.acquire()
     try {
       return await fn()
     } finally {
-      release?.()
+      release()
     }
   }
 
@@ -45,6 +42,10 @@ export class Mutex {
     )
 
     await previous
-    return release!
+    this._locked = true
+    return () => {
+      this._locked = false
+      release?.()
+    }
   }
 }


### PR DESCRIPTION
## Summary
Serializes all blockchain mutating write tools (`deploy_position`, `claim_fees`, `close_position`, `close_all_positions`, `swap_token`, `swap_all_tokens_to_sol`) behind a shared `writeToolsMutex` in `ToolExecutor.ts`. This ensures write operations dispatched in the same LLM turn execute exclusively one-by-one, preventing concurrent RPC and DEX API rate limit bursts.

Closes #229

## Root Cause & Gap Analysis
- **Why/When it happened**: When the LLM decided to swap multiple tokens or close multiple positions, `agent-loop.ts` executed all tool calls concurrently in `Promise.all`. Combined with RPC retry logic, this unleashed up to 88 rapid RPC requests and 44 Telegram edits in seconds, hitting `429 Too Many Requests`.
- **Why we missed it**: Only `deploy_position` previously had a mutex lock (`deployPositionMutex`). Other mutating operations like `swap_token` and `close_position` were unlocked and executed concurrently.

## Musk Algorithm Simplification
1. **Question Requirement:** Do write tools need separate, complicated per-tool locks or complex queue infrastructure? No — all write tools hit the same wallet and blockchain RPC state.
2. **Delete/Simplify:** Consolidate onto a single, unified `writeToolsMutex` in `ToolExecutor.ts` covering all tools in `WRITE_TOOLS`. Read tools remain non-blocking and concurrent.
3. **Deadlock Prevention:** De-nest composite tools (`close_all_positions`, `swap_all_tokens_to_sol`) to run internal steps via unlocked execution, eliminating re-entrancy deadlocks under the mutex.
4. **Automate:** Added comprehensive concurrency regression tests in `ToolExecutor.test.ts`.

## Acceptance Criteria Checklist
- [x] AC1: All mutating tools (`deploy_position`, `claim_fees`, `close_position`, `close_all_positions`, `swap_token`, `swap_all_tokens_to_sol`) are members of `WRITE_TOOLS`.
- [x] AC2: `executeTool` executes any tool in `WRITE_TOOLS` through `writeToolsMutex.runExclusive(...)`.
- [x] AC3: Read tools (`get_wallet_balance`, `get_token_info`, `search_pools`, etc.) bypass the lock and execute concurrently.
- [x] AC4: Regression tests in `ToolExecutor.test.ts` verify write tool serialization, mutex locking state, read-tool concurrency, mixed read/write non-blocking execution, and composite tool re-entrancy without deadlocks.

## Testing Plan
- [x] **CI / Automated Tests:** All 29 test suites and 276 tests pass cleanly.
- [x] **Unit Tests:** `packages/core/src/adapters/ToolExecutor.test.ts` validates that concurrent write tool dispatches never exceed concurrency of 1, read tools run in parallel, and mixed contention is non-blocking.