### PR TITLE
[Daemon] Drain telegram queue on cycle lock release and prioritize /stop

### DIFF
--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -375,3 +375,183 @@ describe('getDeterministicCloseRule suspect PnL handling', () => {
     })
   })
 })
+
+describe('Telegram /stop & Busy Cycle Queue Draining (#236)', () => {
+  let adapters: DaemonAdapters
+  let daemon: Daemon
+  let exitSpy: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
+    adapters = createMockAdapters()
+    adapters.telegram.isEnabled = () => true
+    daemon = new Daemon(adapters)
+  })
+
+  it('AC-1: queues /stop during active management cycle and shuts down on lock release', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).managementBusy = true
+
+    // Receive /stop while management is busy
+    await (daemon as any).telegramHandler({ text: '/stop' })
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith(
+      expect.stringContaining('⏳ Queued (1 in queue): "/stop"'),
+    )
+    expect(shutdownSpy).not.toHaveBeenCalled()
+    expect((daemon as any).telegramQueue.length).toBe(1)
+
+    // Release management lock
+    ;(daemon as any).releaseLock('management')
+    // Wait microtasks
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith('🛑 Shutting down agent...')
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+  })
+
+  it('AC-2: queues /stop during active screening cycle and shuts down on lock release', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).screeningBusy = true
+
+    await (daemon as any).telegramHandler({ text: '/stop' })
+    expect(shutdownSpy).not.toHaveBeenCalled()
+
+    // Release screening lock
+    ;(daemon as any).releaseLock('screening')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith('🛑 Shutting down agent...')
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+  })
+
+  it('AC-3: queues /stop during active pnlPoll and shuts down on lock release', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).pnlPollBusy = true
+
+    await (daemon as any).telegramHandler({ text: '/stop' })
+    expect(shutdownSpy).not.toHaveBeenCalled()
+
+    // Release pnlPoll lock
+    ;(daemon as any).releaseLock('pnlPoll')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith('🛑 Shutting down agent...')
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+  })
+
+  it('AC-4: queues /stop during active opportunityPoll and shuts down on lock release', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).opportunityPollBusy = true
+
+    await (daemon as any).telegramHandler({ text: '/stop' })
+    expect(shutdownSpy).not.toHaveBeenCalled()
+
+    // Release opportunityPoll lock
+    ;(daemon as any).releaseLock('opportunityPoll')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith('🛑 Shutting down agent...')
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+  })
+
+  it('AC-5: prioritizes /stop over other queued commands and prevents remaining queue execution', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).managementBusy = true
+
+    // Queue /screen, /stop, /positions
+    await (daemon as any).telegramHandler({ text: '/screen' })
+    await (daemon as any).telegramHandler({ text: '/stop' })
+    await (daemon as any).telegramHandler({ text: '/positions' })
+
+    expect((daemon as any).telegramQueue.length).toBe(3)
+    expect(shutdownSpy).not.toHaveBeenCalled()
+
+    // Release lock to trigger drain
+    ;(daemon as any).releaseLock('management')
+    await new Promise((r) => setTimeout(r, 10))
+
+    // /stop was prioritized and triggered shutdown
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+    expect((daemon as any).shuttingDown).toBe(true)
+  })
+
+  it('AC-6: queues /stop during free-form chat and shuts down on chat completion', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).busy = true
+
+    await (daemon as any).telegramHandler({ text: '/stop' })
+    expect(shutdownSpy).not.toHaveBeenCalled()
+
+    // Simulate chat finally block
+    ;(daemon as any).busy = false
+    await (daemon as any).drainTelegramQueue()
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith('🛑 Shutting down agent...')
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+  })
+
+  it('AC-7: executes immediate shutdown when idle', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+
+    await (daemon as any).telegramHandler({ text: '/stop' })
+
+    expect(adapters.telegram.sendMessage).toHaveBeenCalledWith('🛑 Shutting down agent...')
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+    expect((daemon as any).telegramQueue.length).toBe(0)
+  })
+
+  it('AC-8: shuttingDown flag prevents cycle execution and lock acquisition', async () => {
+    ;(daemon as any).shuttingDown = true
+
+    expect((daemon as any).acquireLock('management')).toBe(false)
+    expect((daemon as any).acquireLock('screening')).toBe(false)
+    expect((daemon as any).acquireLock('pnlPoll')).toBe(false)
+    expect((daemon as any).acquireLock('opportunityPoll')).toBe(false)
+
+    const mgmtRes = await daemon.runManagementCycle()
+    expect(mgmtRes).toBeNull()
+
+    const screenRes = await daemon.runScreeningCycle()
+    expect(screenRes).toBeNull()
+  })
+
+  it('AC-9: drains full queue without starving /stop at the tail', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+    ;(daemon as any).managementBusy = true
+
+    await (daemon as any).telegramHandler({ text: '/status' })
+    await (daemon as any).telegramHandler({ text: '/config' })
+    await (daemon as any).telegramHandler({ text: '/positions' })
+    await (daemon as any).telegramHandler({ text: '/help' })
+    await (daemon as any).telegramHandler({ text: '/stop' })
+
+    expect((daemon as any).telegramQueue.length).toBe(5)
+
+    ;(daemon as any).releaseLock('management')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(shutdownSpy).toHaveBeenCalledWith('telegram /stop')
+  })
+
+  it('Edge Case 1: handles concurrent /stop without duplicate shutdown', async () => {
+    const shutdownSpy = vi.spyOn(daemon as any, 'shutdown')
+
+    await (daemon as any).telegramHandler({ text: '/stop' })
+    await (daemon as any).telegramHandler({ text: '/stop' })
+
+    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Edge Case 4: shutdown proceeds cleanly even if sendMessage fails or throws', async () => {
+    adapters.telegram.sendMessage = vi.fn().mockRejectedValue(new Error('Network offline'))
+    const stopPollingSpy = vi.spyOn(adapters.telegram, 'stopPolling')
+
+    await (daemon as any).shutdown('telegram /stop')
+
+    expect((daemon as any).shuttingDown).toBe(true)
+    expect(stopPollingSpy).toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+})

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -307,6 +307,7 @@ export class Daemon {
    * Prevents overlapping timer ticks or event-loop delays from entering guarded sections concurrently.
    */
   private acquireLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): boolean {
+    if (this.shuttingDown) return false
     switch (lockName) {
       case 'management':
         if (this.managementBusy || this.pnlPollBusy) return false
@@ -345,6 +346,9 @@ export class Daemon {
         this.opportunityPollBusy = false
         break
     }
+    this.drainTelegramQueue().catch((err: any) => {
+      log('telegram_warn', `Failed to drain telegram queue after releasing ${lockName} lock: ${err?.message || err}`)
+    })
   }
 
   // Countdown timer
@@ -935,7 +939,7 @@ After evaluating, write a brief one-line result per position.
   }
 
   async runManagementCycle({ silent = false } = {}): Promise<string | null> {
-    if (!this.acquireLock('management')) return null
+    if (this.shuttingDown || !this.acquireLock('management')) return null
     this.managementLastRun = Date.now()
     log('cron', 'Starting management cycle')
     let mgmtReport: string | null = null
@@ -1139,7 +1143,7 @@ After evaluating, write a brief one-line result per position.
   }
 
   async runScreeningCycle({ silent = false } = {}): Promise<string | null> {
-    if (!this.acquireLock('screening')) {
+    if (this.shuttingDown || !this.acquireLock('screening')) {
       log('cron', 'Screening skipped — previous cycle still running')
       return null
     }
@@ -2074,6 +2078,7 @@ IMPORTANT:
   }
 
   private async telegramHandler(msg: any): Promise<void> {
+    if (this.shuttingDown) return
     const text = msg?.text?.trim()
     if (!text) return
     if (msg?.isCallback && text.startsWith('cfg:')) {
@@ -2093,7 +2098,7 @@ IMPORTANT:
       })
       return
     }
