### PR TITLE
feat(core): full portfolio & wallet asset visibility (Token-2022 & unified holdings)

### DIFF
--- a/packages/core/src/adapters/ToolDefinitions.ts
+++ b/packages/core/src/adapters/ToolDefinitions.ts
@@ -248,8 +248,36 @@ Returns current feePerTvl24h which indicates the current APY of the pool.`,
   {
     type: 'function',
     function: {
+      name: 'get_meteora_positions',
+      description: `List all open Meteora DLMM LP positions for the agent wallet.
+Strictly inspects active Meteora LP liquidity positions, deployed range (min/max bin IDs), uncollected fees, and in-range status.
+This does NOT show spot tokens sitting in the wallet.
+
+Returns positions grouped by pool, each with:
+- position address
+- pool address and token pair
+- bin range (min/max bin IDs)
+- whether currently in range
+- unclaimed fees (in USD)
+- total deposited value vs current value
+- time since last rebalance
+
+Use this at the start of every management cycle or when inspecting LP positions.`,
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+
+  {
+    type: 'function',
+    function: {
       name: 'get_my_positions',
-      description: `List all open DLMM positions for the agent wallet.
+      description: `List all open Meteora DLMM LP positions for the agent wallet (alias for get_meteora_positions).
+Strictly inspects active Meteora LP liquidity positions, deployed range, and uncollected fees.
+This does NOT show spot tokens sitting in the wallet (use get_wallet_balance for wallet tokens).
+
 Returns positions grouped by pool, each with:
 - position address
 - pool address and token pair
@@ -355,14 +383,37 @@ position address, pool, bin range, in-range status, unclaimed fees, PnL, age.`,
     type: 'function',
     function: {
       name: 'get_wallet_balance',
-      description: `Get current wallet balances for SOL, USDC, and all other token holdings.
+      description: `Get current spot wallet balances for SOL, USDC, standard SPL tokens, and Token-2022 tokens held directly in the wallet.
+Use this to check real token balances and cash held directly in the wallet.
+This does NOT show Meteora LP positions (use get_meteora_positions for LP bins).
+
 Returns:
 - SOL balance (native)
 - USDC balance
-- Other SPL token balances with USD values
-- Total portfolio value in USD
+- Token balances (SPL & Token-2022) with USD values and program standard
+- Total spot holdings value in USD
 
-Use to check available capital before deploying positions.`,
+Use to check available capital before deploying positions or executing swaps.`,
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+
+  {
+    type: 'function',
+    function: {
+      name: 'get_portfolio_summary',
+      description: `Get unified portfolio summary combining spot wallet holdings and active Meteora DLMM LP positions.
+Delivers total net worth and capital allocation breakdown across:
+- Liquid SOL (cash & gas) with USD valuation
+- Spot token balances (SPL & Token-2022) with individual USD valuations
+- Active Meteora LP positions (deposited capital, active bins, in-range status)
+- Uncollected LP fees ($ USD)
+- Total Net Equity ($ USD)
+
+Use when asked for "portfolio", "net worth", "total assets", "total capital", or "all holdings".`,
       parameters: {
         type: 'object',
         properties: {},

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -6,6 +6,7 @@ import { tools } from './ToolDefinitions.js'
 import {
   closeAllPositions,
   executeTool,
+  getPortfolioSummary,
   swapAllTokensToSol,
   swapBaseToSolWithRetry,
   WRITE_TOOLS,
@@ -831,5 +832,91 @@ describe('ToolExecutor - close_position auto-swap', () => {
     expect(result.success).toBe(true)
     expect(result.auto_swapped).toBeUndefined()
     expect(WalletAdapter.swapToken).not.toHaveBeenCalled()
+  })
+})
+
+describe('ToolExecutor - Portfolio & Position Disambiguation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('getPortfolioSummary computes unified net worth combining spot balances and LP positions', async () => {
+    const mockBalances = {
+      wallet: 'TestWallet111111111111111111111111111111111',
+      sol: 2.5,
+      sol_price: 150,
+      sol_usd: 375,
+      usdc: 50,
+      tokens: [
+        { mint: 'USDC_MINT', symbol: 'USDC', balance: 50, usd: 50, program: 'spl-token' },
+        { mint: 'TOKEN2022_MINT', symbol: 'OTC', balance: 1000, usd: 25, program: 'token-2022' },
+      ],
+      total_usd: 450, // 375 + 50 + 25
+    }
+
+    const mockPositions = {
+      wallet: 'TestWallet111111111111111111111111111111111',
+      total_positions: 1,
+      positions: [
+        {
+          position: 'PosAddress111111111111111111111111111111111',
+          pool: 'PoolAddress111111111111111111111111111111111',
+          in_range: true,
+          pnl_pct: 3.5,
+          unclaimed_fees_usd: 12.5,
+          total_value_usd: 200,
+        },
+      ],
+    }
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue(mockBalances as any)
+    vi.mocked(MeteoraAdapter.getMyPositions).mockResolvedValue(mockPositions as any)
+
+    const summary = await getPortfolioSummary()
+
+    expect(summary.wallet).toBe('TestWallet111111111111111111111111111111111')
+    expect(summary.sol).toBe(2.5)
+    expect(summary.sol_usd).toBe(375)
+    expect(summary.spot_tokens_usd).toBe(75) // 50 + 25
+    expect(summary.spot_tokens).toHaveLength(2)
+    expect(summary.lp_positions_count).toBe(1)
+    expect(summary.lp_positions_usd).toBe(200)
+    expect(summary.lp_unclaimed_fees_usd).toBe(12.5)
+    // total net worth = 450 (spot) + 200 (LP capital) + 12.5 (fees) = 662.5
+    expect(summary.total_net_worth_usd).toBe(662.5)
+  })
+
+  it('executes get_meteora_positions via executeTool and delegates to getMyPositions', async () => {
+    vi.mocked(MeteoraAdapter.getMyPositions).mockResolvedValue({
+      total_positions: 0,
+      positions: [],
+    } as any)
+
+    const result = await executeTool('get_meteora_positions', {})
+
+    expect(MeteoraAdapter.getMyPositions).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ total_positions: 0, positions: [] })
+  })
+
+  it('executes get_portfolio_summary via executeTool', async () => {
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({
+      wallet: 'W1',
+      sol: 1,
+      sol_price: 100,
+      sol_usd: 100,
+      usdc: 0,
+      tokens: [],
+      total_usd: 100,
+    } as any)
+    vi.mocked(MeteoraAdapter.getMyPositions).mockResolvedValue({
+      total_positions: 0,
+      positions: [],
+    } as any)
+
+    const result = (await executeTool('get_portfolio_summary', {})) as any
+
+    expect(result.total_net_worth_usd).toBe(100)
+    expect(result.lp_positions_count).toBe(0)
+    expect(result.sol).toBe(1)
   })
 })

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -55,7 +55,7 @@ import { addToBlacklist, listBlacklist, removeFromBlacklist } from '../domain/to
 import { getMinSafeBinsBelow, REPO_ROOT, USER_CONFIG_PATH } from '../shared/constants.js'
 import { log, logAction, logStructured } from '../shared/logger.js'
 import { Mutex } from '../shared/mutex.js'
