### PR TITLE
fix: wallet keystore format, prompt secret masking, and cjs warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,6 @@ JUPITER_API_KEY=
 # LPAgent position-data lookups. Also set api.lpAgent.enabled=true in user-config.json.
 LPAGENT_API_KEY=
 # Agent Meridian API authentication. Needed for authenticated Meridian requests.
-AGENT_MERIDIAN_PUBLIC_API_KEY=
 DEFAULT_AGENT_MERIDIAN_PUBLIC_KEY=bWVyaWRpYW4taXMtdGhlLWJlc3QtYWdlbnRz
 # GMGN token-fee analysis. Also set gmgn.enabled=true and feeSource="gmgn".
 # Get your free GMGN API key at https://docs.gmgn.ai/index/gmgn-agent-api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,8 @@ For instructions, guidelines, and project rules, please read:
 
 - [AGENTS.local.md](AGENTS.local.md) (Local agent engineering manual)
 - [docs/START_HERE.md](docs/START_HERE.md) (Project documentation index)
+
+## Security & Secrets Boundary
+
+- **NEVER** view, read, grep, cat, or display any files matching `.env*`, `*.prod`, or `.credentials/*`.
+- Refer exclusively to [.env.example](.env.example) and TypeScript schema definitions for configuration reference.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -275,7 +275,7 @@ The `api` block contains two independent services.
 | ----------------------- | -------------------------------------- | --------------------------------------- |
 | `enabled`             | Enable Meridian API requests.          | `true`                                |
 | `url`                 | Meridian API base URL.                 | `"https://api.agentmeridian.xyz/api"` |
-| `publicApiKey`        | Public API key for Meridian endpoints. | `"env.AGENT_MERIDIAN_PUBLIC_API_KEY"` |
+| `publicApiKey`        | Public API key for Meridian endpoints. | `"env.DEFAULT_AGENT_MERIDIAN_PUBLIC_KEY"` |
 | `lpAgentRelayEnabled` | Enable Meridian relay execution.       | `false`                               |
 
 ##### LPAgent

--- a/packages/cli/src/Cli.test.ts
+++ b/packages/cli/src/Cli.test.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { dataPath, LESSONS_FILENAME } from '@etemaro/core'
+import { dataPath, LESSONS_FILENAME, wallet } from '@etemaro/core'
 import { describe, expect, it, vi } from 'vitest'
 import { applyCliRuntimeFlags, Cli, formatConfigLoadError, loadCore, resolveGlobalFlagValue } from './Cli.js'
 
@@ -246,5 +246,38 @@ describe('Cli handleStart', () => {
 
     await cli.run(['start', '--headless'])
     expect(mockDaemon.start).toHaveBeenCalledWith({ tty: false })
+  })
+})
+
+describe('Cli handleGenerateWallet', () => {
+  it('calls wallet.generateNewWallet and reports correct savedTo path', async () => {
+    await loadCore()
+    const generateSpy = vi.spyOn(wallet, 'generateNewWallet').mockReturnValue({
+      publicKey: 'mockPubKey123',
+      privateKey: 'mockPrivKey456',
+      createdAt: new Date().toISOString(),
+      label: 'my-wallet',
+      savedTo: '/path/to/.credentials/wallets/my-wallet.json',
+    })
+    const cli = new Cli({} as any)
+    let stdoutOutput = ''
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
+    const mockStdout = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      stdoutOutput += String(chunk)
+      return true
+    })
+
+    try {
+      ;(cli as any).handleGenerateWallet({ name: 'my-wallet' })
+      expect(generateSpy).toHaveBeenCalledWith({ label: 'my-wallet' })
+      const parsed = JSON.parse(stdoutOutput)
+      expect(parsed.success).toBe(true)
+      expect(parsed.savedTo).toBe('/path/to/.credentials/wallets/my-wallet.json')
+      expect(parsed.label).toBe('my-wallet')
+    } finally {
+      generateSpy.mockRestore()
+      mockExit.mockRestore()
+      mockStdout.mockRestore()
+    }
   })
 })

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -14,12 +14,57 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { stdin as stdinStream, stdout as stdoutStream } from 'node:process'
+import nodeReadline from 'node:readline'
 import readline from 'node:readline/promises'
+import { Writable } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
 import type { GeneratedWallet } from '@etemaro/core'
 import { Keypair } from '@solana/web3.js'
 import bs58 from 'bs58'