-    if (this.managementBusy || this.screeningBusy || this.pnlPollBusy || this.busy) {
+    if (this.managementBusy || this.screeningBusy || this.pnlPollBusy || this.opportunityPollBusy || this.busy) {
       if (this.telegramQueue.length < this.MAX_TELEGRAM_QUEUE) {
         this.telegramQueue.push(msg)
         await this.sendTelegramSafe(`⏳ Queued (${this.telegramQueue.length} in queue): "${text.slice(0, 60)}"`)
@@ -2520,6 +2525,9 @@ IMPORTANT:
     } finally {
       this.busy = false
       this.refreshPrompt()
+      this.drainTelegramQueue().catch((err: any) => {
+        log('telegram_warn', `Failed to drain telegram queue: ${err?.message || err}`)
+      })
     }
   }
 
@@ -2618,14 +2626,21 @@ IMPORTANT:
   }
 
   private async drainTelegramQueue(): Promise<void> {
+    if (this.shuttingDown) return
     while (
       this.telegramQueue.length > 0 &&
       !this.managementBusy &&
       !this.screeningBusy &&
       !this.pnlPollBusy &&
-      !this.busy
+      !this.opportunityPollBusy &&
+      !this.busy &&
+      !this.shuttingDown
     ) {
-      const queued = this.telegramQueue.shift()
+      const stopIdx = this.telegramQueue.findIndex((m: any) => {
+        const t = (typeof m === 'string' ? m : m?.text)?.trim()
+        return t === '/stop'
+      })
+      const queued = stopIdx !== -1 ? this.telegramQueue.splice(stopIdx, 1)[0] : this.telegramQueue.shift()
       await this.telegramHandler(queued)
     }
   }