-import type { AgentRole } from '../shared/types.js'
+import type { AgentRole, PortfolioSummaryResult } from '../shared/types.js'
 import { loadJsonFile, normalizeTimeframe, saveJsonFile, scaleScreeningToTimeframe } from '../shared/utils.js'
 import { sleep } from '../utils/time.js'
 import {
@@ -424,6 +424,50 @@ function normalizeConfigValue(key: string, value: unknown): unknown {
   return coerceFiniteNumber(value, key)
 }
 
+/**
+ * Unified portfolio summary combining spot wallet token holdings (SOL, SPL, Token-2022)
+ * and active Meteora DLMM LP positions.
+ */
+export async function getPortfolioSummary(options?: { force?: boolean }): Promise<PortfolioSummaryResult> {
+  const [walletBalances, myPositions] = await Promise.all([
+    getWalletBalances(options),
+    getMyPositions(options ? { force: options.force, silent: true } : { silent: true }),
+  ])
+
+  let lpPositionsUsd = 0
+  let lpUnclaimedFeesUsd = 0
+  for (const pos of myPositions.positions || []) {
+    const val = pos.total_value_usd ?? pos.value_usd ?? 0
+    lpPositionsUsd += val
+    lpUnclaimedFeesUsd += pos.unclaimed_fees_usd ?? 0
+  }
+  lpPositionsUsd = Math.round(lpPositionsUsd * 100) / 100
+  lpUnclaimedFeesUsd = Math.round(lpUnclaimedFeesUsd * 100) / 100
+
+  let spotTokensUsd = 0
+  for (const t of walletBalances.tokens || []) {
+    spotTokensUsd += t.usd ?? 0
+  }
+  spotTokensUsd = Math.round(spotTokensUsd * 100) / 100
+
+  const totalNetWorthUsd = Math.round((walletBalances.total_usd + lpPositionsUsd + lpUnclaimedFeesUsd) * 100) / 100
+
+  return {
+    wallet: walletBalances.wallet,
+    sol: walletBalances.sol,
+    sol_price: walletBalances.sol_price,
+    sol_usd: walletBalances.sol_usd,
+    spot_tokens_usd: spotTokensUsd,
+    spot_tokens: walletBalances.tokens,
+    lp_positions_count: myPositions.total_positions ?? myPositions.positions?.length ?? 0,
+    lp_positions_usd: lpPositionsUsd,
+    lp_unclaimed_fees_usd: lpUnclaimedFeesUsd,
+    lp_positions: myPositions.positions || [],
+    total_net_worth_usd: totalNetWorthUsd,
+    error: walletBalances.error || myPositions.error,
+  }
+}
+
 // ─── Tool map ──────────────────────────────────────────────────
 
 type ToolFn = (args: Record<string, unknown>) => Promise<Record<string, unknown>> | Record<string, unknown>
@@ -436,6 +480,7 @@ const toolMap: Record<string, ToolFn> = {
   get_active_bin: getActiveBin as unknown as ToolFn,
   deploy_position: deployPosition as unknown as ToolFn,
   get_my_positions: getMyPositions as unknown as ToolFn,
+  get_meteora_positions: getMyPositions as unknown as ToolFn,
   get_wallet_positions: getWalletPositions as unknown as ToolFn,
   search_pools: searchPools as unknown as ToolFn,
   get_token_info: getTokenInfo as unknown as ToolFn,
@@ -452,6 +497,7 @@ const toolMap: Record<string, ToolFn> = {
     return closeAllPositionsUnlocked(skipSwap)
   }) as ToolFn,
   get_wallet_balance: getWalletBalances as unknown as ToolFn,
+  get_portfolio_summary: getPortfolioSummary as unknown as ToolFn,
   swap_all_tokens_to_sol: ((args: Record<string, unknown> = {}) => {
     const skipMints = (args.skipMints as string[]) || (args.skip_mints as string[]) || []
     return swapAllTokensToSolUnlocked(Array.isArray(skipMints) ? skipMints : [])

--- a/packages/core/src/adapters/blockchain/WalletAdapter.test.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.test.ts
@@ -18,6 +18,8 @@ import {
   invalidateBalanceCache,
   setCachedMintDecimals,
   swapToken,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
 } from './WalletAdapter.js'
 
 describe('WalletAdapter', () => {
@@ -209,6 +211,213 @@ describe('WalletAdapter', () => {
       expect(res.wallet).toBe(testKeypair.publicKey.toString())
       expect(res.sol).toBe(2.0)
       expect(res.total_usd).toBe(200.0)
+    })
+
+    it('queries both standard SPL Token and Token-2022 programs concurrently and discovers Token-2022 accounts', async () => {
+      const getParsedTokenAccountsSpy = vi.spyOn(Connection.prototype, 'getParsedTokenAccountsByOwner')
+      getParsedTokenAccountsSpy.mockImplementation(async (_owner, filter: any) => {
+        if (filter.programId.equals(TOKEN_PROGRAM_ID)) {
+          return {
+            value: [
+              {
+                account: {
+                  data: {
+                    parsed: {
+                      info: {
+                        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                        tokenAmount: { uiAmount: 10.5, decimals: 6 },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          } as any
+        }
+        if (filter.programId.equals(TOKEN_2022_PROGRAM_ID)) {
+          return {
+            value: [
+              {
+                account: {
+                  data: {
+                    parsed: {
+                      info: {
+                        mint: 'Token2022MintAddress111111111111111111111111',
+                        tokenAmount: { uiAmount: 1397.91, decimals: 9 },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          } as any
+        }
+        return { value: [] } as any
+      })
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
+        if (String(url).includes('jup.ag/price/v2')) {
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers(),
+            json: async () => ({
+              data: {
+                So11111111111111111111111111111111111111112: { price: '150.0' },
+                EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: { price: '1.0' },
+                Token2022MintAddress111111111111111111111111: { price: '0.02' },
+              },
+            }),
+          } as any
+        }
+        return { ok: false, status: 404, headers: new Headers() } as any
+      })
+
+      const balances = await getWalletBalances({ force: true })
+      expect(getParsedTokenAccountsSpy).toHaveBeenCalledTimes(2)
+      const token2022Item = balances.tokens.find((t) => t.mint === 'Token2022MintAddress111111111111111111111111')
+      expect(token2022Item).toBeDefined()
+      expect(token2022Item?.balance).toBe(1397.91)
+      expect(token2022Item?.usd).toBe(27.96)
+      expect(token2022Item?.program).toBe('token-2022')
+    })
+
+    it('aggregates multiple token accounts for the same mint across programs', async () => {
+      const getParsedTokenAccountsSpy = vi.spyOn(Connection.prototype, 'getParsedTokenAccountsByOwner')
+      getParsedTokenAccountsSpy.mockImplementation(async (_owner, filter: any) => {
+        if (filter.programId.equals(TOKEN_PROGRAM_ID)) {
+          return {
+            value: [
+              {
+                account: {
+                  data: {
+                    parsed: {
+                      info: {
+                        mint: 'DUAL_MINT_1111111111111111111111111111111111',
+                        tokenAmount: { uiAmount: 50, decimals: 6 },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          } as any
+        }
+        if (filter.programId.equals(TOKEN_2022_PROGRAM_ID)) {
+          return {
+            value: [
+              {
+                account: {
+                  data: {
+                    parsed: {
+                      info: {
+                        mint: 'DUAL_MINT_1111111111111111111111111111111111',
+                        tokenAmount: { uiAmount: 25, decimals: 6 },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          } as any
+        }
+        return { value: [] } as any
+      })
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
+        if (String(url).includes('jup.ag/price/v2')) {
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers(),
+            json: async () => ({
+              data: {
+                So11111111111111111111111111111111111111112: { price: '150.0' },
+                DUAL_MINT_1111111111111111111111111111111111: { price: '2.0' },
+              },
+            }),
+          } as any
+        }
+        return { ok: false, status: 404, headers: new Headers() } as any
+      })
+
+      const balances = await getWalletBalances({ force: true })
+      const item = balances.tokens.find((t) => t.mint === 'DUAL_MINT_1111111111111111111111111111111111')
+      expect(item).toBeDefined()
+      expect(item?.balance).toBe(75) // 50 + 25 aggregated
+      expect(item?.usd).toBe(150)
+    })
+
+    it('enriches unpriced tokens with Helius balances API when heliusApiKey is present', async () => {
+      config.connection = {
+        ...config.connection,
+        heliusApiKey: 'enrich-helius-key',
+      }
+      const unpricedMint = 'UNPRICED_MEME_TOKEN_MINT_11111111111111111111'
+      const getParsedTokenAccountsSpy = vi.spyOn(Connection.prototype, 'getParsedTokenAccountsByOwner')
+      getParsedTokenAccountsSpy.mockImplementation(async (_owner, filter: any) => {
+        if (filter.programId.equals(TOKEN_PROGRAM_ID)) {
+          return {
+            value: [
+              {
+                account: {
+                  data: {
+                    parsed: {
+                      info: {
+                        mint: unpricedMint,
+                        tokenAmount: { uiAmount: 1000, decimals: 6 },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          } as any
+        }
+        return { value: [] } as any
+      })
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any) => {
+        const urlStr = String(url)
+        if (urlStr.includes('jup.ag/price/v2')) {
+          // Jupiter returns no price for this unpriced meme token
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers(),
+            json: async () => ({
+              data: {
+                So11111111111111111111111111111111111111112: { price: '150.0' },
+              },
+            }),
+          } as any
+        }
+        if (urlStr.includes('api.helius.xyz')) {
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers(),
+            json: async () => ({
+              balances: [
+                {
+                  mint: unpricedMint,
+                  symbol: 'MEME',
+                  balance: 1000,
+                  pricePerToken: 0.05,
+                  usdValue: 50.0,
+                },
+              ],
+            }),
+          } as any
+        }
+        return { ok: false, status: 404, headers: new Headers() } as any
+      })
+
+      const balances = await getWalletBalances({ force: true })
+      const memeToken = balances.tokens.find((t) => t.mint === unpricedMint)
+      expect(memeToken).toBeDefined()
+      expect(memeToken?.symbol).toBe('MEME')
+      expect(memeToken?.usd).toBe(50.0)
     })
 
     it('invalidates balance cache when swapToken completes successfully', async () => {

--- a/packages/core/src/adapters/blockchain/WalletAdapter.ts
+++ b/packages/core/src/adapters/blockchain/WalletAdapter.ts
@@ -206,8 +206,8 @@ function getJupiterReferralParams(): JupiterReferralParams | null {
 export const BALANCE_CACHE_TTL = 30_000
 const SOL_MINT = 'So11111111111111111111111111111111111111112'
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
-const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA') // Token Program
-const _TOKEN_2022_PROGRAM_ID = new PublicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb') // Token-2022 Program
+export const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA') // Token Program
+export const TOKEN_2022_PROGRAM_ID = new PublicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb') // Token-2022 Program
 
 const _mintDecimalsCache = new Map<string, number>([
   [SOL_MINT, 9],
@@ -270,9 +270,9 @@ export async function getSolPrice(options?: { force?: boolean }): Promise<number
 export type { WalletBalancesResult }
 
 /**
- * Get current wallet balances: SOL, USDC, and all SPL tokens.
- * Primary method: standard on-chain Solana RPC + free Jupiter Price API v2 (0 Helius credit cost).
- * Optional fallback: Helius Enhanced API if on-chain RPC fails.
+ * Get current wallet balances: SOL, USDC, and all SPL & Token-2022 tokens.
+ * Primary method: standard on-chain Solana dual RPC scan + free Jupiter Price API v2 (0 Helius credit cost).
+ * Optional fallback / enrichment: Helius Enhanced API if on-chain RPC fails or unpriced tokens exist.
  * Caches results in memory for 30 seconds unless force=true is passed.
  */
 export async function getWalletBalances(options?: { force?: boolean }): Promise<WalletBalancesResult> {
@@ -306,35 +306,73 @@ export async function getWalletBalances(options?: { force?: boolean }): Promise<
   const fetchBalances = async (): Promise<WalletBalancesResult> => {
     // ─── 1. Primary Method: Standard Solana RPC + composite price provider ─
     try {
-      const solLamports = await withRpcFailover((conn) => conn.getBalance(walletPubkey), { label: 'getBalance' })
+      const [solLamports, tokenAccounts, token2022Accounts] = await Promise.all([
+        withRpcFailover((conn) => conn.getBalance(walletPubkey), { label: 'getBalance' }),
+        withRpcFailover((conn) => conn.getParsedTokenAccountsByOwner(walletPubkey, { programId: TOKEN_PROGRAM_ID }), {
+          label: 'getParsedTokenAccountsByOwner(Token)',
+        }),
+        withRpcFailover(
+          (conn) => conn.getParsedTokenAccountsByOwner(walletPubkey, { programId: TOKEN_2022_PROGRAM_ID }),
+          { label: 'getParsedTokenAccountsByOwner(Token-2022)' },
+        ).catch((err: unknown) => {
+          const e = err as { message?: string }
+          log('wallet_warn', `Token-2022 scan failed (${e.message || err}); continuing with standard tokens`)
+          return { value: [] }
+        }),
+      ])
       const solBalance = (solLamports || 0) / 1e9
 
-      const tokenAccounts = await withRpcFailover(
-        (conn) => conn.getParsedTokenAccountsByOwner(walletPubkey, { programId: TOKEN_PROGRAM_ID }),
-        { label: 'getParsedTokenAccountsByOwner' },
-      )
-
-      const tokensList: Array<{ mint: string; symbol: string; balance: number; usd: number | null }> = []
+      const tokensMap = new Map<
+        string,
+        {
+          mint: string
+          symbol: string
+          balance: number
+          usd: number | null
+          program: 'spl-token' | 'token-2022'
+        }
+      >()
       const mintsToPrice: string[] = [SOL_MINT, USDC_MINT]
 
-      for (const item of tokenAccounts.value || []) {
-        const info = item.account?.data?.parsed?.info
-        if (!info) continue
-        const mint = info.mint
-        const decimals = info.tokenAmount?.decimals
-        if (typeof decimals === 'number') {
-          _mintDecimalsCache.set(mint, decimals)
+      const processAccounts = (
+        accounts: Array<{ account?: { data?: { parsed?: { info?: any } } } }>,
+        program: 'spl-token' | 'token-2022',
+      ) => {
+        for (const item of accounts) {
+          const info = item.account?.data?.parsed?.info
+          if (!info) continue
+          const mint = info.mint
+          if (!mint || typeof mint !== 'string') continue
+          const decimals = info.tokenAmount?.decimals
+          if (typeof decimals === 'number') {
+            _mintDecimalsCache.set(mint, decimals)
+          }
+          const uiAmount = info.tokenAmount?.uiAmount ?? 0
+          if (uiAmount <= 0) continue
+
+          if (!mintsToPrice.includes(mint)) {
+            mintsToPrice.push(mint)
+          }
+
+          const existing = tokensMap.get(mint)
+          if (existing) {
+            existing.balance += uiAmount
+          } else {
+            tokensMap.set(mint, {
+              mint,
+              symbol: mint === USDC_MINT ? 'USDC' : mint.slice(0, 8),
+              balance: uiAmount,
+              usd: null,
+              program,
+            })
+          }
         }
-        const uiAmount = info.tokenAmount?.uiAmount ?? 0
-        if (uiAmount <= 0) continue
-        if (!mintsToPrice.includes(mint)) mintsToPrice.push(mint)
-        tokensList.push({
-          mint,
-          symbol: mint === USDC_MINT ? 'USDC' : mint.slice(0, 8),
-          balance: uiAmount,
-          usd: null,
-        })
       }
+
+      processAccounts(tokenAccounts.value || [], 'spl-token')
+      processAccounts(token2022Accounts.value || [], 'token-2022')
+
+      const tokensList = Array.from(tokensMap.values())
 
       // Fetch SOL price via Binance/Coinbase (cached) — fallback if composite doesn't return SOL
       const binanceSolPrice = (await getSolPrice()) ?? 0
@@ -361,6 +399,50 @@ export async function getWalletBalances(options?: { force?: boolean }): Promise<
         }
         if (t.usd) tokenUsdSum += t.usd
       }
+
+      // Optional enrichment: if heliusApiKey is configured and there are tokens with missing price or symbol
+      let HELIUS_API_KEY = config.connection?.heliusApiKey
+      if (HELIUS_API_KEY) {
+        HELIUS_API_KEY = HELIUS_API_KEY.trim().replace(/^api-key=/i, '')
+      }
+      const hasUnpricedTokens = tokensList.some((t) => t.usd === null)
+      if (HELIUS_API_KEY && hasUnpricedTokens) {
+        try {
+          const url = `https://api.helius.xyz/v1/wallet/${walletAddress}/balances?api-key=${HELIUS_API_KEY}`
+          const res = await fetch(url)
+          if (res.ok) {
+            const data = (await res.json()) as {
+              balances?: Array<{
+                mint: string
+                symbol?: string
+                balance: number
+                pricePerToken?: number
+                usdValue?: number
+              }>
+            }
+            const heliusBalances = data.balances || []
+            const heliusMap = new Map(heliusBalances.map((b) => [b.mint, b]))
+            tokenUsdSum = 0
+            for (const t of tokensList) {
+              const h = heliusMap.get(t.mint)
+              if (t.usd === null && h) {
+                if (h.usdValue != null) {
+                  t.usd = Math.round(h.usdValue * 100) / 100
+                } else if (h.pricePerToken != null) {
+                  t.usd = Math.round(t.balance * h.pricePerToken * 100) / 100
+                }
+              }
+              if ((!t.symbol || t.symbol === t.mint.slice(0, 8)) && h?.symbol) {
+                t.symbol = h.symbol
+              }
+              if (t.usd) tokenUsdSum += t.usd
+            }
+          }
+        } catch (enrichErr: unknown) {
+          log('wallet_warn', `Helius token enrichment failed: ${(enrichErr as Error)?.message || enrichErr}`)
+        }
+      }
+
       const totalUsd = Math.round((solUsd + tokenUsdSum) * 100) / 100
 
       const result: WalletBalancesResult = {

--- a/packages/core/src/adapters/notifications/TelegramAdapter.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.ts
@@ -337,7 +337,9 @@ function toolLabel(name: string): string {
     swap_all_tokens_to_sol: 'swap all tokens to SOL',
     update_config: 'update config',
     get_my_positions: 'get positions',
+    get_meteora_positions: 'get Meteora positions',
     get_wallet_balance: 'get wallet balance',
+    get_portfolio_summary: 'get portfolio summary',
     check_smart_wallets_on_pool: 'check smart wallets',
     study_top_lpers: 'study top LPers',
     get_top_lpers: 'get top LPers',
@@ -370,9 +372,12 @@ export function summarizeToolResult(name: string, result: any): string {
     case 'discover_pools':
       return formatCandidateScanSummary(result)
     case 'get_my_positions':
+    case 'get_meteora_positions':
       return `${result.total_positions ?? result.positions?.length ?? 0} positions`
     case 'get_wallet_balance':
-      return `${result.sol ?? '?'} SOL`
+      return `${result.sol ?? '?'} SOL ($${result.total_usd ?? 0})`
+    case 'get_portfolio_summary':
+      return `$${result.total_net_worth_usd ?? 0} total`
     case 'study_top_lpers':
     case 'get_top_lpers':
       return `${result.lpers?.length ?? 0} LPers`

--- a/packages/core/src/application/agent-loop.test.ts
+++ b/packages/core/src/application/agent-loop.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { agentLoop } from '../application/agent-loop.js'
+import { agentLoop, INTENT_PATTERNS, INTENT_TOOLS, MANAGER_TOOLS, SCREENER_TOOLS } from '../application/agent-loop.js'
 
 const mockOpenAICreate = vi.fn()
 
@@ -439,5 +439,32 @@ STEPS:
         reason: expect.stringContaining('already attempted this session'),
       }),
     )
+  })
+})
+
+describe('agent-loop — portfolio intent routing & tools', () => {
+  it('recognizes portfolio and net worth intent patterns', () => {
+    const portfolioPattern = INTENT_PATTERNS.find((p) => p.intent === 'portfolio')
+    expect(portfolioPattern).toBeDefined()
+    expect(portfolioPattern?.re.test('what is my portfolio summary?')).toBe(true)
+    expect(portfolioPattern?.re.test('show total net worth')).toBe(true)
+    expect(portfolioPattern?.re.test('what are all assets in wallet?')).toBe(true)
+    expect(portfolioPattern?.re.test('check my holdings')).toBe(true)
+  })
+
+  it('includes get_portfolio_summary in MANAGER_TOOLS and SCREENER_TOOLS', () => {
+    expect(MANAGER_TOOLS.has('get_portfolio_summary')).toBe(true)
+    expect(MANAGER_TOOLS.has('get_meteora_positions')).toBe(true)
+    expect(SCREENER_TOOLS.has('get_portfolio_summary')).toBe(true)
+    expect(SCREENER_TOOLS.has('get_meteora_positions')).toBe(true)
+  })
+
+  it('provides comprehensive tool set under portfolio intent', () => {
+    const tools = INTENT_TOOLS.portfolio
+    expect(tools).toBeDefined()
+    expect(tools?.has('get_portfolio_summary')).toBe(true)
+    expect(tools?.has('get_wallet_balance')).toBe(true)
+    expect(tools?.has('get_meteora_positions')).toBe(true)
+    expect(tools?.has('get_my_positions')).toBe(true)
   })
 })

--- a/packages/core/src/application/agent-loop.ts
+++ b/packages/core/src/application/agent-loop.ts
@@ -55,7 +55,9 @@ export const MANAGER_TOOLS = new Set([
   'swap_token',
   'get_position_pnl',
   'get_my_positions',
+  'get_meteora_positions',
   'get_wallet_balance',
+  'get_portfolio_summary',
 ])
 
 export const SCREENER_TOOLS = new Set([
@@ -70,6 +72,8 @@ export const SCREENER_TOOLS = new Set([
   'get_pool_memory',
   'get_wallet_balance',
   'get_my_positions',
+  'get_meteora_positions',
+  'get_portfolio_summary',
 ])
 
 export const GENERAL_INTENT_ONLY_TOOLS = new Set([
@@ -122,11 +126,20 @@ export const INTENT_TOOLS: Record<string, Set<string>> = {
     'list_blocked_deployers',
   ]),
   selfupdate: new Set(['self_update']),
-  balance: new Set(['get_wallet_balance', 'get_my_positions', 'get_wallet_positions']),
+  portfolio: new Set(['get_portfolio_summary', 'get_wallet_balance', 'get_meteora_positions', 'get_my_positions']),
+  balance: new Set([
+    'get_wallet_balance',
+    'get_portfolio_summary',
+    'get_my_positions',
+    'get_meteora_positions',
+    'get_wallet_positions',
+  ]),
   positions: new Set([
+    'get_meteora_positions',
     'get_my_positions',
     'get_position_pnl',
     'get_wallet_balance',
+    'get_portfolio_summary',
     'set_position_note',
     'get_wallet_positions',
   ]),
@@ -189,8 +202,12 @@ export const INTENT_PATTERNS: Array<{ intent: string; re: RegExp }> = [
     re: /\b(blacklist|block|unblock|blocklist|blocked deployer|rugger|block dev|block deployer)\b/i,
   },
   { intent: 'config', re: /\b(config|setting|threshold|update|set |change)\b/i },
+  {
+    intent: 'portfolio',
+    re: /\b(portfolio|net worth|total assets|total capital|all assets|holdings)\b/i,
+  },
   { intent: 'balance', re: /\b(balance|wallet|sol|how much)\b/i },
-  { intent: 'positions', re: /\b(position|portfolio|open|pnl|yield|range)\b/i },
+  { intent: 'positions', re: /\b(position|open|pnl|yield|range)\b/i },
   { intent: 'strategy', re: /\b(strategy|strategies)\b/i },
   { intent: 'screen', re: /\b(screen|candidate|find pool|search|research|token)\b/i },
   { intent: 'memory', re: /\b(memory|pool history|note|remember)\b/i },

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -150,8 +150,30 @@ export interface WalletBalancesResult {
     symbol: string
     balance: number
     usd: number | null
+    program?: 'spl-token' | 'token-2022'
   }>
   total_usd: number
+  error?: string
+}
+
+export interface PortfolioSummaryResult {
+  wallet: string | null
+  sol: number
+  sol_price: number
+  sol_usd: number
+  spot_tokens_usd: number
+  spot_tokens: Array<{
+    mint: string
+    symbol: string
+    balance: number
+    usd: number | null
+    program?: 'spl-token' | 'token-2022'
+  }>
+  lp_positions_count: number
+  lp_positions_usd: number
+  lp_unclaimed_fees_usd: number
+  lp_positions: OnChainPosition[]
+  total_net_worth_usd: number
   error?: string
 }
 


### PR DESCRIPTION
## Summary
- Supports parallel dual RPC scanning of standard SPL Token (`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`) and Token-2022 (`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`) programs.
- Aggregates balances across multiple token accounts for the same mint into unified entries and caches token decimals for all discovered tokens.
- Supports Helius price and symbol enrichment for unpriced tokens when `heliusApiKey` is configured, while retaining Helius as the full fallback on standard RPC failure.
- Resolves semantic ambiguity with clear tool separation:
  - `get_meteora_positions`: Strictly inspects active Meteora DLMM LP bins (updated `get_my_positions` description as alias).
  - `get_wallet_balance`: Strictly inspects spot tokens and cash held directly in the wallet.
  - `get_portfolio_summary`: Unified net worth across spot holdings and active Meteora LP capital + uncollected fees.
- Adds `portfolio` intent pattern and tool mapping in `agent-loop.ts`, with Telegram status label formatting.

Closes #262

## Root Cause & Gap Analysis
- **Why/When it happened**: `WalletAdapter.ts` only queried `TOKEN_PROGRAM_ID`, omitting `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` entirely. Helius fallback was trapped in a crash-only catch block. Semantic confusion occurred when operators asked for positions and the agent only checked DLMM LP bins instead of spot wallet balances.
- **Why we missed it**: Unit tests mocked `getParsedTokenAccountsByOwner` with legacy USDC only and never asserted concurrent queries to both token programs.

## Acceptance Criteria Checklist
- [x] AC1: Dual program native RPC scanning (`TOKEN_PROGRAM_ID` and `TOKEN_2022_PROGRAM_ID` queried in parallel).
- [x] AC2: Mint deduplication and decimal caching across both programs.
- [x] AC3: Helius price and symbol enrichment for unpriced tokens when `heliusApiKey` is configured.
- [x] AC4: Semantic tool disambiguation (`get_meteora_positions`, `get_wallet_balance`, `get_portfolio_summary`).
- [x] AC5: Intent routing and notification formatting for `portfolio` queries.
- [x] AC6: Regression tests passing (14 tests in `WalletAdapter.test.ts`, 30 in `ToolExecutor.test.ts`, 8 in `agent-loop.test.ts`, 387 across monorepo).

## Testing Plan
- [x] **CI: Typecheck & Lint** — clean (`pnpm -r run typecheck`, `npx biome check`)
- [x] **CI: Automated Tests** — all green (33 test files, 387 tests passed)