+
+/**
+ * Prompt for a sensitive secret (such as a private key) without echoing input to terminal stdout.
+ */
+async function promptSecret(promptText: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    const rl = readline.createInterface({ input: stdinStream, output: stdoutStream })
+    try {
+      const answer = await rl.question(promptText)
+      return answer.trim()
+    } finally {
+      rl.close()
+    }
+  }
+
+  return new Promise((resolve) => {
+    let muted = false
+    const mutableStdout = new Writable({
+      write(chunk, encoding, callback) {
+        if (!muted) {
+          stdoutStream.write(chunk, encoding)
+        }
+        callback()
+      },
+    })
+
+    const rl = nodeReadline.createInterface({
+      input: stdinStream,
+      output: mutableStdout,
+      terminal: true,
+    })
+
+    stdoutStream.write(promptText)
+    muted = true
+
+    rl.question('', (answer) => {
+      muted = false
+      stdoutStream.write('\n')
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
 
 function loadJsonFile<T>(filePath: string, fallback: T): T {
   try {
@@ -96,6 +141,9 @@ let hivemind: CoreExports['hivemind'] = null as any
 let tools: CoreExports['tools'] = null as any
 let defaultUserConfigStr: CoreExports['defaultUserConfigStr'] = null as any
 let DEFAULT_STRATEGIES: CoreExports['DEFAULT_STRATEGIES'] = null as any
+// Used to disable the global logger's [DRY RUN] tag during real keystore operations
+// (e.g. wallet import/generate), where core's default config otherwise sets dryRun: true.
+let _setDryRun: CoreExports['setDryRun'] = null as any
 
 // Lazily populated Daemon constructor
 let DaemonCtor: DaemonExports['Daemon'] = null as any
@@ -136,6 +184,7 @@ export async function loadCore(): Promise<void> {
   tools = coreMod.tools
   defaultUserConfigStr = coreMod.defaultUserConfigStr
   DEFAULT_STRATEGIES = coreMod.DEFAULT_STRATEGIES
+  _setDryRun = coreMod.setDryRun
   // Assign Daemon constructor
   DaemonCtor = daemonMod.Daemon
 }
@@ -732,6 +781,8 @@ export class Cli {
   }
 
   private handleGenerateWallet(flags: Record<string, any>): void {
+    // Administrative keystore operations are live disk writes, not dry-run simulations
+    _setDryRun?.(false)
     const configDir = path.join(this.etemaroDir, 'config')
     const alias = flags.name || flags.label || 'default'
     const result = wallet.generateNewWallet({
@@ -744,7 +795,7 @@ export class Cli {
       privateKey: result.privateKey,
       createdAt: result.createdAt,
       label: result.label,
-      savedTo: path.join(configDir, 'wallets.json'),
+      savedTo: path.join(this.etemaroDir, '.credentials', 'wallets', `${alias}.json`),
       message: `New Solana wallet generated and saved as "${alias}"`,
     })
   }
@@ -757,12 +808,11 @@ export class Cli {
     if (!privateKey && flags.file) {
       // File import handled by wallet.importWallet
     } else if (!privateKey && flags.prompt) {
-      const readline = await import('node:readline/promises')
-      const rl = readline.createInterface({ input: stdinStream, output: stdoutStream })
-      privateKey = await rl.question('Enter Base58 private key: ')
-      rl.close()
+      privateKey = await promptSecret('Enter Base58 private key: ')
     }
 
+    // Administrative keystore operations are live disk writes, not dry-run simulations
+    _setDryRun?.(false)
     const result = wallet.importWallet({
       label: alias,
       privateKey,
@@ -796,14 +846,16 @@ export class Cli {
             try {
               const raw = JSON.parse(fs.readFileSync(fullPath, 'utf8'))
               let key: string | null = null
-              if (Array.isArray(raw)) {
-                key = bs58.encode(Uint8Array.from(raw))
-              } else if (typeof raw === 'string') {
-                key = raw
-              } else if (raw.privateKey) {
-                key = raw.privateKey
+              let pubKey: string | undefined
+              if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+                if (typeof raw.publicKey === 'string' && raw.publicKey.trim().length > 0) {
+                  pubKey = raw.publicKey.trim()
+                }
+                if (typeof raw.privateKey === 'string' && raw.privateKey.trim().length > 0) {
+                  key = raw.privateKey.trim()
+                }
               }
-              const pk = key ? Keypair.fromSecretKey(bs58.decode(key)).publicKey.toBase58() : undefined
+              const pk = pubKey || (key ? Keypair.fromSecretKey(bs58.decode(key)).publicKey.toBase58() : undefined)
               if (!walletsMap.has(alias)) {
                 walletsMap.set(alias, { alias, publicKey: pk, path: fullPath })
               }
@@ -854,15 +906,56 @@ export class Cli {
       console.error('Export cancelled.')
       return
     }
-    const walletPath = path.join(this.etemaroDir, 'config', 'wallets.json')
-    const existing = loadJsonFile<{ wallets: GeneratedWallet[] }>(walletPath, { wallets: [] })
-    const found = existing.wallets?.find((w) => w.label === alias)
-    if (!found) die(`Wallet alias not found: ${alias}`)
+
+    // Check secure keystore first (.credentials/wallets/<alias>.json)
+    let foundPub: string | undefined
+    let foundPriv: string | undefined
+
+    const credDirs = [
+      path.join(getEtemaroDir(), '.credentials', 'wallets'),
+      path.join(_REPO_ROOT, 'config', '.credentials', 'wallets'),
+    ]
+    for (const dir of credDirs) {
+      const credFile = path.join(dir, `${alias}.json`)
+      if (fs.existsSync(credFile)) {
+        try {
+          const raw = JSON.parse(fs.readFileSync(credFile, 'utf8'))
+          if (
+            typeof raw === 'object' &&
+            raw !== null &&
+            typeof raw.privateKey === 'string' &&
+            raw.privateKey.trim().length > 0
+          ) {
+            const priv = raw.privateKey.trim()
+            foundPriv = priv
+            foundPub =
+              typeof raw.publicKey === 'string' && raw.publicKey.trim().length > 0
+                ? raw.publicKey.trim()
+                : Keypair.fromSecretKey(bs58.decode(priv)).publicKey.toBase58()
+            break
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    if (!foundPriv) {
+      const walletPath = path.join(this.etemaroDir, 'config', 'wallets.json')
+      const existing = loadJsonFile<{ wallets: GeneratedWallet[] }>(walletPath, { wallets: [] })
+      const found = existing.wallets?.find((w) => w.label === alias)
+      if (found) {
+        foundPub = found.publicKey
+        foundPriv = found.privateKey
+      }
+    }
+
+    if (!foundPriv) die(`Wallet alias not found: ${alias}`)
 
     out({
-      alias: found.label,
-      publicKey: found.publicKey,
-      privateKey: found.privateKey,
+      alias,
+      publicKey: foundPub,
+      privateKey: foundPriv,
       warning: 'Private key exposed - handle with care!',
     })
   }
@@ -1178,7 +1271,9 @@ export class Cli {
           }
           case '2': {
             const label = (await rl.question('Enter wallet alias: ')) || 'default'
-            const key = await rl.question('Enter Base58 private key: ')
+            const key = await promptSecret('Enter Base58 private key: ')
+            // Administrative keystore operations are live disk writes, not dry-run simulations
+            _setDryRun?.(false)
             const result = this.adapters.wallet.importWallet({ label, privateKey: key })
             console.log(`Imported wallet ${result.publicKey} as "${label}"`)
             const configObj = JSON.parse(fs.readFileSync(_USER_CONFIG_PATH, 'utf8'))

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -73,7 +73,7 @@ async function promptSecret(promptText: string): Promise<string> {
   })
 }
 
-function loadJsonFile<T>(filePath: string, fallback: T): T {
+function _loadJsonFile<T>(filePath: string, fallback: T): T {
   try {
     if (!fs.existsSync(filePath)) return fallback
     return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T
@@ -844,23 +844,16 @@ export class Cli {
             const fullPath = path.join(dir, f)
             try {
               const raw = JSON.parse(fs.readFileSync(fullPath, 'utf8'))
-              let key: string | null = null
               let pubKey: string | undefined
-              if (Array.isArray(raw)) {
-                key = bs58.encode(Uint8Array.from(raw))
-              } else if (typeof raw === 'string' && raw.trim().length > 0) {
-                key = raw.trim()
-              } else if (typeof raw === 'object' && raw !== null) {
+              if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
                 if (typeof raw.publicKey === 'string' && raw.publicKey.trim().length > 0) {
                   pubKey = raw.publicKey.trim()
-                }
-                if (typeof raw.privateKey === 'string' && raw.privateKey.trim().length > 0) {
-                  key = raw.privateKey.trim()
+                } else if (typeof raw.privateKey === 'string' && raw.privateKey.trim().length > 0) {
+                  pubKey = Keypair.fromSecretKey(bs58.decode(raw.privateKey.trim())).publicKey.toBase58()
                 }
               }
-              const pk = pubKey || (key ? Keypair.fromSecretKey(bs58.decode(key)).publicKey.toBase58() : undefined)
               if (!walletsMap.has(alias)) {
-                walletsMap.set(alias, { alias, publicKey: pk, path: fullPath })
+                walletsMap.set(alias, { alias, publicKey: pubKey, path: fullPath })
               }
             } catch {
               if (!walletsMap.has(alias)) {
@@ -871,15 +864,6 @@ export class Cli {
         } catch {
           /* ignore */
         }
-      }
-    }
-
-    const walletJsonPath = path.join(this.etemaroDir, 'config', 'wallets.json')
-    const existing = loadJsonFile<{ wallets: GeneratedWallet[] }>(walletJsonPath, { wallets: [] })
-    for (const w of existing.wallets || []) {
-      const alias = w.label || 'unnamed'
-      if (!walletsMap.has(alias)) {
-        walletsMap.set(alias, { alias, publicKey: w.publicKey, path: walletJsonPath })
       }
     }
 
@@ -910,7 +894,7 @@ export class Cli {
       return
     }
 
-    // Check secure keystore first (.credentials/wallets/<alias>.json)
+    // Check secure keystore (.credentials/wallets/<alias>.json)
     let foundPub: string | undefined
     let foundPriv: string | undefined
 
@@ -923,19 +907,10 @@ export class Cli {
       if (fs.existsSync(credFile)) {
         try {
           const raw = JSON.parse(fs.readFileSync(credFile, 'utf8'))
-          if (Array.isArray(raw)) {
-            const priv = bs58.encode(Uint8Array.from(raw))
-            foundPriv = priv
-            foundPub = Keypair.fromSecretKey(bs58.decode(priv)).publicKey.toBase58()
-            break
-          } else if (typeof raw === 'string' && raw.trim().length > 0) {
-            const priv = raw.trim()
-            foundPriv = priv
-            foundPub = Keypair.fromSecretKey(bs58.decode(priv)).publicKey.toBase58()
-            break
-          } else if (
+          if (
             typeof raw === 'object' &&
             raw !== null &&
+            !Array.isArray(raw) &&
             typeof raw.privateKey === 'string' &&
             raw.privateKey.trim().length > 0
           ) {
@@ -950,16 +925,6 @@ export class Cli {
         } catch {
           /* ignore */
         }
-      }
-    }
-
-    if (!foundPriv) {
-      const walletPath = path.join(this.etemaroDir, 'config', 'wallets.json')
-      const existing = loadJsonFile<{ wallets: GeneratedWallet[] }>(walletPath, { wallets: [] })
-      const found = existing.wallets?.find((w) => w.label === alias)
-      if (found) {
-        foundPub = found.publicKey
-        foundPriv = found.privateKey
       }
     }
 
@@ -1308,15 +1273,45 @@ export class Cli {
             break
           }
           case '4': {
-            const walletPath = path.join(this.etemaroDir, 'config', 'wallets.json')
-            const existing = loadJsonFile<{ wallets: GeneratedWallet[] }>(walletPath, { wallets: [] })
-            if (existing.wallets?.length) {
+            const credDirs = [
+              path.join(getEtemaroDir(), '.credentials', 'wallets'),
+              path.join(_REPO_ROOT, 'config', '.credentials', 'wallets'),
+            ]
+            const availableWallets: Array<{ label: string; publicKey?: string }> = []
+            const seen = new Set<string>()
+            for (const dir of credDirs) {
+              if (fs.existsSync(dir)) {
+                try {
+                  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'))
+                  for (const f of files) {
+                    const label = path.basename(f, '.json')
+                    if (seen.has(label)) continue
+                    seen.add(label)
+                    let pubKey: string | undefined
+                    try {
+                      const raw = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'))
+                      if (typeof raw === 'object' && raw !== null && typeof raw.publicKey === 'string') {
+                        pubKey = raw.publicKey
+                      }
+                    } catch {
+                      /* ignore */
+                    }
+                    availableWallets.push({ label, publicKey: pubKey })
+                  }
+                } catch {
+                  /* ignore */
+                }
+              }
+            }
+            if (availableWallets.length) {
               console.log('Available wallets:')
-              existing.wallets.forEach((w, i) => void console.log(`  ${i + 1}. ${w.label} (${w.publicKey})`))
+              availableWallets.forEach(
+                (w, i) => void console.log(`  ${i + 1}. ${w.label}${w.publicKey ? ` (${w.publicKey})` : ''}`),
+              )
               const choice = await rl.question('Enter number: ')
               const idx = parseInt(choice, 10) - 1
-              if (idx >= 0 && idx < existing.wallets.length) {
-                const selected = existing.wallets[idx]!
+              if (idx >= 0 && idx < availableWallets.length) {
+                const selected = availableWallets[idx]!
                 const configObj = JSON.parse(fs.readFileSync(_USER_CONFIG_PATH, 'utf8'))
                 if (!configObj.connection) configObj.connection = {}
                 configObj.connection.wallet = selected.label

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -73,15 +73,6 @@ async function promptSecret(promptText: string): Promise<string> {
   })
 }
 
-function _loadJsonFile<T>(filePath: string, fallback: T): T {
-  try {
-    if (!fs.existsSync(filePath)) return fallback
-    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T
-  } catch {
-    return fallback
-  }
-}
-
 import {
   assessSetup,
   formatInitMessage,
@@ -130,7 +121,6 @@ let _USER_CONFIG_PATH: CoreExports['USER_CONFIG_PATH'] = null as any
 let _DEFAULT_ENTRY_SOURCE: CoreExports['DEFAULT_ENTRY_SOURCE'] = null as any
 let _SMART_WALLETS_FILENAME: CoreExports['SMART_WALLETS_FILENAME'] = null as any
 let LESSONS_FILENAME: CoreExports['LESSONS_FILENAME'] = null as any
-let _WALLETS_KEYPAIR_FILENAME: CoreExports['WALLETS_KEYPAIR_FILENAME'] = null as any
 let _REPO_ROOT: CoreExports['REPO_ROOT'] = null as any
 let _DEFAULT_ACTIVE_STRATEGY_ID: CoreExports['DEFAULT_ACTIVE_STRATEGY_ID'] = null as any
 let _DEFAULT_STRATEGY_TYPE: CoreExports['DEFAULT_STRATEGY_TYPE'] = null as any
@@ -170,7 +160,6 @@ export async function loadCore(): Promise<void> {
   _DEFAULT_ENTRY_SOURCE = coreMod.DEFAULT_ENTRY_SOURCE
   _SMART_WALLETS_FILENAME = coreMod.SMART_WALLETS_FILENAME
   LESSONS_FILENAME = coreMod.LESSONS_FILENAME
-  _WALLETS_KEYPAIR_FILENAME = coreMod.WALLETS_KEYPAIR_FILENAME
   _REPO_ROOT = coreMod.REPO_ROOT
   _DEFAULT_ACTIVE_STRATEGY_ID = coreMod.DEFAULT_ACTIVE_STRATEGY_ID
   _DEFAULT_STRATEGY_TYPE = coreMod.DEFAULT_STRATEGY_TYPE
@@ -784,11 +773,9 @@ export class Cli {
   }
 
   private handleGenerateWallet(flags: Record<string, any>): void {
-    const configDir = path.join(this.etemaroDir, 'config')
     const alias = flags.name || flags.label || 'default'
     const result = wallet.generateNewWallet({
       label: alias,
-      configDir,
     })
     out({
       success: true,
@@ -796,7 +783,7 @@ export class Cli {
       privateKey: result.privateKey,
       createdAt: result.createdAt,
       label: result.label,
-      savedTo: path.join(this.etemaroDir, '.credentials', 'wallets', `${alias}.json`),
+      savedTo: result.savedTo ?? path.join(this.etemaroDir, '.credentials', 'wallets', `${alias}.json`),
       message: `New Solana wallet generated and saved as "${alias}"`,
     })
   }

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -25,20 +25,12 @@ import bs58 from 'bs58'
 
 /**
  * Prompt for a sensitive secret (such as a private key) without echoing input to terminal stdout.
+ * Works consistently across both TTY and non-TTY / piped inputs.
  */
 async function promptSecret(promptText: string): Promise<string> {
-  if (!process.stdin.isTTY) {
-    const rl = readline.createInterface({ input: stdinStream, output: stdoutStream })
-    try {
-      const answer = await rl.question(promptText)
-      return answer.trim()
-    } finally {
-      rl.close()
-    }
-  }
-
   return new Promise((resolve) => {
     let muted = false
+    let resolved = false
     const mutableStdout = new Writable({
       write(chunk, encoding, callback) {
         if (!muted) {
@@ -48,20 +40,35 @@ async function promptSecret(promptText: string): Promise<string> {
       },
     })
 
+    const isTTY = Boolean((stdinStream as any).isTTY)
     const rl = nodeReadline.createInterface({
       input: stdinStream,
       output: mutableStdout,
-      terminal: true,
+      terminal: isTTY,
     })
 
     stdoutStream.write(promptText)
     muted = true
 
     rl.question('', (answer) => {
+      if (resolved) return
+      resolved = true
       muted = false
-      stdoutStream.write('\n')
+      if (isTTY) {
+        stdoutStream.write('\n')
+      }
       rl.close()
       resolve(answer.trim())
+    })
+
+    rl.on('close', () => {
+      if (resolved) return
+      resolved = true
+      muted = false
+      if (isTTY) {
+        stdoutStream.write('\n')
+      }
+      resolve('')
     })
   })
 }
@@ -141,9 +148,6 @@ let hivemind: CoreExports['hivemind'] = null as any
 let tools: CoreExports['tools'] = null as any
 let defaultUserConfigStr: CoreExports['defaultUserConfigStr'] = null as any
 let DEFAULT_STRATEGIES: CoreExports['DEFAULT_STRATEGIES'] = null as any
-// Used to disable the global logger's [DRY RUN] tag during real keystore operations
-// (e.g. wallet import/generate), where core's default config otherwise sets dryRun: true.
-let _setDryRun: CoreExports['setDryRun'] = null as any
 
 // Lazily populated Daemon constructor
 let DaemonCtor: DaemonExports['Daemon'] = null as any
@@ -184,7 +188,6 @@ export async function loadCore(): Promise<void> {
   tools = coreMod.tools
   defaultUserConfigStr = coreMod.defaultUserConfigStr
   DEFAULT_STRATEGIES = coreMod.DEFAULT_STRATEGIES
-  _setDryRun = coreMod.setDryRun
   // Assign Daemon constructor
   DaemonCtor = daemonMod.Daemon
 }
@@ -781,8 +784,6 @@ export class Cli {
   }
 
   private handleGenerateWallet(flags: Record<string, any>): void {
-    // Administrative keystore operations are live disk writes, not dry-run simulations
-    _setDryRun?.(false)
     const configDir = path.join(this.etemaroDir, 'config')
     const alias = flags.name || flags.label || 'default'
     const result = wallet.generateNewWallet({
@@ -811,8 +812,6 @@ export class Cli {
       privateKey = await promptSecret('Enter Base58 private key: ')
     }
 
-    // Administrative keystore operations are live disk writes, not dry-run simulations
-    _setDryRun?.(false)
     const result = wallet.importWallet({
       label: alias,
       privateKey,
@@ -847,7 +846,11 @@ export class Cli {
               const raw = JSON.parse(fs.readFileSync(fullPath, 'utf8'))
               let key: string | null = null
               let pubKey: string | undefined
-              if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+              if (Array.isArray(raw)) {
+                key = bs58.encode(Uint8Array.from(raw))
+              } else if (typeof raw === 'string' && raw.trim().length > 0) {
+                key = raw.trim()
+              } else if (typeof raw === 'object' && raw !== null) {
                 if (typeof raw.publicKey === 'string' && raw.publicKey.trim().length > 0) {
                   pubKey = raw.publicKey.trim()
                 }
@@ -920,7 +923,17 @@ export class Cli {
       if (fs.existsSync(credFile)) {
         try {
           const raw = JSON.parse(fs.readFileSync(credFile, 'utf8'))
-          if (
+          if (Array.isArray(raw)) {
+            const priv = bs58.encode(Uint8Array.from(raw))
+            foundPriv = priv
+            foundPub = Keypair.fromSecretKey(bs58.decode(priv)).publicKey.toBase58()
+            break
+          } else if (typeof raw === 'string' && raw.trim().length > 0) {
+            const priv = raw.trim()
+            foundPriv = priv
+            foundPub = Keypair.fromSecretKey(bs58.decode(priv)).publicKey.toBase58()
+            break
+          } else if (
             typeof raw === 'object' &&
             raw !== null &&
             typeof raw.privateKey === 'string' &&
@@ -1271,9 +1284,10 @@ export class Cli {
           }
           case '2': {
             const label = (await rl.question('Enter wallet alias: ')) || 'default'
+            // Close the outer readline interface before promptSecret so it stops listening
+            // and does not compete with promptSecret on stdin, which would echo keystrokes to terminal.
+            rl.close()
             const key = await promptSecret('Enter Base58 private key: ')
-            // Administrative keystore operations are live disk writes, not dry-run simulations
-            _setDryRun?.(false)
             const result = this.adapters.wallet.importWallet({ label, privateKey: key })
             console.log(`Imported wallet ${result.publicKey} as "${label}"`)
             const configObj = JSON.parse(fs.readFileSync(_USER_CONFIG_PATH, 'utf8'))

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -195,7 +195,7 @@ export interface CliAdapters {
   wallet: {
     getWalletBalances: () => Promise<any>
     swapToken: (opts: any) => Promise<any>
-    generateNewWallet: (opts?: { label?: string; configDir?: string }) => GeneratedWallet
+    generateNewWallet: (opts?: { label?: string; credentialsDir?: string }) => GeneratedWallet
     importWallet: (opts: { label: string; privateKey?: string; filePath?: string }) => GeneratedWallet
   }
   screening: {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   banner: {
     js: '#!/usr/bin/env node',
   },
+  shims: true, // Enable cjs and esm shims. Provides support for import.meta.url when targeting modern ESM builds
   // Bundle internal workspace packages into the standalone distribution
   noExternal: ['@etemaro/core', '@etemaro/daemon'],
 })

--- a/packages/core/src/adapters/blockchain/WalletAdapter.test.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.test.ts
@@ -18,7 +18,6 @@ import {
   invalidateBalanceCache,
   setCachedMintDecimals,
   swapToken,
-  type WalletsStore,
 } from './WalletAdapter.js'
 
 describe('WalletAdapter', () => {
@@ -69,7 +68,7 @@ describe('WalletAdapter', () => {
   })
 
   describe('generateNewWallet', () => {
-    it('generates a valid Solana keypair and saves it to wallets.json', () => {
+    it('generates a valid Solana keypair and saves it to individual keystore', () => {
       const result = generateNewWallet({
         configDir: tempDir,
         label: 'Test Generated Wallet',
@@ -88,29 +87,31 @@ describe('WalletAdapter', () => {
       const decodedSecret = bs58.decode(result.privateKey)
       expect(decodedSecret.length).toBe(64)
 
-      // Verify wallets.json was created and populated
-      const targetFile = path.join(tempDir, 'wallets.json')
+      // Verify keystore file was created and populated
+      const targetFile = path.join(tempDir, 'Test Generated Wallet.json')
       expect(fs.existsSync(targetFile)).toBe(true)
 
-      const store: WalletsStore = JSON.parse(fs.readFileSync(targetFile, 'utf8'))
-      expect(store.wallets).toHaveLength(1)
-      expect(store.wallets[0]?.publicKey).toBe(result.publicKey)
-      expect(store.wallets[0]?.privateKey).toBe(result.privateKey)
-      expect(store.wallets[0]?.label).toBe('Test Generated Wallet')
+      const payload = JSON.parse(fs.readFileSync(targetFile, 'utf8'))
+      expect(payload.publicKey).toBe(result.publicKey)
+      expect(payload.privateKey).toBe(result.privateKey)
     })
 
-    it('appends multiple generated wallets without overwriting existing entries', () => {
+    it('creates separate keystore files for multiple generated wallets', () => {
       const w1 = generateNewWallet({ configDir: tempDir, label: 'Wallet 1' })
       const w2 = generateNewWallet({ configDir: tempDir, label: 'Wallet 2' })
 
       expect(w1.publicKey).not.toBe(w2.publicKey)
       expect(w1.privateKey).not.toBe(w2.privateKey)
 
-      const targetFile = path.join(tempDir, 'wallets.json')
-      const store: WalletsStore = JSON.parse(fs.readFileSync(targetFile, 'utf8'))
-      expect(store.wallets).toHaveLength(2)
-      expect(store.wallets[0]?.publicKey).toBe(w1.publicKey)
-      expect(store.wallets[1]?.publicKey).toBe(w2.publicKey)
+      const f1 = path.join(tempDir, 'Wallet 1.json')
+      const f2 = path.join(tempDir, 'Wallet 2.json')
+      expect(fs.existsSync(f1)).toBe(true)
+      expect(fs.existsSync(f2)).toBe(true)
+
+      const p1 = JSON.parse(fs.readFileSync(f1, 'utf8'))
+      const p2 = JSON.parse(fs.readFileSync(f2, 'utf8'))
+      expect(p1.publicKey).toBe(w1.publicKey)
+      expect(p2.publicKey).toBe(w2.publicKey)
     })
   })
 

--- a/packages/core/src/adapters/blockchain/WalletAdapter.test.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.test.ts
@@ -70,7 +70,7 @@ describe('WalletAdapter', () => {
   describe('generateNewWallet', () => {
     it('generates a valid Solana keypair and saves it to individual keystore', () => {
       const result = generateNewWallet({
-        configDir: tempDir,
+        credentialsDir: tempDir,
         label: 'Test Generated Wallet',
       })
 
@@ -89,6 +89,7 @@ describe('WalletAdapter', () => {
 
       // Verify keystore file was created and populated
       const targetFile = path.join(tempDir, 'Test Generated Wallet.json')
+      expect(result.savedTo).toBe(targetFile)
       expect(fs.existsSync(targetFile)).toBe(true)
 
       const payload = JSON.parse(fs.readFileSync(targetFile, 'utf8'))
@@ -97,8 +98,8 @@ describe('WalletAdapter', () => {
     })
 
     it('creates separate keystore files for multiple generated wallets', () => {
-      const w1 = generateNewWallet({ configDir: tempDir, label: 'Wallet 1' })
-      const w2 = generateNewWallet({ configDir: tempDir, label: 'Wallet 2' })
+      const w1 = generateNewWallet({ credentialsDir: tempDir, label: 'Wallet 1' })
+      const w2 = generateNewWallet({ credentialsDir: tempDir, label: 'Wallet 2' })
 
       expect(w1.publicKey).not.toBe(w2.publicKey)
       expect(w1.privateKey).not.toBe(w2.privateKey)

--- a/packages/core/src/adapters/blockchain/WalletAdapter.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.ts
@@ -17,10 +17,10 @@ import { Keypair, PublicKey, VersionedTransaction } from '@solana/web3.js'
 import bs58 from 'bs58'
 import { config } from '../../config/Config.js'
 import { getConnection, getWalletKeypair, withRpcFailover } from '../../shared/connection.js'
-import { configPath, credentialsPath } from '../../shared/constants.js'
+import { credentialsPath } from '../../shared/constants.js'
 import { createTimer, log, logStructured } from '../../shared/logger.js'
 import type { WalletBalancesResult } from '../../shared/types.js'
-import { loadJsonFile, saveJsonFile, withRpcRetry } from '../../shared/utils.js'
+import { withRpcRetry } from '../../shared/utils.js'
 import { sleep } from '../../utils/time.js'
 import { binanceProvider, coinbaseProvider, priceProvider } from '../external/PriceProvider.js'
 
@@ -31,14 +31,6 @@ export interface GeneratedWallet {
   label?: string
 }
 
-export interface WalletsStore {
-  wallets: GeneratedWallet[]
-}
-
-/**
- * Generates a fresh Solana keypair, stores it in wallets.json under the config directory,
- * and returns the public key and base58 private key.
- */
 /**
  * Import a wallet from a Base58 private key and store it with a label.
  * If a file path is provided, reads a Solana CLI keypair JSON array.
@@ -66,12 +58,6 @@ export function importWallet(opts: { label: string; privateKey?: string; filePat
     createdAt: new Date().toISOString(),
     label: opts.label,
   }
-  // Persist to wallets store
-  const targetFile = configPath('wallets.json')
-  const existing = loadJsonFile<WalletsStore>(targetFile, { wallets: [] })
-  existing.wallets = existing.wallets || []
-  existing.wallets.push(wallet)
-  saveJsonFile(targetFile, existing)
 
   // Persist to secure individual keystore file
   try {
@@ -101,54 +87,42 @@ export function importWallet(opts: { label: string; privateKey?: string; filePat
 }
 
 /**
- * Generates a fresh Solana keypair, stores it in wallets.json under the config directory,
+ * Generates a fresh Solana keypair, stores it in an individual keystore under .credentials/wallets,
  * and returns the public key and base58 private key.
  */
 export function generateNewWallet(opts?: { label?: string; configDir?: string }): GeneratedWallet {
   const kp = Keypair.generate()
   const publicKey = kp.publicKey.toBase58()
   const privateKey = bs58.encode(kp.secretKey)
+  const label = opts?.label || 'Generated Keypair'
   const wallet: GeneratedWallet = {
     publicKey,
     privateKey,
     createdAt: new Date().toISOString(),
-    label: opts?.label || 'Generated Keypair',
+    label,
   }
 
   try {
-    const targetFile = opts?.configDir ? path.join(opts.configDir, 'wallets.json') : configPath('wallets.json')
-    const existing = loadJsonFile<WalletsStore>(targetFile, { wallets: [] })
-    existing.wallets = existing.wallets || []
-    existing.wallets.push(wallet)
-    saveJsonFile(targetFile, existing)
-    log('wallet', `Generated and stored new wallet ${publicKey} to ${targetFile}`)
-  } catch (err: unknown) {
-    const e = err as { message?: string }
-    log('wallet', `Warning: Failed to persist generated wallet to wallets.json: ${e.message || err}`)
-  }
-
-  if (wallet.label) {
-    try {
-      const credFile = credentialsPath(`${wallet.label}.json`)
-      const credDir = path.dirname(credFile)
-      if (!fs.existsSync(credDir)) {
-        fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
-      }
-      const payload = {
-        publicKey: wallet.publicKey,
-        privateKey: privateKey,
-      }
-      fs.writeFileSync(credFile, JSON.stringify(payload, null, 2), { mode: 0o600 })
-      if (process.platform !== 'win32') {
-        try {
-          fs.chmodSync(credFile, 0o600)
-        } catch {
-          /* ignore */
-        }
-      }
-    } catch (err: any) {
-      log('wallet', `Warning: Failed to persist individual keystore file: ${err?.message || err}`)
+    const credFile = opts?.configDir ? path.join(opts.configDir, `${label}.json`) : credentialsPath(`${label}.json`)
+    const credDir = path.dirname(credFile)
+    if (!fs.existsSync(credDir)) {
+      fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
     }
+    const payload = {
+      publicKey: wallet.publicKey,
+      privateKey,
+    }
+    fs.writeFileSync(credFile, JSON.stringify(payload, null, 2), { mode: 0o600 })
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(credFile, 0o600)
+      } catch {
+        /* ignore */
+      }
+    }
+    log('wallet', `Generated and stored new wallet ${publicKey} to ${credFile}`)
+  } catch (err: any) {
+    log('wallet', `Warning: Failed to persist individual keystore file: ${err?.message || err}`)
   }
 
   return wallet

--- a/packages/core/src/adapters/blockchain/WalletAdapter.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.ts
@@ -80,7 +80,11 @@ export function importWallet(opts: { label: string; privateKey?: string; filePat
     if (!fs.existsSync(credDir)) {
       fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
     }
-    fs.writeFileSync(credFile, JSON.stringify(key), { mode: 0o600 })
+    const payload = {
+      publicKey: wallet.publicKey,
+      privateKey: key,
+    }
+    fs.writeFileSync(credFile, JSON.stringify(payload, null, 2), { mode: 0o600 })
     if (process.platform !== 'win32') {
       try {
         fs.chmodSync(credFile, 0o600)
@@ -130,7 +134,11 @@ export function generateNewWallet(opts?: { label?: string; configDir?: string })
       if (!fs.existsSync(credDir)) {
         fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
       }
-      fs.writeFileSync(credFile, JSON.stringify(privateKey), { mode: 0o600 })
+      const payload = {
+        publicKey: wallet.publicKey,
+        privateKey: privateKey,
+      }
+      fs.writeFileSync(credFile, JSON.stringify(payload, null, 2), { mode: 0o600 })
       if (process.platform !== 'win32') {
         try {
           fs.chmodSync(credFile, 0o600)

--- a/packages/core/src/adapters/blockchain/WalletAdapter.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.ts
@@ -29,6 +29,7 @@ export interface GeneratedWallet {
   privateKey: string
   createdAt: string
   label?: string
+  savedTo?: string
 }
 
 /**
@@ -52,16 +53,17 @@ export function importWallet(opts: { label: string; privateKey?: string; filePat
     throw new Error('No private key provided for import')
   }
   const kp = Keypair.fromSecretKey(bs58.decode(key))
+  const credFile = credentialsPath(`${opts.label}.json`)
   const wallet: GeneratedWallet = {
     publicKey: kp.publicKey.toBase58(),
     privateKey: key,
     createdAt: new Date().toISOString(),
     label: opts.label,
+    savedTo: credFile,
   }
 
   // Persist to secure individual keystore file
   try {
-    const credFile = credentialsPath(`${opts.label}.json`)
     const credDir = path.dirname(credFile)
     if (!fs.existsSync(credDir)) {
       fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
@@ -88,22 +90,30 @@ export function importWallet(opts: { label: string; privateKey?: string; filePat
 
 /**
  * Generates a fresh Solana keypair, stores it in an individual keystore under .credentials/wallets,
- * and returns the public key and base58 private key.
+ * and returns the public key, base58 private key, and saved location.
  */
-export function generateNewWallet(opts?: { label?: string; configDir?: string }): GeneratedWallet {
+export function generateNewWallet(opts?: {
+  label?: string
+  credentialsDir?: string
+  /** @deprecated use credentialsDir */
+  configDir?: string
+}): GeneratedWallet {
   const kp = Keypair.generate()
   const publicKey = kp.publicKey.toBase58()
   const privateKey = bs58.encode(kp.secretKey)
   const label = opts?.label || 'Generated Keypair'
+  const credFile = opts?.credentialsDir
+    ? path.join(opts.credentialsDir, `${label}.json`)
+    : credentialsPath(`${label}.json`)
   const wallet: GeneratedWallet = {
     publicKey,
     privateKey,
     createdAt: new Date().toISOString(),
     label,
+    savedTo: credFile,
   }
 
   try {
-    const credFile = opts?.configDir ? path.join(opts.configDir, `${label}.json`) : credentialsPath(`${label}.json`)
     const credDir = path.dirname(credFile)
     if (!fs.existsSync(credDir)) {
       fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -15,7 +15,7 @@ import {
   resetConnectionState,
   withRpcFailover,
 } from './connection.js'
-import { credentialsPath } from './constants.js'
+import { configPath, credentialsPath } from './constants.js'
 
 describe('connection module', () => {
   const originalEnv = { ...process.env }
@@ -137,7 +137,7 @@ describe('connection module', () => {
       }
     })
 
-    it('rejects bare string-only format in keystore file', () => {
+    it('auto-migrates bare string-only format in keystore file to { publicKey, privateKey }', () => {
       const kp = Keypair.generate()
       const alias = 'test-string-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
@@ -150,13 +150,19 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        expect(() => getWalletKeypair()).toThrow(/bare string or array format is not supported/)
+        const resolved = getWalletKeypair()
+        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
+
+        // Verify in-place auto-migration on disk
+        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
+        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
+        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }
     })
 
-    it('rejects array format in keystore file', () => {
+    it('auto-migrates array format in keystore file to { publicKey, privateKey }', () => {
       const kp = Keypair.generate()
       const alias = 'test-array-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
@@ -169,9 +175,71 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        expect(() => getWalletKeypair()).toThrow(/bare string or array format is not supported/)
+        const resolved = getWalletKeypair()
+        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
+
+        // Verify in-place auto-migration on disk
+        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
+        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
+        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+      }
+    })
+
+    it('auto-migrates keystore missing publicKey to include publicKey', () => {
+      const kp = Keypair.generate()
+      const alias = 'test-nopubkey-wallet'
+      const keyfilePath = credentialsPath(`${alias}.json`)
+      fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
+      fs.writeFileSync(keyfilePath, JSON.stringify({ privateKey: bs58.encode(kp.secretKey) }), { mode: 0o600 })
+
+      try {
+        config.connection = {
+          ...config.connection,
+          wallet: alias,
+        }
+
+        const resolved = getWalletKeypair()
+        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
+
+        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
+        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
+        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
+      } finally {
+        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+      }
+    })
+
+    it('auto-migrates from config/wallets.json if keystore does not exist', () => {
+      const kp = Keypair.generate()
+      const alias = 'test-fallback-wallet'
+      const keyfilePath = credentialsPath(`${alias}.json`)
+      const walletsJsonPath = configPath('wallets.json')
+      fs.mkdirSync(path.dirname(walletsJsonPath), { recursive: true })
+      fs.writeFileSync(
+        walletsJsonPath,
+        JSON.stringify({
+          wallets: [{ label: alias, privateKey: bs58.encode(kp.secretKey) }],
+        }),
+      )
+
+      try {
+        config.connection = {
+          ...config.connection,
+          wallet: alias,
+        }
+
+        const resolved = getWalletKeypair()
+        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
+
+        expect(fs.existsSync(keyfilePath)).toBe(true)
+        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
+        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
+        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
+      } finally {
+        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+        if (fs.existsSync(walletsJsonPath)) fs.unlinkSync(walletsJsonPath)
       }
     })
 
@@ -189,6 +257,24 @@ describe('connection module', () => {
         }
 
         expect(() => getWalletKeypair()).toThrow(/Missing mandatory "privateKey"/)
+      } finally {
+        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+      }
+    })
+
+    it('rejects invalid non-object format (e.g. number/boolean) in keystore file', () => {
+      const alias = 'test-invalid-primitive-wallet'
+      const keyfilePath = credentialsPath(`${alias}.json`)
+      fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
+      fs.writeFileSync(keyfilePath, JSON.stringify(12345), { mode: 0o600 })
+
+      try {
+        config.connection = {
+          ...config.connection,
+          wallet: alias,
+        }
+
+        expect(() => getWalletKeypair()).toThrow(/Invalid keystore format/)
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -137,9 +137,9 @@ describe('connection module', () => {
       }
     })
 
-    it('rejects string-only format in keystore file', () => {
+    it('auto-migrates legacy string-only format in keystore file to { publicKey, privateKey }', () => {
       const kp = Keypair.generate()
-      const alias = 'test-string-wallet'
+      const alias = 'test-legacy-string-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
       fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
       fs.writeFileSync(keyfilePath, JSON.stringify(bs58.encode(kp.secretKey)), { mode: 0o600 })
@@ -150,7 +150,42 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        expect(() => getWalletKeypair()).toThrow(/string-only or array format is not supported/)
+        const resolved = getWalletKeypair()
+        expect(resolved.publicKey.toBase58()).toBe(kp.publicKey.toBase58())
+
+        // Verify file was migrated in-place
+        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
+        expect(migrated).toEqual({
+          publicKey: kp.publicKey.toBase58(),
+          privateKey: bs58.encode(kp.secretKey),
+        })
+      } finally {
+        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+      }
+    })
+
+    it('auto-migrates legacy array format in keystore file to { publicKey, privateKey }', () => {
+      const kp = Keypair.generate()
+      const alias = 'test-legacy-array-wallet'
+      const keyfilePath = credentialsPath(`${alias}.json`)
+      fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
+      fs.writeFileSync(keyfilePath, JSON.stringify(Array.from(kp.secretKey)), { mode: 0o600 })
+
+      try {
+        config.connection = {
+          ...config.connection,
+          wallet: alias,
+        }
+
+        const resolved = getWalletKeypair()
+        expect(resolved.publicKey.toBase58()).toBe(kp.publicKey.toBase58())
+
+        // Verify file was migrated in-place
+        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
+        expect(migrated).toEqual({
+          publicKey: kp.publicKey.toBase58(),
+          privateKey: bs58.encode(kp.secretKey),
+        })
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -15,7 +15,7 @@ import {
   resetConnectionState,
   withRpcFailover,
 } from './connection.js'
-import { configPath, credentialsPath } from './constants.js'
+import { credentialsPath } from './constants.js'
 
 describe('connection module', () => {
   const originalEnv = { ...process.env }
@@ -137,7 +137,7 @@ describe('connection module', () => {
       }
     })
 
-    it('auto-migrates bare string-only format in keystore file to { publicKey, privateKey }', () => {
+    it('rejects bare string-only format in keystore file', () => {
       const kp = Keypair.generate()
       const alias = 'test-string-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
@@ -150,19 +150,13 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        const resolved = getWalletKeypair()
-        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
-
-        // Verify in-place auto-migration on disk
-        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
-        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
-        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
+        expect(() => getWalletKeypair()).toThrow(/bare string or array format is not supported/)
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }
     })
 
-    it('auto-migrates array format in keystore file to { publicKey, privateKey }', () => {
+    it('rejects array format in keystore file', () => {
       const kp = Keypair.generate()
       const alias = 'test-array-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
@@ -175,71 +169,9 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        const resolved = getWalletKeypair()
-        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
-
-        // Verify in-place auto-migration on disk
-        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
-        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
-        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
+        expect(() => getWalletKeypair()).toThrow(/bare string or array format is not supported/)
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
-      }
-    })
-
-    it('auto-migrates keystore missing publicKey to include publicKey', () => {
-      const kp = Keypair.generate()
-      const alias = 'test-nopubkey-wallet'
-      const keyfilePath = credentialsPath(`${alias}.json`)
-      fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
-      fs.writeFileSync(keyfilePath, JSON.stringify({ privateKey: bs58.encode(kp.secretKey) }), { mode: 0o600 })
-
-      try {
-        config.connection = {
-          ...config.connection,
-          wallet: alias,
-        }
-
-        const resolved = getWalletKeypair()
-        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
-
-        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
-        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
-        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
-      } finally {
-        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
-      }
-    })
-
-    it('auto-migrates from config/wallets.json if keystore does not exist', () => {
-      const kp = Keypair.generate()
-      const alias = 'test-fallback-wallet'
-      const keyfilePath = credentialsPath(`${alias}.json`)
-      const walletsJsonPath = configPath('wallets.json')
-      fs.mkdirSync(path.dirname(walletsJsonPath), { recursive: true })
-      fs.writeFileSync(
-        walletsJsonPath,
-        JSON.stringify({
-          wallets: [{ label: alias, privateKey: bs58.encode(kp.secretKey) }],
-        }),
-      )
-
-      try {
-        config.connection = {
-          ...config.connection,
-          wallet: alias,
-        }
-
-        const resolved = getWalletKeypair()
-        expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
-
-        expect(fs.existsSync(keyfilePath)).toBe(true)
-        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
-        expect(migrated.publicKey).toBe(kp.publicKey.toBase58())
-        expect(migrated.privateKey).toBe(bs58.encode(kp.secretKey))
-      } finally {
-        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
-        if (fs.existsSync(walletsJsonPath)) fs.unlinkSync(walletsJsonPath)
       }
     })
 

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -117,7 +117,11 @@ describe('connection module', () => {
       const alias = 'test-unit-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
       fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
-      fs.writeFileSync(keyfilePath, JSON.stringify(bs58.encode(kp.secretKey)), { mode: 0o600 })
+      const payload = {
+        publicKey: kp.publicKey.toBase58(),
+        privateKey: bs58.encode(kp.secretKey),
+      }
+      fs.writeFileSync(keyfilePath, JSON.stringify(payload), { mode: 0o600 })
 
       try {
         config.connection = {
@@ -128,6 +132,44 @@ describe('connection module', () => {
         const resolved = getWalletKeypair()
         expect(resolved.publicKey.toString()).toBe(kp.publicKey.toString())
         expect(getWalletAddress()).toBe(kp.publicKey.toString())
+      } finally {
+        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+      }
+    })
+
+    it('rejects string-only format in keystore file', () => {
+      const kp = Keypair.generate()
+      const alias = 'test-string-wallet'
+      const keyfilePath = credentialsPath(`${alias}.json`)
+      fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
+      fs.writeFileSync(keyfilePath, JSON.stringify(bs58.encode(kp.secretKey)), { mode: 0o600 })
+
+      try {
+        config.connection = {
+          ...config.connection,
+          wallet: alias,
+        }
+
+        expect(() => getWalletKeypair()).toThrow(/string-only or array format is not supported/)
+      } finally {
+        if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
+      }
+    })
+
+    it('rejects keystore file missing mandatory privateKey', () => {
+      const kp = Keypair.generate()
+      const alias = 'test-nopriv-wallet'
+      const keyfilePath = credentialsPath(`${alias}.json`)
+      fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
+      fs.writeFileSync(keyfilePath, JSON.stringify({ publicKey: kp.publicKey.toBase58() }), { mode: 0o600 })
+
+      try {
+        config.connection = {
+          ...config.connection,
+          wallet: alias,
+        }
+
+        expect(() => getWalletKeypair()).toThrow(/Missing mandatory "privateKey"/)
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }

--- a/packages/core/src/shared/connection.test.ts
+++ b/packages/core/src/shared/connection.test.ts
@@ -137,9 +137,9 @@ describe('connection module', () => {
       }
     })
 
-    it('auto-migrates legacy string-only format in keystore file to { publicKey, privateKey }', () => {
+    it('rejects bare string-only format in keystore file', () => {
       const kp = Keypair.generate()
-      const alias = 'test-legacy-string-wallet'
+      const alias = 'test-string-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
       fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
       fs.writeFileSync(keyfilePath, JSON.stringify(bs58.encode(kp.secretKey)), { mode: 0o600 })
@@ -150,23 +150,15 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        const resolved = getWalletKeypair()
-        expect(resolved.publicKey.toBase58()).toBe(kp.publicKey.toBase58())
-
-        // Verify file was migrated in-place
-        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
-        expect(migrated).toEqual({
-          publicKey: kp.publicKey.toBase58(),
-          privateKey: bs58.encode(kp.secretKey),
-        })
+        expect(() => getWalletKeypair()).toThrow(/bare string or array format is not supported/)
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }
     })
 
-    it('auto-migrates legacy array format in keystore file to { publicKey, privateKey }', () => {
+    it('rejects array format in keystore file', () => {
       const kp = Keypair.generate()
-      const alias = 'test-legacy-array-wallet'
+      const alias = 'test-array-wallet'
       const keyfilePath = credentialsPath(`${alias}.json`)
       fs.mkdirSync(path.dirname(keyfilePath), { recursive: true })
       fs.writeFileSync(keyfilePath, JSON.stringify(Array.from(kp.secretKey)), { mode: 0o600 })
@@ -177,15 +169,7 @@ describe('connection module', () => {
           wallet: alias,
         }
 
-        const resolved = getWalletKeypair()
-        expect(resolved.publicKey.toBase58()).toBe(kp.publicKey.toBase58())
-
-        // Verify file was migrated in-place
-        const migrated = JSON.parse(fs.readFileSync(keyfilePath, 'utf8'))
-        expect(migrated).toEqual({
-          publicKey: kp.publicKey.toBase58(),
-          privateKey: bs58.encode(kp.secretKey),
-        })
+        expect(() => getWalletKeypair()).toThrow(/bare string or array format is not supported/)
       } finally {
         if (fs.existsSync(keyfilePath)) fs.unlinkSync(keyfilePath)
       }

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -5,11 +5,10 @@
  */
 
 import fs from 'node:fs'
-import path from 'node:path'
 import { Connection, Keypair } from '@solana/web3.js'
 import bs58 from 'bs58'
 import { config } from '../config/Config.js'
-import { configPath, credentialsPath } from './constants.js'
+import { credentialsPath } from './constants.js'
 import { log } from './logger.js'
 import { isTransientRpcError, type RpcRetryOptions, withRpcRetry } from './utils.js'
 
@@ -75,38 +74,6 @@ export function getWalletKeypair(): Keypair {
 
   const walletPath = credentialsPath(`${alias}.json`)
   if (!fs.existsSync(walletPath)) {
-    // Fallback: check config/wallets.json for alias and auto-migrate to keystore
-    const walletsJsonPath = configPath('wallets.json')
-    if (fs.existsSync(walletsJsonPath)) {
-      try {
-        const store = JSON.parse(fs.readFileSync(walletsJsonPath, 'utf8'))
-        const found = store.wallets?.find((w: any) => w.label === alias)
-        if (found?.privateKey) {
-          const credDir = path.dirname(walletPath)
-          if (!fs.existsSync(credDir)) {
-            fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
-          }
-          const pubKey = found.publicKey || Keypair.fromSecretKey(bs58.decode(found.privateKey)).publicKey.toBase58()
-          const payload = {
-            publicKey: pubKey,
-            privateKey: found.privateKey,
-          }
-          fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
-          if (process.platform !== 'win32') {
-            try {
-              fs.chmodSync(walletPath, 0o600)
-            } catch {
-              /* ignore */
-            }
-          }
-        }
-      } catch {
-        /* ignore */
-      }
-    }
-  }
-
-  if (!fs.existsSync(walletPath)) {
     throw new Error(
       `Wallet keystore not found for alias "${alias}" at ${walletPath}. Import or generate a wallet first (e.g. etemaro wallet import --name ${alias}).`,
     )
@@ -127,29 +94,19 @@ export function getWalletKeypair(): Keypair {
   }
 
   let key: string | null = null
-  let needsMigration = false
   try {
     const walletData = JSON.parse(fs.readFileSync(walletPath, 'utf8'))
-    if (Array.isArray(walletData)) {
-      // Legacy Solana CLI byte array [1, 2, ...]
-      key = bs58.encode(Uint8Array.from(walletData))
-      needsMigration = true
-    } else if (typeof walletData === 'string') {
-      // Legacy bare Base58 string
-      key = walletData.trim()
-      needsMigration = true
-    } else if (typeof walletData === 'object' && walletData !== null) {
-      if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
-        throw new Error(
-          `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
-        )
-      }
-      key = walletData.privateKey.trim()
-    } else {
+    if (typeof walletData !== 'object' || walletData === null || Array.isArray(walletData)) {
       throw new Error(
-        `Invalid keystore format. Keystore must be a JSON object: { "publicKey": "...", "privateKey": "..." }`,
+        `Invalid keystore format: must be a JSON object with "publicKey" and "privateKey" (bare string or array format is not supported).`,
       )
     }
+    if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
+      throw new Error(
+        `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
+      )
+    }
+    key = walletData.privateKey.trim()
   } catch (err: any) {
     throw new Error(`Failed to parse wallet keystore file at ${walletPath}: ${err?.message || err}`)
   }
@@ -162,26 +119,6 @@ export function getWalletKeypair(): Keypair {
     _walletKeypair = Keypair.fromSecretKey(bs58.decode(key))
   } catch (err: any) {
     throw new Error(`Invalid secret key in wallet keystore at ${walletPath}: ${err?.message || err}`)
-  }
-
-  // Auto-migrate legacy format in-place to { publicKey, privateKey }
-  if (needsMigration) {
-    try {
-      const payload = {
-        publicKey: _walletKeypair.publicKey.toBase58(),
-        privateKey: key,
-      }
-      fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
-      if (process.platform !== 'win32') {
-        try {
-          fs.chmodSync(walletPath, 0o600)
-        } catch {
-          /* ignore */
-        }
-      }
-    } catch {
-      /* ignore migration rewrite errors if filesystem is read-only */
-    }
   }
 
   _walletAlias = alias

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -5,11 +5,10 @@
  */
 
 import fs from 'node:fs'
-import path from 'node:path'
 import { Connection, Keypair } from '@solana/web3.js'
 import bs58 from 'bs58'
 import { config } from '../config/Config.js'
-import { configPath, credentialsPath } from './constants.js'
+import { credentialsPath } from './constants.js'
 import { log } from './logger.js'
 import { isTransientRpcError, type RpcRetryOptions, withRpcRetry } from './utils.js'
 
@@ -75,38 +74,6 @@ export function getWalletKeypair(): Keypair {
 
   const walletPath = credentialsPath(`${alias}.json`)
   if (!fs.existsSync(walletPath)) {
-    // Fallback: check config/wallets.json for alias and auto-migrate to keystore
-    const walletsJsonPath = configPath('wallets.json')
-    if (fs.existsSync(walletsJsonPath)) {
-      try {
-        const store = JSON.parse(fs.readFileSync(walletsJsonPath, 'utf8'))
-        const found = store.wallets?.find((w: any) => w.label === alias)
-        if (found?.privateKey) {
-          const credDir = path.dirname(walletPath)
-          if (!fs.existsSync(credDir)) {
-            fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
-          }
-          const pubKey = found.publicKey || Keypair.fromSecretKey(bs58.decode(found.privateKey)).publicKey.toBase58()
-          const payload = {
-            publicKey: pubKey,
-            privateKey: found.privateKey,
-          }
-          fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
-          if (process.platform !== 'win32') {
-            try {
-              fs.chmodSync(walletPath, 0o600)
-            } catch {
-              /* ignore */
-            }
-          }
-        }
-      } catch {
-        /* ignore */
-      }
-    }
-  }
-
-  if (!fs.existsSync(walletPath)) {
     throw new Error(
       `Wallet keystore not found for alias "${alias}" at ${walletPath}. Import or generate a wallet first (e.g. etemaro wallet import --name ${alias}).`,
     )
@@ -127,32 +94,19 @@ export function getWalletKeypair(): Keypair {
   }
 
   let key: string | null = null
-  let needsMigration = false
   try {
     const walletData = JSON.parse(fs.readFileSync(walletPath, 'utf8'))
-    if (Array.isArray(walletData)) {
-      // Legacy Solana CLI byte array [1, 2, ...]
-      key = bs58.encode(Uint8Array.from(walletData))
-      needsMigration = true
-    } else if (typeof walletData === 'string') {
-      // Legacy bare Base58 string
-      key = walletData.trim()
-      needsMigration = true
-    } else if (typeof walletData === 'object' && walletData !== null) {
-      if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
-        throw new Error(
-          `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
-        )
-      }
-      key = walletData.privateKey.trim()
-      if (!walletData.publicKey || typeof walletData.publicKey !== 'string') {
-        needsMigration = true
-      }
-    } else {
+    if (typeof walletData !== 'object' || walletData === null || Array.isArray(walletData)) {
       throw new Error(
         `Invalid keystore format: must be a JSON object with "publicKey" and "privateKey" (bare string or array format is not supported).`,
       )
     }
+    if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
+      throw new Error(
+        `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
+      )
+    }
+    key = walletData.privateKey.trim()
   } catch (err: any) {
     throw new Error(`Failed to parse wallet keystore file at ${walletPath}: ${err?.message || err}`)
   }
@@ -165,26 +119,6 @@ export function getWalletKeypair(): Keypair {
     _walletKeypair = Keypair.fromSecretKey(bs58.decode(key))
   } catch (err: any) {
     throw new Error(`Invalid secret key in wallet keystore at ${walletPath}: ${err?.message || err}`)
-  }
-
-  // Auto-migrate legacy format in-place to { publicKey, privateKey }
-  if (needsMigration) {
-    try {
-      const payload = {
-        publicKey: _walletKeypair.publicKey.toBase58(),
-        privateKey: key,
-      }
-      fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
-      if (process.platform !== 'win32') {
-        try {
-          fs.chmodSync(walletPath, 0o600)
-        } catch {
-          /* ignore */
-        }
-      }
-    } catch {
-      /* ignore migration rewrite errors if filesystem is read-only */
-    }
   }
 
   _walletAlias = alias

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -127,19 +127,29 @@ export function getWalletKeypair(): Keypair {
   }
 
   let key: string | null = null
+  let needsMigration = false
   try {
     const walletData = JSON.parse(fs.readFileSync(walletPath, 'utf8'))
-    if (typeof walletData !== 'object' || walletData === null || Array.isArray(walletData)) {
+    if (Array.isArray(walletData)) {
+      // Legacy Solana CLI byte array [1, 2, ...]
+      key = bs58.encode(Uint8Array.from(walletData))
+      needsMigration = true
+    } else if (typeof walletData === 'string') {
+      // Legacy bare Base58 string
+      key = walletData.trim()
+      needsMigration = true
+    } else if (typeof walletData === 'object' && walletData !== null) {
+      if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
+        throw new Error(
+          `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
+        )
+      }
+      key = walletData.privateKey.trim()
+    } else {
       throw new Error(
-        `Invalid keystore format. Keystore must be a JSON object: { "publicKey": "...", "privateKey": "..." } (string-only or array format is not supported).`,
+        `Invalid keystore format. Keystore must be a JSON object: { "publicKey": "...", "privateKey": "..." }`,
       )
     }
-    if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
-      throw new Error(
-        `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
-      )
-    }
-    key = walletData.privateKey.trim()
   } catch (err: any) {
     throw new Error(`Failed to parse wallet keystore file at ${walletPath}: ${err?.message || err}`)
   }
@@ -148,7 +158,32 @@ export function getWalletKeypair(): Keypair {
     throw new Error(`Wallet keystore file at ${walletPath} does not contain a valid private key.`)
   }
 
-  _walletKeypair = Keypair.fromSecretKey(bs58.decode(key))
+  try {
+    _walletKeypair = Keypair.fromSecretKey(bs58.decode(key))
+  } catch (err: any) {
+    throw new Error(`Invalid secret key in wallet keystore at ${walletPath}: ${err?.message || err}`)
+  }
+
+  // Auto-migrate legacy format in-place to { publicKey, privateKey }
+  if (needsMigration) {
+    try {
+      const payload = {
+        publicKey: _walletKeypair.publicKey.toBase58(),
+        privateKey: key,
+      }
+      fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
+      if (process.platform !== 'win32') {
+        try {
+          fs.chmodSync(walletPath, 0o600)
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch {
+      /* ignore migration rewrite errors if filesystem is read-only */
+    }
+  }
+
   _walletAlias = alias
   return _walletKeypair
 }

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -5,10 +5,11 @@
  */
 
 import fs from 'node:fs'
+import path from 'node:path'
 import { Connection, Keypair } from '@solana/web3.js'
 import bs58 from 'bs58'
 import { config } from '../config/Config.js'
-import { credentialsPath } from './constants.js'
+import { configPath, credentialsPath } from './constants.js'
 import { log } from './logger.js'
 import { isTransientRpcError, type RpcRetryOptions, withRpcRetry } from './utils.js'
 
@@ -74,6 +75,38 @@ export function getWalletKeypair(): Keypair {
 
   const walletPath = credentialsPath(`${alias}.json`)
   if (!fs.existsSync(walletPath)) {
+    // Fallback: check config/wallets.json for alias and auto-migrate to keystore
+    const walletsJsonPath = configPath('wallets.json')
+    if (fs.existsSync(walletsJsonPath)) {
+      try {
+        const store = JSON.parse(fs.readFileSync(walletsJsonPath, 'utf8'))
+        const found = store.wallets?.find((w: any) => w.label === alias)
+        if (found?.privateKey) {
+          const credDir = path.dirname(walletPath)
+          if (!fs.existsSync(credDir)) {
+            fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
+          }
+          const pubKey = found.publicKey || Keypair.fromSecretKey(bs58.decode(found.privateKey)).publicKey.toBase58()
+          const payload = {
+            publicKey: pubKey,
+            privateKey: found.privateKey,
+          }
+          fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
+          if (process.platform !== 'win32') {
+            try {
+              fs.chmodSync(walletPath, 0o600)
+            } catch {
+              /* ignore */
+            }
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  if (!fs.existsSync(walletPath)) {
     throw new Error(
       `Wallet keystore not found for alias "${alias}" at ${walletPath}. Import or generate a wallet first (e.g. etemaro wallet import --name ${alias}).`,
     )
@@ -94,19 +127,32 @@ export function getWalletKeypair(): Keypair {
   }
 
   let key: string | null = null
+  let needsMigration = false
   try {
     const walletData = JSON.parse(fs.readFileSync(walletPath, 'utf8'))
-    if (typeof walletData !== 'object' || walletData === null || Array.isArray(walletData)) {
+    if (Array.isArray(walletData)) {
+      // Legacy Solana CLI byte array [1, 2, ...]
+      key = bs58.encode(Uint8Array.from(walletData))
+      needsMigration = true
+    } else if (typeof walletData === 'string') {
+      // Legacy bare Base58 string
+      key = walletData.trim()
+      needsMigration = true
+    } else if (typeof walletData === 'object' && walletData !== null) {
+      if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
+        throw new Error(
+          `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
+        )
+      }
+      key = walletData.privateKey.trim()
+      if (!walletData.publicKey || typeof walletData.publicKey !== 'string') {
+        needsMigration = true
+      }
+    } else {
       throw new Error(
         `Invalid keystore format: must be a JSON object with "publicKey" and "privateKey" (bare string or array format is not supported).`,
       )
     }
-    if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
-      throw new Error(
-        `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
-      )
-    }
-    key = walletData.privateKey.trim()
   } catch (err: any) {
     throw new Error(`Failed to parse wallet keystore file at ${walletPath}: ${err?.message || err}`)
   }
@@ -119,6 +165,26 @@ export function getWalletKeypair(): Keypair {
     _walletKeypair = Keypair.fromSecretKey(bs58.decode(key))
   } catch (err: any) {
     throw new Error(`Invalid secret key in wallet keystore at ${walletPath}: ${err?.message || err}`)
+  }
+
+  // Auto-migrate legacy format in-place to { publicKey, privateKey }
+  if (needsMigration) {
+    try {
+      const payload = {
+        publicKey: _walletKeypair.publicKey.toBase58(),
+        privateKey: key,
+      }
+      fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
+      if (process.platform !== 'win32') {
+        try {
+          fs.chmodSync(walletPath, 0o600)
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch {
+      /* ignore migration rewrite errors if filesystem is read-only */
+    }
   }
 
   _walletAlias = alias

--- a/packages/core/src/shared/connection.ts
+++ b/packages/core/src/shared/connection.ts
@@ -86,7 +86,12 @@ export function getWalletKeypair(): Keypair {
           if (!fs.existsSync(credDir)) {
             fs.mkdirSync(credDir, { recursive: true, mode: 0o700 })
           }
-          fs.writeFileSync(walletPath, JSON.stringify(found.privateKey), { mode: 0o600 })
+          const pubKey = found.publicKey || Keypair.fromSecretKey(bs58.decode(found.privateKey)).publicKey.toBase58()
+          const payload = {
+            publicKey: pubKey,
+            privateKey: found.privateKey,
+          }
+          fs.writeFileSync(walletPath, JSON.stringify(payload, null, 2), { mode: 0o600 })
           if (process.platform !== 'win32') {
             try {
               fs.chmodSync(walletPath, 0o600)
@@ -124,16 +129,19 @@ export function getWalletKeypair(): Keypair {
   let key: string | null = null
   try {
     const walletData = JSON.parse(fs.readFileSync(walletPath, 'utf8'))
-    // Support both Base58 strings and Solana CLI JSON arrays
-    if (Array.isArray(walletData)) {
-      key = bs58.encode(Uint8Array.from(walletData))
-    } else if (typeof walletData === 'string') {
-      key = walletData
-    } else if (walletData.privateKey) {
-      key = walletData.privateKey
+    if (typeof walletData !== 'object' || walletData === null || Array.isArray(walletData)) {
+      throw new Error(
+        `Invalid keystore format. Keystore must be a JSON object: { "publicKey": "...", "privateKey": "..." } (string-only or array format is not supported).`,
+      )
     }
-  } catch (err) {
-    throw new Error(`Failed to parse wallet keystore file at ${walletPath}: ${err}`)
+    if (typeof walletData.privateKey !== 'string' || walletData.privateKey.trim().length === 0) {
+      throw new Error(
+        `Missing mandatory "privateKey" in wallet keystore file at ${walletPath}. Expected format: { "publicKey": "...", "privateKey": "..." }`,
+      )
+    }
+    key = walletData.privateKey.trim()
+  } catch (err: any) {
+    throw new Error(`Failed to parse wallet keystore file at ${walletPath}: ${err?.message || err}`)
   }
 
   if (!key) {

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -35,10 +35,10 @@ function findRepoRoot(startDir: string): string {
 }
 
 const currentFileDir =
-  typeof import.meta?.url === 'string' && import.meta.url.startsWith('file:')
-    ? path.dirname(fileURLToPath(import.meta.url))
-    : typeof __dirname !== 'undefined'
-      ? __dirname
+  typeof __dirname !== 'undefined' && __dirname.length > 0
+    ? __dirname
+    : typeof import.meta?.url === 'string' && import.meta.url.startsWith('file:')
+      ? path.dirname(fileURLToPath(import.meta.url))
       : process.cwd()
 
 /** Absolute path to the repository root (the pnpm workspace root). */

--- a/packages/core/src/shared/logger.test.ts
+++ b/packages/core/src/shared/logger.test.ts
@@ -51,6 +51,16 @@ describe('logger', () => {
     expect(output).toContain('[DRY RUN]')
     expect(output).toContain('Test message dry run')
   })
+
+  it('does not inject [DRY RUN] tag for wallet administrative logs even when dryRun is true', () => {
+    setDryRun(true)
+    log('wallet', 'Imported wallet abc as default')
+    expect(stdoutSpy).toHaveBeenCalled()
+    const output = stdoutSpy.mock.calls[0][0] as string
+    expect(output).toContain('[wallet]')
+    expect(output).not.toContain('[DRY RUN]')
+    expect(output).toContain('Imported wallet abc as default')
+  })
 })
 
 describe('redactSensitive', () => {

--- a/packages/core/src/shared/logger.ts
+++ b/packages/core/src/shared/logger.ts
@@ -205,7 +205,8 @@ function getStructuredLogPath(): string {
 export function log(level: string, message: string): void {
   const ts = new Date().toISOString()
   const agentId = getAgentIdForRequests()
-  const dryTag = getDryRun() ? ' [DRY RUN]' : ''
+  // Keystore and wallet administration actions are live disk writes, not dry-run simulations
+  const dryTag = getDryRun() && level !== 'wallet' ? ' [DRY RUN]' : ''
   const redacted = redactSensitive(message)
   const line = `[${ts}] [${level}] [${agentId}]${dryTag} ${redacted}\n`
   try {


### PR DESCRIPTION
## Summary

- **Security & Secret Boundary**:
  - Enforced security boundary in `AGENTS.md` prohibiting AI agents from viewing, reading, or displaying files matching `.env*`, `*.prod`, or `.credentials/*`.
  - Replaced production RPC key examples in documentation with placeholders.
  - Implemented `promptSecret` with unified write-muted terminal streams across both TTY and non-TTY / piped inputs.
  - Resolved readline interface competition in the onboarding wizard by closing the outer interface before prompting for secrets, ensuring private keys are never echoed during interactive onboarding.
- **Strict Keystore Format & Path Fix (Option B: Zero Legacy Baggage)**:
  - Wallet keystore files strictly require JSON object format:
    ```json
    {
      "publicKey": "...",
      "privateKey": "..."
    }
    ```
  - Made `privateKey` mandatory and verified with strict schema checks. Bare strings and arrays are rejected with clear error messages.
  - Removed all legacy `config/wallets.json` fallbacks and keystore migration logic, keeping the codebase completely lean and modern since all environments are already upgraded.
  - Fixed `generateNewWallet` path resolution so keystores are saved directly to `.credentials/wallets/<alias>.json` with mode `0600`, returning `savedTo` and reporting the correct path in CLI `handleGenerateWallet`.
  - Updated `CliAdapters.wallet.generateNewWallet` parameter type from `configDir` to `credentialsDir`.
  - Cleaned up dead code (`_loadJsonFile` and `_WALLETS_KEYPAIR_FILENAME`) in `packages/cli/src/Cli.ts`.
- **Dry-Run Tag Isolation & CJS Build**:
  - Eliminated global `_setDryRun` mutations in the CLI. Administrative keystore operations are excluded at the logger level from the `[DRY RUN]` tag without mutating the runtime `dryRun` flag, ensuring subsequent daemon starts retain their configured dry-run mode.
  - Resolved `import.meta` CJS build warning by checking `typeof __dirname !== 'undefined'` first and enabling `shims: true` in `packages/cli/tsup.config.ts`.

## Verification
- Unit test suite: 378/378 passed across 33 test files (`pnpm test`).
- Full workspace build: `pnpm build` succeeded cleanly with 0 errors and 0 warnings.