### PR TITLE
[Core] Unsold base token lifecycle & continuous reconciliation sweeper

### DIFF
--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -569,6 +569,11 @@ export class Cli {
         return this.handleClose(flags)
       case 'swap':
         return this.handleSwap(flags)
+      case 'sweep':
+      case 'swap-all':
+        return this.handleSweep(flags)
+      case 'liquidations':
+        return this.handleLiquidations(flags)
       case 'screen':
         return this.handleScreen(flags)
       case 'manage':
@@ -1108,6 +1113,23 @@ export class Cli {
     out(
       await this.adapters.toolExecutor.executeTool('swap_all_tokens_to_sol', {
         skipMints,
+      }),
+    )
+  }
+
+  private async handleSweep(flags: Record<string, any>): Promise<void> {
+    const skipMints = typeof flags.skip === 'string' ? flags.skip.split(',') : []
+    out(
+      await this.adapters.toolExecutor.executeTool('sweep_unsold_tokens', {
+        skipMints,
+      }),
+    )
+  }
+
+  private async handleLiquidations(flags: Record<string, any>): Promise<void> {
+    out(
+      await this.adapters.toolExecutor.executeTool('get_pending_liquidations', {
+        status: flags.status,
       }),
     )
   }

--- a/packages/core/src/adapters/ToolDefinitions.ts
+++ b/packages/core/src/adapters/ToolDefinitions.ts
@@ -456,9 +456,9 @@ WARNING: This executes a real on-chain transaction.`,
     type: 'function',
     function: {
       name: 'swap_all_tokens_to_sol',
-      description: `Sweep and swap all non-SOL SPL tokens in the wallet back to SOL in a single safe, sequentially paced batch.
+      description: `Sweep and swap all non-SOL SPL tokens in the wallet back to SOL in a single safe, sequentially paced batch (alias for sweep_unsold_tokens).
 Use when multiple leftover tokens or claimed fee tokens have accumulated in the wallet.
-Automatically skips SOL and USDC, and sequentially sells each token via Jupiter with built-in retry and pacing to prevent rate limits.
+Automatically skips SOL and USDC, and sequentially sells each token via Jupiter with DLMM direct pool fallback.
 
 WARNING: This executes real on-chain transactions.`,
       parameters: {
@@ -468,6 +468,48 @@ WARNING: This executes real on-chain transactions.`,
             type: 'array',
             items: { type: 'string' },
             description: 'Optional list of token mint addresses to exclude from swapping',
+          },
+        },
+      },
+    },
+  },
+
+  {
+    type: 'function',
+    function: {
+      name: 'sweep_unsold_tokens',
+      description: `Sweep and liquidate all unsold base tokens in the wallet back to SOL.
+Reconciles active wallet balances against the persistent liquidation backlog in state.json.
+Attempts Jupiter aggregator first, then falls back to direct Meteora DLMM pool swaps if Jupiter has no route.
+Skips micro-dust (< $0.02) and marks persistently illiquid/rugged tokens as abandoned to preserve gas.
+
+WARNING: This executes real on-chain transactions.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          skip_mints: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional list of token mint addresses to exclude from sweeping',
+          },
+        },
+      },
+    },
+  },
+
+  {
+    type: 'function',
+    function: {
+      name: 'get_pending_liquidations',
+      description: `Inspect the persistent backlog of unsold tokens awaiting liquidation.
+Returns details for each token including mint, symbol, amount, USD value, liquidation attempts, status (pending, liquidated, abandoned), and last error.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'string',
+            enum: ['pending', 'liquidated', 'abandoned'],
+            description: 'Optional status filter. Omit to retrieve all tracked liquidations.',
           },
         },
       },

--- a/packages/core/src/adapters/ToolExecutor.test.ts
+++ b/packages/core/src/adapters/ToolExecutor.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { config } from '../config/Config.js'
+import { __setStateFilePath } from '../domain/state.js'
 import * as MeteoraAdapter from './blockchain/MeteoraAdapter.js'
 import * as WalletAdapter from './blockchain/WalletAdapter.js'
 import { tools } from './ToolDefinitions.js'
@@ -12,6 +16,16 @@ import {
   WRITE_TOOLS,
   writeToolsMutex,
 } from './ToolExecutor.js'
+
+const TMP_STATE = path.join(os.tmpdir(), `etemaro-toolexecutor-test-${process.pid}.json`)
+
+beforeAll(() => {
+  __setStateFilePath(TMP_STATE)
+})
+
+afterAll(() => {
+  if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE)
+})
 
 // Mock the WalletAdapter functions
 vi.mock('./blockchain/WalletAdapter.js', () => ({
@@ -28,6 +42,16 @@ vi.mock('./blockchain/MeteoraAdapter.js', () => ({
   claimFees: vi.fn(),
   closePosition: vi.fn(),
   searchPools: vi.fn(),
+  swapDirectDlmm: vi.fn(),
+}))
+
+vi.mock('./notifications/TelegramAdapter.js', () => ({
+  notifyClose: vi.fn().mockResolvedValue(undefined),
+  notifyDeploy: vi.fn().mockResolvedValue(undefined),
+  notifySwap: vi.fn().mockResolvedValue(undefined),
+  notifySwapError: vi.fn().mockResolvedValue(undefined),
+  notifyTransactionError: vi.fn().mockResolvedValue(undefined),
+  notifyLiquidationAlert: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('./blockchain/ScreeningAdapter.js', () => ({
@@ -398,6 +422,7 @@ describe('ToolExecutor - deploy_position serialization', () => {
         'close_all_positions',
         'swap_token',
         'swap_all_tokens_to_sol',
+        'sweep_unsold_tokens',
       ]),
     )
 
@@ -918,5 +943,117 @@ describe('ToolExecutor - Portfolio & Position Disambiguation', () => {
     expect(result.total_net_worth_usd).toBe(100)
     expect(result.lp_positions_count).toBe(0)
     expect(result.sol).toBe(1)
+  })
+})
+
+describe('ToolExecutor - Unsold Token Lifecycle & Sweeper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('falls back to swapDirectDlmm when Jupiter aggregator fails and poolAddress is provided', async () => {
+    const baseMint = 'DLMM_FALLBACK_MINT_111111111111111111111'
+    const poolAddress = 'DLMM_POOL_111111111111111111111111111111111'
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({
+      sol_price: 150,
+      tokens: [{ mint: baseMint, symbol: 'FALLBACK', balance: 500, usd: 2.5 }],
+    } as any)
+
+    // Jupiter fails with no route
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: false,
+      error: 'Jupiter 400: No route found',
+    } as any)
+
+    // Direct DLMM pool swap succeeds
+    vi.mocked(MeteoraAdapter.swapDirectDlmm).mockResolvedValue({
+      success: true,
+      tx: 'direct-dlmm-tx-hash',
+      amount_out: 0.016,
+    })
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test dlmm fallback', 0.05, poolAddress)
+
+    expect(res.swapped).toBe(true)
+    expect(res.result).toMatchObject({ success: true, tx: 'direct-dlmm-tx-hash' })
+    expect(WalletAdapter.swapToken).toHaveBeenCalledTimes(1)
+    expect(MeteoraAdapter.swapDirectDlmm).toHaveBeenCalledWith({
+      pool_address: poolAddress,
+      input_mint: baseMint,
+      amount: 500,
+    })
+  })
+
+  it('enqueues into persistent liquidation queue and triggers notifyLiquidationAlert for high-value tokens', async () => {
+    const baseMint = 'HIGH_VAL_FAIL_MINT_111111111111111111111'
+    const TelegramAdapter = await import('./notifications/TelegramAdapter.js')
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({
+      sol_price: 150,
+      tokens: [{ mint: baseMint, symbol: 'HIGHVAL', balance: 1000, usd: 5.0 }],
+    } as any)
+
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: false,
+      error: 'HTTP 400 Bad Request',
+    } as any)
+
+    const res = await swapBaseToSolWithRetry(baseMint, 'test high value alert', 0.05)
+
+    expect(res.swapped).toBe(false)
+    const { getPendingLiquidation } = await import('../domain/liquidation-queue.js')
+    const queued = getPendingLiquidation(baseMint)
+    expect(queued).not.toBeNull()
+    expect(queued?.symbol).toBe('HIGHVAL')
+    expect(queued?.usd).toBe(5.0)
+
+    expect(TelegramAdapter.notifyLiquidationAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: 'HIGHVAL',
+        mint: baseMint,
+        usd: 5.0,
+      }),
+    )
+  })
+
+  it('sweep_unsold_tokens tool skips micro-dust (< $0.02) and executes swaps on actionable balances', async () => {
+    const dustMint = 'DUST_TOKEN_MINT_11111111111111111111111111'
+    const actionMint = 'ACTION_TOKEN_MINT_111111111111111111111111'
+
+    vi.mocked(WalletAdapter.getWalletBalances).mockResolvedValue({
+      sol_price: 150,
+      tokens: [
+        { mint: dustMint, symbol: 'DUST', balance: 10, usd: 0.005 },
+        { mint: actionMint, symbol: 'ACTION', balance: 200, usd: 1.5 },
+      ],
+    } as any)
+
+    vi.mocked(WalletAdapter.swapToken).mockResolvedValue({
+      success: true,
+      tx: 'action-swap-tx',
+      amount_out: '0.01',
+    } as any)
+
+    const result = (await executeTool('sweep_unsold_tokens', {})) as any
+
+    expect(result.successful).toBe(1)
+    expect(result.skipped).toBeGreaterThanOrEqual(1)
+    expect(WalletAdapter.swapToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input_mint: actionMint,
+      }),
+    )
+    expect(WalletAdapter.swapToken).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        input_mint: dustMint,
+      }),
+    )
+  })
+
+  it('get_pending_liquidations tool inspects queue via executeTool', async () => {
+    const res = (await executeTool('get_pending_liquidations', {})) as any
+    expect(res).toHaveProperty('liquidations')
+    expect(Array.isArray(res.liquidations)).toBe(true)
   })
 })

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -30,6 +30,14 @@ import {
   removeLessonsByKeyword,
   unpinLesson,
 } from '../domain/lessons.js'
+import {
+  enqueuePendingLiquidation,
+  getPendingLiquidation,
+  getPendingLiquidations,
+  markLiquidationAttempt,
+  markLiquidationSuccess,
+  pruneSettledLiquidations,
+} from '../domain/liquidation-queue.js'
 import { addPoolNote, getPoolMemory } from '../domain/pool-memory.js'
 import {
   addSmartWallet,
@@ -67,6 +75,7 @@ import {
   getPositionPnl,
   getWalletPositions,
   searchPools,
+  swapDirectDlmm,
 } from './blockchain/MeteoraAdapter.js'
 // ─── Adapter imports ───────────────────────────────────────────
 import { discoverPools, getPoolDetail, getTopCandidates } from './blockchain/ScreeningAdapter.js'
@@ -76,6 +85,7 @@ import { getWalletBalances, swapToken } from './blockchain/WalletAdapter.js'
 import {
   notifyClose,
   notifyDeploy,
+  notifyLiquidationAlert,
   notifySwap,
   notifySwapError,
   notifyTransactionError,
@@ -502,6 +512,14 @@ const toolMap: Record<string, ToolFn> = {
     const skipMints = (args.skipMints as string[]) || (args.skip_mints as string[]) || []
     return swapAllTokensToSolUnlocked(Array.isArray(skipMints) ? skipMints : [])
   }) as ToolFn,
+  sweep_unsold_tokens: ((args: Record<string, unknown> = {}) => {
+    const skipMints = (args.skipMints as string[]) || (args.skip_mints as string[]) || []
+    return sweepUnsoldTokensUnlocked({ skipMints: Array.isArray(skipMints) ? skipMints : [] })
+  }) as ToolFn,
+  get_pending_liquidations: ((args: Record<string, unknown> = {}) => {
+    const status = args.status as any
+    return { liquidations: getPendingLiquidations(status) }
+  }) as ToolFn,
   swap_token: swapToken as unknown as ToolFn,
   get_top_lpers: studyTopLPers as unknown as ToolFn,
   study_top_lpers: studyTopLPers as unknown as ToolFn,
@@ -864,6 +882,7 @@ export const WRITE_TOOLS = new Set([
   'close_all_positions',
   'swap_token',
   'swap_all_tokens_to_sol',
+  'sweep_unsold_tokens',
 ])
 export const PROTECTED_TOOLS = new Set([...WRITE_TOOLS, 'self_update'])
 
@@ -884,6 +903,7 @@ export async function swapBaseToSolWithRetry(
   baseMint: string,
   label: string,
   minUsd: number = 0.05,
+  poolAddress?: string | null,
 ): Promise<{
   swapped: boolean
   result: Record<string, unknown> | null
@@ -912,15 +932,42 @@ export async function swapBaseToSolWithRetry(
         'executor',
         `Auto-swapping ${label} ${token.symbol || baseMint.slice(0, 8)}${usdDisplay} back to SOL (attempt ${attempt}/${attempts})`,
       )
-      const swapResult = await swapToken({ input_mint: baseMint, output_mint: 'SOL', amount: token.balance })
-      const sr = swapResult as any
-      const ok = swapResult && sr.success !== false && !sr.error && (sr.tx || sr.amount_out)
+      let swapResult = await swapToken({ input_mint: baseMint, output_mint: 'SOL', amount: token.balance })
+      let sr = swapResult as any
+      let ok = swapResult && sr.success !== false && !sr.error && (sr.tx || sr.amount_out)
+
+      // Fallback: if Jupiter aggregator has no route or fails, attempt direct DLMM pool swap if pool address is known
+      if (!ok && poolAddress) {
+        log(
+          'executor',
+          `Jupiter swap failed for ${token.symbol || baseMint.slice(0, 8)} (${sr?.error || 'no route'}); attempting direct DLMM pool swap fallback on ${poolAddress.slice(0, 8)}`,
+        )
+        const dlmmRes = await swapDirectDlmm({
+          pool_address: poolAddress,
+          input_mint: baseMint,
+          amount: token.balance,
+        })
+        if (dlmmRes?.success && (dlmmRes.tx || dlmmRes.amount_out)) {
+          swapResult = dlmmRes as any
+          sr = dlmmRes as any
+          ok = true
+        } else if (dlmmRes?.error) {
+          lastErr = `DLMM direct swap failed: ${dlmmRes.error} (Jupiter: ${sr?.error || 'no route'})`
+        }
+      }
+
       if (ok) {
         recordSwapSuccess()
         const solReceived =
           sr.amount_out != null ? (typeof sr.amount_out === 'number' ? sr.amount_out : parseFloat(sr.amount_out)) : null
         const usdValue =
           token.usd ?? (solReceived != null && balances.sol_price ? solReceived * balances.sol_price : null)
+
+        await markLiquidationSuccess(baseMint, {
+          tx: sr.tx,
+          amountOutSol: solReceived != null ? solReceived : undefined,
+        }).catch(() => {})
+
         notifySwap({
           inputSymbol: token.symbol || baseMint.slice(0, 8),
           outputSymbol: 'SOL',
@@ -937,7 +984,7 @@ export async function swapBaseToSolWithRetry(
           token: token as unknown as Record<string, unknown>,
         }
       }
-      lastErr = sr?.error || sr?.reason || 'swap returned no tx'
+      if (!lastErr) lastErr = sr?.error || sr?.reason || 'swap returned no tx'
     } catch (e: any) {
       lastErr = e.message
     }
@@ -950,14 +997,197 @@ export async function swapBaseToSolWithRetry(
   )
   recordSwapFailure({ maxFailedSwapsBeforeHalt, haltOnSwapFailure })
   const symbol = lastToken?.symbol || baseMint.slice(0, 8)
-  notifySwapError({
-    inputSymbol: symbol,
-    outputSymbol: 'SOL',
-    reason: lastErr || `Failed after ${attempts} attempts`,
+  const tokenUsd = lastToken?.usd ?? null
+  const alertThreshold = config.management.sweeperAlertUsd ?? 1.0
+
+  // Register in persistent liquidation queue
+  await enqueuePendingLiquidation({
+    mint: baseMint,
+    symbol,
+    amount: lastToken?.balance ?? 0,
+    usd: tokenUsd,
+    pool_address: poolAddress || null,
+    error: lastErr || `Failed after ${attempts} attempts`,
   }).catch((err: any) => {
-    log('telegram_warn', `Failed to send swap error notification: ${err?.message || err}`)
+    log('state_error', `Failed to enqueue pending liquidation: ${err?.message || err}`)
   })
+
+  // Trigger high-priority alert if token value exceeds alert threshold
+  if (typeof tokenUsd === 'number' && tokenUsd >= alertThreshold) {
+    notifyLiquidationAlert({
+      symbol,
+      mint: baseMint,
+      amount: lastToken?.balance ?? 0,
+      usd: tokenUsd,
+      reason: lastErr || `Failed after ${attempts} attempts`,
+      attempts,
+    }).catch((err: any) => {
+      log('telegram_warn', `Failed to send liquidation alert notification: ${err?.message || err}`)
+    })
+  } else {
+    notifySwapError({
+      inputSymbol: symbol,
+      outputSymbol: 'SOL',
+      reason: lastErr || `Failed after ${attempts} attempts`,
+    }).catch((err: any) => {
+      log('telegram_warn', `Failed to send swap error notification: ${err?.message || err}`)
+    })
+  }
+
   return { swapped: false, result: null, token: null }
+}
+
+/**
+ * Sweep and reconcile all unsold base tokens in the wallet back to SOL.
+ * Combines active wallet holdings with the persistent liquidation backlog.
+ */
+export async function sweepUnsoldTokens(opts: { skipMints?: string[]; dryRun?: boolean } = [] as any): Promise<{
+  total: number
+  successful: number
+  failed: number
+  abandoned: number
+  skipped: number
+  results: any[]
+}> {
+  return withWriteToolsLock(() => sweepUnsoldTokensUnlocked(opts))
+}
+
+export async function sweepUnsoldTokensUnlocked(opts: { skipMints?: string[]; dryRun?: boolean } = [] as any): Promise<{
+  total: number
+  successful: number
+  failed: number
+  abandoned: number
+  skipped: number
+  results: any[]
+}> {
+  let skipMints: string[] = []
+  if (Array.isArray(opts)) {
+    skipMints = opts
+  } else if (opts && typeof opts === 'object') {
+    const raw = (opts as any).skipMints || (opts as any).skip_mints
+    if (Array.isArray(raw)) skipMints = raw
+  }
+
+  const balances = await getWalletBalances()
+  if (!balances?.tokens) {
+    return { total: 0, successful: 0, failed: 0, abandoned: 0, skipped: 0, results: [] }
+  }
+
+  const SOL_MINT_1 = 'So11111111111111111111111111111111111111111'
+  const SOL_MINT_2 = 'So11111111111111111111111111111111111111112'
+  const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+  const skips = new Set([SOL_MINT_1, SOL_MINT_2, USDC_MINT, ...skipMints])
+
+  // Reconcile wallet balances with persistent liquidation queue
+  for (const t of balances.tokens as any[]) {
+    const symbolUpper = (t.symbol || '').toUpperCase()
+    const isSolOrUsdc = symbolUpper === 'SOL' || symbolUpper === 'WSOL' || symbolUpper === 'USDC'
+    if (skips.has(t.mint) || isSolOrUsdc || (t.balance ?? 0) <= 0) continue
+
+    const existing = getPendingLiquidation(t.mint)
+    if (!existing || existing.status === 'liquidated') {
+      await enqueuePendingLiquidation({
+        mint: t.mint,
+        symbol: t.symbol,
+        amount: t.balance,
+        usd: t.usd,
+      }).catch(() => {})
+    }
+  }
+
+  const pendingItems = getPendingLiquidations('pending')
+  let total = 0
+  let skipped = 0
+  let successful = 0
+  let failed = 0
+  let abandoned = 0
+  const results: any[] = []
+
+  const interSwapDelayMs = Math.max(0, Number(config.management.autoSwapInterSwapDelayMs ?? 1500))
+  const minUsd = Math.max(0, Number(config.management.sweeperMinUsd ?? 0.02))
+  const maxAttempts = Math.max(1, Number(config.management.sweeperMaxAttempts ?? 10))
+  const abandonWindowHours = Math.max(1, Number(config.management.sweeperAbandonWindowHours ?? 2))
+  let swapAttempted = false
+
+  for (const item of pendingItems) {
+    if (skips.has(item.mint)) {
+      skipped++
+      continue
+    }
+
+    total++
+    const currentToken = (balances.tokens as any[])?.find((t: any) => t.mint === item.mint)
+    if (!currentToken || (currentToken.balance ?? 0) <= 0) {
+      await markLiquidationSuccess(item.mint).catch(() => {})
+      skipped++
+      continue
+    }
+
+    const isDust = typeof currentToken.usd === 'number' && currentToken.usd >= 0 && currentToken.usd < minUsd
+    if (isDust) {
+      skipped++
+      results.push({
+        mint: item.mint,
+        symbol: item.symbol,
+        success: false,
+        reason: `skipped dust (< $${minUsd.toFixed(2)})`,
+      })
+      continue
+    }
+
+    // Pace swaps to respect API rate limits
+    if (swapAttempted && interSwapDelayMs > 0) {
+      await sleep(interSwapDelayMs)
+    }
+    swapAttempted = true
+
+    try {
+      const res = await swapBaseToSolWithRetry(item.mint, 'sweeper', minUsd, item.pool_address)
+      if (res.swapped) {
+        successful++
+        results.push({ mint: item.mint, symbol: item.symbol, success: true, result: res.result })
+      } else {
+        const outcome = await markLiquidationAttempt(item.mint, {
+          error: 'sweeper failed to liquidate token',
+          maxAttempts,
+          abandonWindowHours,
+        })
+        if (outcome.status === 'abandoned') {
+          abandoned++
+          results.push({
+            mint: item.mint,
+            symbol: item.symbol,
+            success: false,
+            reason: `abandoned after ${outcome.attempts} attempts`,
+          })
+        } else {
+          failed++
+          results.push({
+            mint: item.mint,
+            symbol: item.symbol,
+            success: false,
+            reason: `liquidation attempt ${outcome.attempts} failed`,
+          })
+        }
+      }
+    } catch (e: any) {
+      failed++
+      results.push({ mint: item.mint, symbol: item.symbol, success: false, reason: e.message })
+    }
+  }
+
+  // Prune older settled entries (settled > 24h ago)
+  await pruneSettledLiquidations(24).catch(() => {})
+
+  logAction({
+    tool: 'sweepUnsoldTokens',
+    args: { skipMints },
+    result: { total, skipped, successful, failed, abandoned },
+    duration_ms: 0,
+    success: failed === 0,
+  })
+
+  return { total, skipped, successful, failed, abandoned, results }
 }
 
 /**
@@ -1248,9 +1478,12 @@ async function executeToolUnlocked(name: string, args: Record<string, unknown> =
           }
           // Auto-swap base token back to SOL unless user said to hold (retried).
           if (!args.skip_swap && (result as any).base_mint) {
+            const poolAddress = (result as any).pool || (args.pool_address as string)
             const { swapped, result: swapResult } = await swapBaseToSolWithRetry(
               (result as any).base_mint,
               'after close',
+              0.05,
+              poolAddress,
             )
             if (swapped) {
               ;(result as any).auto_swapped = true
@@ -1271,7 +1504,8 @@ async function executeToolUnlocked(name: string, args: Record<string, unknown> =
             log('telegram_warn', `Failed to send claim error notification: ${err?.message || err}`)
           })
         } else if (config.management.autoSwapAfterClaim && (result as any).base_mint) {
-          await swapBaseToSolWithRetry((result as any).base_mint, 'after claim')
+          const poolAddress = (result as any).pool || (args.pool_address as string)
+          await swapBaseToSolWithRetry((result as any).base_mint, 'after claim', 0.05, poolAddress)
         }
       }
     }

--- a/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
+++ b/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
@@ -2413,3 +2413,110 @@ async function lookupPoolForPosition(position_address: string, walletAddress: st
 
 // Need to import getWalletBalances for deploy fallback
 import { getWalletBalances } from './WalletAdapter.js'
+
+export interface SwapDirectDlmmArgs {
+  pool_address: string
+  input_mint: string
+  amount: number
+  slippageBps?: number
+}
+
+export interface SwapDirectDlmmResult {
+  success: boolean
+  tx?: string
+  dry_run?: boolean
+  amount_in?: number
+  amount_out?: number
+  error?: string
+}
+
+/**
+ * Fallback swap directly against an originating Meteora DLMM pool when Jupiter
+ * aggregator has no route or returns quote errors.
+ */
+export async function swapDirectDlmm({
+  pool_address,
+  input_mint,
+  amount,
+  slippageBps = 300,
+}: SwapDirectDlmmArgs): Promise<SwapDirectDlmmResult> {
+  try {
+    const wallet = getWallet()
+    const pool = await getPool(pool_address)
+    const tokenXMintStr = pool.lbPair.tokenXMint.toString()
+    const tokenYMintStr = pool.lbPair.tokenYMint.toString()
+
+    const swapForY = input_mint === tokenXMintStr
+    if (!swapForY && input_mint !== tokenYMintStr) {
+      return {
+        success: false,
+        error: `Input mint ${input_mint} does not belong to DLMM pool ${pool_address} (X: ${tokenXMintStr}, Y: ${tokenYMintStr})`,
+      }
+    }
+
+    const inToken = swapForY ? pool.tokenX : pool.tokenY
+    const outToken = swapForY ? pool.tokenY : pool.tokenX
+    const inDecimals = inToken.mint?.decimals ?? 9
+    const outDecimals = outToken.mint?.decimals ?? 9
+
+    const inAmountRaw = Math.floor(amount * 10 ** inDecimals)
+    if (inAmountRaw <= 0) {
+      return { success: false, error: 'Swap amount too small' }
+    }
+    const inAmountBN = new BN(inAmountRaw.toString())
+    const allowedSlippageBN = new BN(slippageBps)
+
+    const binArrays = await pool.getBinArrayForSwap(swapForY)
+    if (!binArrays || binArrays.length === 0) {
+      return { success: false, error: 'No active bin arrays available for swap on DLMM pool' }
+    }
+
+    const swapQuote = await pool.swapQuote(inAmountBN, swapForY, allowedSlippageBN, binArrays)
+    if (!swapQuote?.minOutAmount) {
+      return { success: false, error: 'Failed to compute swap quote on DLMM pool' }
+    }
+
+    const amountOutEst = Number(swapQuote.outAmount.toString()) / 10 ** outDecimals
+
+    if (config.connection.dryRun) {
+      log(
+        'swap',
+        `[DRY RUN] Direct DLMM swap: ${amount} of ${input_mint.slice(0, 8)} → ${amountOutEst.toFixed(4)} SOL on pool ${pool_address.slice(0, 8)}`,
+      )
+      return {
+        success: true,
+        dry_run: true,
+        tx: 'dry_run_direct_dlmm_tx',
+        amount_in: amount,
+        amount_out: amountOutEst,
+      }
+    }
+
+    const swapTx = await pool.swap({
+      inToken: inToken.publicKey,
+      outToken: outToken.publicKey,
+      inAmount: inAmountBN,
+      minOutAmount: swapQuote.minOutAmount,
+      lbPair: pool.pubkey,
+      user: wallet.publicKey,
+      binArraysPubkey: swapQuote.binArraysPubkey,
+    })
+
+    const txHash = await sendAndConfirmTransaction(getConnection(), swapTx, [wallet])
+    log(
+      'swap',
+      `Direct DLMM swap SUCCESS: ${amount} ${input_mint.slice(0, 8)} → ~${amountOutEst.toFixed(4)} SOL [tx: ${txHash}]`,
+    )
+
+    return {
+      success: true,
+      tx: txHash,
+      amount_in: amount,
+      amount_out: amountOutEst,
+    }
+  } catch (err: any) {
+    const error = err?.message || String(err)
+    log('swap_warn', `Direct DLMM swap failed on pool ${pool_address}: ${error}`)
+    return { success: false, error }
+  }
+}

--- a/packages/core/src/adapters/notifications/NotificationSink.ts
+++ b/packages/core/src/adapters/notifications/NotificationSink.ts
@@ -24,6 +24,7 @@ export type NotificationType =
   | 'close'
   | 'swap'
   | 'swap_error'
+  | 'liquidation_alert'
   | 'oor'
   | 'briefing'
   | 'message'

--- a/packages/core/src/adapters/notifications/TelegramAdapter.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.ts
@@ -707,6 +707,36 @@ export async function notifySwapError({
   await sendPlain(`⚠️ Auto-swap failed: ${inputSymbol} → ${outputSymbol}\n${body}`)
 }
 
+export async function notifyLiquidationAlert({
+  symbol,
+  mint,
+  amount,
+  usd,
+  reason,
+  attempts,
+}: {
+  symbol?: string
+  mint: string
+  amount: number
+  usd?: number | null
+  reason?: string
+  attempts?: number
+}): Promise<void> {
+  if (hasActiveLiveMessage()) return
+  const tokenLabel = symbol || mint.slice(0, 8)
+  const usdLabel = usd != null ? ` (~$${usd.toFixed(2)})` : ''
+  const attemptsLabel = attempts ? ` after ${attempts} attempts` : ''
+  const title = `🚨 Stranded Token Alert: ${tokenLabel}${usdLabel}`
+  const body =
+    `Base token left unliquidated in wallet${attemptsLabel}.\n` +
+    `Mint: ${mint}\n` +
+    `Amount: ${amount}\n` +
+    `Reason: ${reason || 'Liquidation failed across all routes'}\n` +
+    'Manual intervention recommended before liquidity drains.'
+  notify('liquidation_alert', '🚨', title, body)
+  await sendPlain(`${title}\n${body}`)
+}
+
 interface NotifyOutOfRangeArgs {
   pair: string
   minutesOOR: number

--- a/packages/core/src/application/agent-loop.ts
+++ b/packages/core/src/application/agent-loop.ts
@@ -115,7 +115,13 @@ export const INTENT_TOOLS: Record<string, Set<string>> = {
   ]),
   close: new Set(['close_position', 'get_my_positions', 'get_position_pnl', 'get_wallet_balance', 'swap_token']),
   claim: new Set(['claim_fees', 'get_my_positions', 'get_position_pnl', 'get_wallet_balance']),
-  swap: new Set(['swap_token', 'get_wallet_balance']),
+  swap: new Set([
+    'swap_token',
+    'swap_all_tokens_to_sol',
+    'sweep_unsold_tokens',
+    'get_pending_liquidations',
+    'get_wallet_balance',
+  ]),
   config: new Set(['update_config']),
   blocklist: new Set([
     'add_to_blacklist',
@@ -126,7 +132,13 @@ export const INTENT_TOOLS: Record<string, Set<string>> = {
     'list_blocked_deployers',
   ]),
   selfupdate: new Set(['self_update']),
-  portfolio: new Set(['get_portfolio_summary', 'get_wallet_balance', 'get_meteora_positions', 'get_my_positions']),
+  portfolio: new Set([
+    'get_portfolio_summary',
+    'get_wallet_balance',
+    'get_meteora_positions',
+    'get_my_positions',
+    'get_pending_liquidations',
+  ]),
   balance: new Set([
     'get_wallet_balance',
     'get_portfolio_summary',

--- a/packages/core/src/config/Config.ts
+++ b/packages/core/src/config/Config.ts
@@ -163,6 +163,12 @@ function buildConfig(): AppConfig {
       trailingDropPct: u.management.trailingDropPct,
       pnlSanityMaxDiffPct: u.management.pnlSanityMaxDiffPct,
       solMode: u.management.solMode,
+      sweeperEnabled: u.management.sweeperEnabled ?? true,
+      sweeperIntervalMin: u.management.sweeperIntervalMin ?? 15,
+      sweeperMinUsd: u.management.sweeperMinUsd ?? 0.02,
+      sweeperAlertUsd: u.management.sweeperAlertUsd ?? 1.0,
+      sweeperMaxAttempts: u.management.sweeperMaxAttempts ?? 10,
+      sweeperAbandonWindowHours: u.management.sweeperAbandonWindowHours ?? 2,
     },
     strategy: {
       activeStrategyId: u.strategy.activeStrategyId,

--- a/packages/core/src/config/defaultUserConfig.ts
+++ b/packages/core/src/config/defaultUserConfig.ts
@@ -90,6 +90,12 @@ export const DEFAULT_USER_CONFIG: UserConfigRaw = {
     trailingDropPct: 1.5,
     pnlSanityMaxDiffPct: 5,
     solMode: false,
+    sweeperEnabled: true,
+    sweeperIntervalMin: 15,
+    sweeperMinUsd: 0.02,
+    sweeperAlertUsd: 1.0,
+    sweeperMaxAttempts: 10,
+    sweeperAbandonWindowHours: 2,
   },
 
   strategy: {

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -186,6 +186,12 @@ export const UserConfigSchema = z
         trailingDropPct: envNumber,
         pnlSanityMaxDiffPct: envNumber,
         solMode: envBoolean,
+        sweeperEnabled: envBoolean.optional().default(true),
+        sweeperIntervalMin: envNumber.optional().default(15),
+        sweeperMinUsd: envNumber.optional().default(0.02),
+        sweeperAlertUsd: envNumber.optional().default(1.0),
+        sweeperMaxAttempts: envNumber.optional().default(10),
+        sweeperAbandonWindowHours: envNumber.optional().default(2),
       })
       .strict(),
     strategy: z

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -3,6 +3,7 @@
 export * from './decision-log.js'
 export * from './dev-blocklist.js'
 export * from './lessons.js'
+export * from './liquidation-queue.js'
 export * from './pool-memory.js'
 export * from './pool-metrics.js'
 export * from './signal-tracker.js'

--- a/packages/core/src/domain/liquidation-queue.test.ts
+++ b/packages/core/src/domain/liquidation-queue.test.ts
@@ -1,0 +1,157 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  enqueuePendingLiquidation,
+  getPendingLiquidation,
+  getPendingLiquidations,
+  markLiquidationAttempt,
+  markLiquidationSuccess,
+  pruneSettledLiquidations,
+} from './liquidation-queue.js'
+import { __setStateFilePath } from './state.js'
+
+const TMP_STATE = path.join(os.tmpdir(), `etemaro-liquidation-test-${process.pid}.json`)
+
+describe('Liquidation Queue Domain', () => {
+  beforeAll(() => {
+    __setStateFilePath(TMP_STATE)
+  })
+
+  afterAll(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE)
+  })
+
+  beforeEach(() => {
+    if (fs.existsSync(TMP_STATE)) fs.unlinkSync(TMP_STATE)
+  })
+
+  it('enqueues a new stranded token and retrieves it', async () => {
+    const item = await enqueuePendingLiquidation({
+      mint: 'MintA11111111111111111111111111111111111111',
+      symbol: 'AKIRA',
+      amount: 349517,
+      usd: 12.5,
+      pool_address: 'PoolXYZ111111111111111111111111111111111111',
+      error: 'Jupiter 400: Failed to get quotes',
+    })
+
+    expect(item.mint).toBe('MintA11111111111111111111111111111111111111')
+    expect(item.symbol).toBe('AKIRA')
+    expect(item.amount).toBe(349517)
+    expect(item.usd).toBe(12.5)
+    expect(item.pool_address).toBe('PoolXYZ111111111111111111111111111111111111')
+    expect(item.status).toBe('pending')
+    expect(item.attempts).toBe(0)
+    expect(item.last_error).toBe('Jupiter 400: Failed to get quotes')
+
+    const fetched = getPendingLiquidation('MintA11111111111111111111111111111111111111')
+    expect(fetched).not.toBeNull()
+    expect(fetched?.symbol).toBe('AKIRA')
+
+    const all = getPendingLiquidations('pending')
+    expect(all.length).toBe(1)
+  })
+
+  it('re-enqueuing an existing token updates details and resets status to pending', async () => {
+    await enqueuePendingLiquidation({
+      mint: 'MintB',
+      symbol: 'TOKENB',
+      amount: 100,
+      usd: 1.0,
+      error: 'Initial timeout',
+    })
+
+    await markLiquidationSuccess('MintB', { tx: 'tx-old' })
+    let item = getPendingLiquidation('MintB')
+    expect(item?.status).toBe('liquidated')
+
+    // New residual unswapped tokens discovered
+    await enqueuePendingLiquidation({
+      mint: 'MintB',
+      amount: 50,
+      usd: 0.5,
+      error: 'Second close left dust',
+    })
+
+    item = getPendingLiquidation('MintB')
+    expect(item?.status).toBe('pending')
+    expect(item?.amount).toBe(50)
+    expect(item?.last_error).toBe('Second close left dust')
+  })
+
+  it('records liquidation attempts and abandons after max attempts', async () => {
+    await enqueuePendingLiquidation({
+      mint: 'MintC',
+      symbol: 'RUGGED',
+      amount: 5000,
+      usd: 0.25,
+    })
+
+    // 1st attempt
+    let res = await markLiquidationAttempt('MintC', {
+      error: 'No route found',
+      maxAttempts: 3,
+    })
+    expect(res.status).toBe('pending')
+    expect(res.attempts).toBe(1)
+
+    // 2nd attempt
+    res = await markLiquidationAttempt('MintC', {
+      error: 'No route found',
+      maxAttempts: 3,
+    })
+    expect(res.status).toBe('pending')
+    expect(res.attempts).toBe(2)
+
+    // 3rd attempt -> threshold reached
+    res = await markLiquidationAttempt('MintC', {
+      error: 'Zero pool liquidity',
+      maxAttempts: 3,
+    })
+    expect(res.status).toBe('abandoned')
+    expect(res.attempts).toBe(3)
+
+    const item = getPendingLiquidation('MintC')
+    expect(item?.status).toBe('abandoned')
+    expect(item?.last_error).toBe('Zero pool liquidity')
+  })
+
+  it('marks liquidation as successful', async () => {
+    await enqueuePendingLiquidation({
+      mint: 'MintD',
+      symbol: 'SUCCESS',
+      amount: 1000,
+      usd: 5.0,
+    })
+
+    const ok = await markLiquidationSuccess('MintD', { tx: 'tx_success_123', amountOutSol: 0.035 })
+    expect(ok).toBe(true)
+
+    const item = getPendingLiquidation('MintD')
+    expect(item?.status).toBe('liquidated')
+    expect(item?.last_error).toBeNull()
+
+    const pendingOnly = getPendingLiquidations('pending')
+    expect(pendingOnly.find((i) => i.mint === 'MintD')).toBeUndefined()
+
+    const liquidatedOnly = getPendingLiquidations('liquidated')
+    expect(liquidatedOnly.find((i) => i.mint === 'MintD')).toBeDefined()
+  })
+
+  it('prunes old settled liquidations', async () => {
+    await enqueuePendingLiquidation({
+      mint: 'MintE',
+      symbol: 'OLD',
+      amount: 10,
+    })
+    await markLiquidationSuccess('MintE')
+
+    // Prune entries older than 0 hours (all settled items)
+    const pruned = await pruneSettledLiquidations(0)
+    expect(pruned).toBe(1)
+
+    expect(getPendingLiquidation('MintE')).toBeNull()
+  })
+})

--- a/packages/core/src/domain/liquidation-queue.ts
+++ b/packages/core/src/domain/liquidation-queue.ts
@@ -1,0 +1,191 @@
+/**
+ * @file liquidation-queue.ts
+ * @description Domain manager for persistent unsold token liquidations and reconciliation queue (state.json).
+ *
+ * @features
+ * - Persists unsold token inventory in state.json across daemon restarts
+ * - Tracks liquidation attempts, errors, timestamps, and venue fallback metadata
+ * - Transitions tokens through lifecycle: pending -> liquidated | abandoned
+ * - Filters micro-dust to preserve SOL gas
+ *
+ * @sideEffects Reads and writes pendingLiquidations in data/state.json under stateMutex
+ */
+
+import { log } from '../shared/logger.js'
+import type { PendingLiquidation } from '../shared/types.js'
+import { loadState, saveState, withStateLock } from './state.js'
+
+export interface EnqueueLiquidationOpts {
+  mint: string
+  symbol?: string
+  amount: number
+  usd?: number | null
+  pool_address?: string | null
+  error?: string
+}
+
+/**
+ * Retrieve all tracked liquidations, optionally filtered by status.
+ */
+export function getPendingLiquidations(filter?: 'pending' | 'liquidated' | 'abandoned'): PendingLiquidation[] {
+  const state = loadState()
+  const list = Object.values(state.pendingLiquidations || {})
+  if (!filter) return list
+  return list.filter((item) => item.status === filter)
+}
+
+/**
+ * Retrieve a specific token liquidation entry by mint.
+ */
+export function getPendingLiquidation(mint: string): PendingLiquidation | null {
+  const state = loadState()
+  return state.pendingLiquidations?.[mint] || null
+}
+
+/**
+ * Register or update an unsold token in the persistent liquidation backlog.
+ */
+export async function enqueuePendingLiquidation(opts: EnqueueLiquidationOpts): Promise<PendingLiquidation> {
+  return withStateLock(() => {
+    const state = loadState()
+    if (!state.pendingLiquidations) {
+      state.pendingLiquidations = {}
+    }
+
+    const existing = state.pendingLiquidations[opts.mint]
+    const now = new Date().toISOString()
+
+    let record: PendingLiquidation
+    if (existing) {
+      record = {
+        ...existing,
+        symbol: opts.symbol || existing.symbol,
+        amount: opts.amount > 0 ? opts.amount : existing.amount,
+        usd: opts.usd !== undefined ? opts.usd : existing.usd,
+        pool_address: opts.pool_address || existing.pool_address,
+        last_attempt_at: now,
+        status: 'pending',
+        last_error: opts.error || existing.last_error,
+      }
+    } else {
+      record = {
+        mint: opts.mint,
+        symbol: opts.symbol,
+        amount: opts.amount,
+        usd: opts.usd ?? null,
+        pool_address: opts.pool_address || null,
+        added_at: now,
+        last_attempt_at: now,
+        attempts: 0,
+        status: 'pending',
+        last_error: opts.error || null,
+      }
+    }
+
+    state.pendingLiquidations[opts.mint] = record
+    saveState(state)
+
+    log(
+      'state',
+      `Enqueued pending liquidation: ${record.symbol || record.mint.slice(0, 8)} (${record.amount} units${record.usd ? `, ~$${record.usd.toFixed(2)}` : ''}) [status: pending]`,
+    )
+
+    return record
+  })
+}
+
+/**
+ * Mark a pending liquidation as successfully liquidated.
+ */
+export async function markLiquidationSuccess(
+  mint: string,
+  opts: { tx?: string; amountOutSol?: number } = {},
+): Promise<boolean> {
+  return withStateLock(() => {
+    const state = loadState()
+    const item = state.pendingLiquidations?.[mint]
+    if (!item) return false
+
+    item.status = 'liquidated'
+    item.last_attempt_at = new Date().toISOString()
+    item.last_error = null
+    saveState(state)
+
+    log(
+      'state',
+      `Liquidation success: ${item.symbol || mint.slice(0, 8)} converted to SOL${opts.amountOutSol ? ` (${opts.amountOutSol.toFixed(4)} SOL)` : ''}${opts.tx ? ` [tx: ${opts.tx.slice(0, 16)}...]` : ''}`,
+    )
+    return true
+  })
+}
+
+/**
+ * Record a failed liquidation attempt. If attempts or elapsed time exceed configured limits,
+ * marks the token as abandoned (rugged / zero-liquidity) to stop quote spam.
+ */
+export async function markLiquidationAttempt(
+  mint: string,
+  opts: {
+    error?: string
+    maxAttempts?: number
+    abandonWindowHours?: number
+  } = {},
+): Promise<{ status: 'pending' | 'abandoned'; attempts: number }> {
+  return withStateLock(() => {
+    const state = loadState()
+    const item = state.pendingLiquidations?.[mint]
+    const maxAttempts = opts.maxAttempts ?? 10
+    const abandonWindowHours = opts.abandonWindowHours ?? 2
+
+    if (!item) {
+      return { status: 'abandoned', attempts: 0 }
+    }
+
+    const now = new Date()
+    item.attempts = (item.attempts || 0) + 1
+    item.last_attempt_at = now.toISOString()
+    item.last_error = opts.error || 'Liquidation attempt failed'
+
+    const addedMs = item.added_at ? new Date(item.added_at).getTime() : now.getTime()
+    const ageHours = (now.getTime() - addedMs) / (1000 * 60 * 60)
+
+    if (item.attempts >= maxAttempts || ageHours >= abandonWindowHours) {
+      item.status = 'abandoned'
+      log(
+        'state_warn',
+        `Liquidation abandoned for ${item.symbol || mint.slice(0, 8)} after ${item.attempts} attempts (${ageHours.toFixed(1)}h). Token marked dead/rugged to halt RPC quote spam.`,
+      )
+    }
+
+    saveState(state)
+    return { status: item.status as 'pending' | 'abandoned', attempts: item.attempts }
+  })
+}
+
+/**
+ * Prune old settled (liquidated or abandoned) entries from the liquidation queue.
+ */
+export async function pruneSettledLiquidations(retentionHours = 24): Promise<number> {
+  return withStateLock(() => {
+    const state = loadState()
+    if (!state.pendingLiquidations) return 0
+
+    const cutoff = Date.now() - retentionHours * 60 * 60 * 1000
+    let pruned = 0
+
+    for (const [mint, item] of Object.entries(state.pendingLiquidations)) {
+      if (item.status === 'pending') continue
+      const lastAction = item.last_attempt_at ? new Date(item.last_attempt_at).getTime() : 0
+      if (lastAction > 0 && lastAction <= cutoff) {
+        delete state.pendingLiquidations[mint]
+        pruned++
+      }
+    }
+
+    if (pruned > 0) {
+      saveState(state)
+      log('state', `Pruned ${pruned} settled liquidation entries older than ${retentionHours}h`)
+    }
+    return pruned
+  })
+}

--- a/packages/core/src/domain/state.ts
+++ b/packages/core/src/domain/state.ts
@@ -12,10 +12,17 @@
 
 import { dataPath, MAX_INSTRUCTION_LENGTH, MAX_RECENT_EVENTS, SYNC_GRACE_MS } from '../shared/constants.js'
 import { log } from '../shared/logger.js'
-import type { BinRange, ExitResult, PositionRecord, StateEvent, StateSummary } from '../shared/types.js'
+import type {
+  BinRange,
+  ExitResult,
+  PendingLiquidation,
+  PositionRecord,
+  StateEvent,
+  StateSummary,
+} from '../shared/types.js'
 import { loadJsonFile, sanitizeStoredText, saveJsonFile } from '../shared/utils.js'
 
-export type { PositionRecord } from '../shared/types.js'
+export type { PendingLiquidation, PositionRecord } from '../shared/types.js'
 
 import { Mutex } from '../shared/mutex.js'
 import type { AppConfig } from '../shared/types.js'
@@ -46,27 +53,37 @@ export function __setStateFilePath(path: string): void {
   STATE_FILE = path
 }
 
-interface StateData {
+export interface StateData {
   positions: Record<string, PositionRecord>
   recentEvents?: StateEvent[]
   lastUpdated: string | null
   _lastBriefingDate?: string
   _consecutiveSwapFailures?: number
+  pendingLiquidations?: Record<string, PendingLiquidation>
 }
 
-function load(): StateData {
-  return loadJsonFile<StateData>(
+export function loadState(): StateData {
+  const data = loadJsonFile<StateData>(
     STATE_FILE,
     {
       positions: {},
       recentEvents: [],
       lastUpdated: null,
+      pendingLiquidations: {},
     },
     { label: 'state', critical: true },
   )
+  if (!data.pendingLiquidations) {
+    data.pendingLiquidations = {}
+  }
+  return data
 }
 
-function save(state: StateData): void {
+function load(): StateData {
+  return loadState()
+}
+
+export function saveState(state: StateData): void {
   try {
     state.lastUpdated = new Date().toISOString()
     saveJsonFile(STATE_FILE, state)
@@ -75,6 +92,10 @@ function save(state: StateData): void {
     log('state_error', `Failed to write state.json: ${message}`)
     throw err
   }
+}
+
+function save(state: StateData): void {
+  saveState(state)
 }
 
 // ─── Position Registry ─────────────────────────────────────────

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -676,6 +676,25 @@ export interface ManagementConfig {
   trailingDropPct: number
   pnlSanityMaxDiffPct: number
   solMode: boolean
+  sweeperEnabled?: boolean
+  sweeperIntervalMin?: number
+  sweeperMinUsd?: number
+  sweeperAlertUsd?: number
+  sweeperMaxAttempts?: number
+  sweeperAbandonWindowHours?: number
+}
+
+export interface PendingLiquidation {
+  mint: string
+  symbol?: string
+  amount: number
+  usd?: number | null
+  pool_address?: string | null
+  added_at: string
+  last_attempt_at: string | null
+  attempts: number
+  status: 'pending' | 'liquidated' | 'abandoned'
+  last_error?: string | null
 }
 
 export interface StrategyConfig {

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -282,6 +282,7 @@ export class Daemon {
   private screeningLastTriggered = 0 // Epoch timestamp (ms) of last screening; enforces post-management cooldown
   private pnlPollBusy = false // Guards high-frequency PnL poller ticks to prevent parallel on-chain queries
   private opportunityPollBusy = false // Guards background opportunity/smart-wallet detection polling cycles
+  private sweeperBusy = false // Guards continuous unsold token sweeper reconciliation cycles
   private busy = false // Guards interactive REPL terminal commands and free-form LLM chat sessions
   private shuttingDown = false // Set on SIGINT/SIGTERM or /stop; suppresses new cycles & aborts queue processing
   private draining = false // Single-flight guard ensuring only one loop drains the Telegram queue at a time
@@ -321,7 +322,7 @@ export class Daemon {
    * Synchronous atomic check-and-set lock acquisition for daemon async cycles.
    * Prevents overlapping timer ticks or event-loop delays from entering guarded sections concurrently.
    */
-  private acquireLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): boolean {
+  private acquireLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll' | 'sweeper'): boolean {
     if (this.shuttingDown) return false
     switch (lockName) {
       case 'management':
@@ -340,13 +341,17 @@ export class Daemon {
         if (this.screeningBusy || this.managementBusy || this.pnlPollBusy || this.opportunityPollBusy) return false
         this.opportunityPollBusy = true
         return true
+      case 'sweeper':
+        if (this.sweeperBusy || this.managementBusy) return false
+        this.sweeperBusy = true
+        return true
     }
   }
 
   /**
    * Synchronous lock release helper.
    */
-  private releaseLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll'): void {
+  private releaseLock(lockName: 'management' | 'screening' | 'pnlPoll' | 'opportunityPoll' | 'sweeper'): void {
     switch (lockName) {
       case 'management':
         this.managementBusy = false
@@ -359,6 +364,9 @@ export class Daemon {
         break
       case 'opportunityPoll':
         this.opportunityPollBusy = false
+        break
+      case 'sweeper':
+        this.sweeperBusy = false
         break
     }
     this.drainTelegramQueue().catch((err: any) => {
@@ -866,11 +874,38 @@ Summarize the current portfolio health, total fees earned, and performance of al
       }, oppMs)
     }
 
-    this.cronTasks = [mgmtTask, screenTask, healthTask, briefingTask, briefingWatchdog]
+    const sweeperIntervalMin = Math.max(1, Number(config.management.sweeperIntervalMin ?? 15))
+    const sweeperTask = cron.schedule(`*/${sweeperIntervalMin} * * * *`, () => {
+      if (config.management.sweeperEnabled !== false) {
+        this.runSweeperCycle()
+      }
+    })
+
+    this.cronTasks = [mgmtTask, screenTask, healthTask, briefingTask, briefingWatchdog, sweeperTask]
     log(
       'cron',
-      `Cycles started — management every ${config.schedule.managementIntervalMin}m, screening every ${config.schedule.screeningIntervalMin}m${config.opportunity.enabled ? `, opportunity poll every ${config.opportunity.pollIntervalSec}s` : ''}`,
+      `Cycles started — management every ${config.schedule.managementIntervalMin}m, screening every ${config.schedule.screeningIntervalMin}m, sweeper every ${sweeperIntervalMin}m${config.opportunity.enabled ? `, opportunity poll every ${config.opportunity.pollIntervalSec}s` : ''}`,
     )
+  }
+
+  async runSweeperCycle(): Promise<any> {
+    if (this.shuttingDown || !this.acquireLock('sweeper')) return null
+    try {
+      log('cron', 'Starting unsold token sweeper cycle')
+      const result = await this.adapters.toolExecutor.executeTool('sweep_unsold_tokens', {})
+      if (result && (result.successful > 0 || result.failed > 0 || result.abandoned > 0)) {
+        log(
+          'cron',
+          `Sweeper cycle complete: ${result.successful} swapped, ${result.failed} failed, ${result.abandoned} abandoned out of ${result.total}`,
+        )
+      }
+      return result
+    } catch (err: any) {
+      log('cron_error', `Sweeper cycle error: ${err?.message || err}`)
+      return null
+    } finally {
+      this.releaseLock('sweeper')
+    }
   }
 
   // ─── Briefing ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Resolves #264 by establishing a robust unsold base token lifecycle and continuous reconciliation sweeper:
1. **Persistent Liquidation Backlog**: Stateful tracking in `state.json` (`pendingLiquidations`) across restarts.
2. **Multi-Tier Liquidation Fallback**: Jupiter aggregator fallback to direct Meteora DLMM pool swaps (`swapDirectDlmm`) when aggregator routes fail.
3. **Continuous Background Sweeper**: Scheduled background sweeper cron job in `Daemon.ts` (`sweeperIntervalMin`, default 15m) with concurrency locking (`sweeperBusy`).
4. **Noise & Dust Filtering**: Skips micro-dust (< zsh.02) and transitions stranded tokens to `abandoned` status after max attempts (`sweeperMaxAttempts`, 10) or window (`sweeperAbandonWindowHours`, 2h) to avoid quote spam.
5. **Operator Alerts**: High-priority Telegram alerts (`notifyLiquidationAlert`) if stranded token value exceeds `sweeperAlertUsd` (.00).
6. **Tool & CLI Interface**: LLM tools `sweep_unsold_tokens` and `get_pending_liquidations`; CLI commands `etemaro sweep` and `etemaro liquidations`.

Closes #264

## Root Cause & Gap Analysis
- **Why/When it happened**: In high-slippage or unindexed pool conditions, Jupiter aggregator fails on position close (`swapBaseToSolWithRetry`). Because retry attempts were purely in-memory and fire-and-forget (3 immediate attempts), any failure left base tokens permanently stranded in the wallet, with no fallback venue or background recovery.
- **Why we missed it**: Autoswap was only tested for immediate in-process retries; no stateful persistence or reconciliation sweeper existed to track unsold inventory across positions or daemon restarts.

## Acceptance Criteria Checklist
- [x] AC1: Unsold base tokens are enqueued into `pendingLiquidations` in `state.json` upon failure.
- [x] AC2: Multi-tier fallback attempts direct Meteora DLMM pool swap if Jupiter fails.
- [x] AC3: Daemon runs continuous background sweeper cycle every `sweeperIntervalMin`.
- [x] AC4: Micro-dust (< zsh.02) is skipped and tokens transition to `abandoned` after limit.
- [x] AC5: High-priority Telegram alert sent when stranded token USD >= .00.
- [x] AC6: Tools `sweep_unsold_tokens`, `get_pending_liquidations` and CLI commands work as expected.
- [x] AC7: Full test suite (396 tests) green with zero typecheck or linter errors.

## Testing Plan
- [x] Unit tests: `packages/core/src/domain/liquidation-queue.test.ts` (5 tests passing).
- [x] Integration tests: `packages/core/src/adapters/ToolExecutor.test.ts` (34 tests passing).
- [x] Monorepo test suite: 396 tests passing across 34 test files.
- [x] Monorepo typecheck: `pnpm -r run typecheck` passes with zero errors.
- [x] Biome formatting/linter: clean with zero errors.