@@ -2676,7 +2691,7 @@ IMPORTANT:
     }
 
     const runBusy = async (fn: () => Promise<void>) => {
-      if (this.busy || this.managementBusy || this.screeningBusy || this.pnlPollBusy) {
+      if (this.busy || this.managementBusy || this.screeningBusy || this.pnlPollBusy || this.opportunityPollBusy) {
         console.log('Agent is busy, please wait...')
         rl.prompt()
         return
@@ -2692,6 +2707,9 @@ IMPORTANT:
         rl.setPrompt(this.buildPrompt())
         rl.resume()
         rl.prompt()
+        this.drainTelegramQueue().catch((err: any) => {
+          log('telegram_warn', `Failed to drain telegram queue: ${err?.message || err}`)
+        })
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes an issue where `/stop` sent via Telegram while the daemon was busy executing an autonomous cron cycle (`management`, `screening`, `pnlPoll`, `opportunityPoll`) was queued in `telegramQueue` and never drained or executed.

Closes #236

## Root Cause & Gap Analysis
- **Why/When it happened**:
  1. `telegramHandler()` queued incoming messages when busy guards were active (`managementBusy`, `screeningBusy`, `pnlPollBusy`, `opportunityPollBusy`, `busy`).
  2. `drainTelegramQueue()` was only invoked in the `finally` block of interactive free-form chat.
  3. When autonomous cycles finished and released their locks via `releaseLock()`, `drainTelegramQueue()` was never called.
  4. In commit `8a0577f`, `/stop` was placed after the busy check in `telegramHandler` without connecting cycle lock release to queue draining.
  5. `opportunityPollBusy` was also omitted from busy checks in `telegramHandler`, `drainTelegramQueue`, and `runBusy`.
- **Why we missed it**:
  - Existing tests in `Daemon.test.ts` did not simulate receiving Telegram commands while `managementBusy` or other cycle locks were held.
  - No invariant or test enforced that cycle lock release must drain queued Telegram messages.

## Acceptance Criteria Checklist
- [x] AC-1: `/stop` while management cycle is active queues and triggers shutdown on lock release
- [x] AC-2: `/stop` while screening cycle is active queues and triggers shutdown on lock release
- [x] AC-3: `/stop` while pnlPoll is active queues and triggers shutdown on lock release
- [x] AC-4: `/stop` while opportunityPoll is active queues and triggers shutdown on lock release
- [x] AC-5: Multiple queued commands `["/screen", "/stop", "/positions"]` prioritizes `/stop` and aborts subsequent queued commands
- [x] AC-6: `/stop` during free-form chat queues and shuts down on chat completion
- [x] AC-7: Immediate `/stop` when idle triggers shutdown immediately without queuing
- [x] AC-8: Shutdown flag prevents subsequent cycle execution and lock acquisition
- [x] AC-9: Queue drain does not starve `/stop` at the end of a full queue
- [x] Edge Case 1: Concurrent `/stop` commands handled without duplicate shutdown
- [x] Edge Case 4: Shutdown proceeds cleanly even if `sendMessage` is pending or rejects

## Testing Plan
- [x] **Automated Tests**: Added 11 unit tests in `packages/daemon/src/Daemon.test.ts` covering all ACs and edge cases.
- [x] **CI: Typecheck & Lint**: Zero TypeScript errors (`tsc --noEmit` clean on packages).
- [x] **CI: Automated Tests**: All 29 test files and 250 tests passed (`pnpm test`).