### PR TITLE
feat(core): realistic PnL accounting & mark-to-market (#267)

### DIFF
--- a/packages/core/src/adapters/BriefingAdapter.ts
+++ b/packages/core/src/adapters/BriefingAdapter.ts
@@ -106,9 +106,13 @@ export async function generateBriefing(options?: GenerateBriefingOptions): Promi
     `📉 Price PnL: ${totalPricePnLUsd >= 0 ? '+' : ''}$${totalPricePnLUsd.toFixed(2)}${fmtSol(totalPricePnLUsd)}`,
     `💎 Fees Earned: $${totalFeesUsd.toFixed(2)}${fmtSol(totalFeesUsd)}`,
     `💰 Net PnL: ${totalNetPnLUsd >= 0 ? '+' : ''}$${totalNetPnLUsd.toFixed(2)}${fmtSol(totalNetPnLUsd)}`,
-    perfLast24h.length > 0
-      ? `📈 Win Rate (24h): ${Math.round((perfLast24h.filter((p) => (p.pnl_pct ?? 0) >= 0).length / perfLast24h.length) * 100)}%`
-      : '📈 Win Rate (24h): N/A',
+    (() => {
+      const settled24h = perfLast24h.filter((p) => p.status !== 'closed_pending_swap')
+      const wins24h = settled24h.filter((p) => (p.pnl_pct ?? 0) >= 0).length
+      return settled24h.length > 0
+        ? `📈 Win Rate (24h): ${Math.round((wins24h / settled24h.length) * 100)}%`
+        : '📈 Win Rate (24h): N/A'
+    })(),
     '',
     'Lessons Learned:',
     lessonsLast24h.length > 0
@@ -118,7 +122,11 @@ export async function generateBriefing(options?: GenerateBriefingOptions): Promi
     'Current Portfolio:',
     `📂 Open Positions: ${openPositions.length}`,
     perfSummary
-      ? `📊 All-time PnL: $${allTimePnlUsd.toFixed(2)}${fmtSol(allTimePnlUsd)} | ${perfSummary.win_rate_pct as number}% win | avg ${(perfSummary.avg_pnl_pct as number) >= 0 ? '+' : ''}${(perfSummary.avg_pnl_pct as number).toFixed(2)}%`
+      ? `📊 All-time PnL: $${allTimePnlUsd.toFixed(2)}${fmtSol(allTimePnlUsd)} | ${perfSummary.win_rate_pct as number}% win | avg ${(perfSummary.avg_pnl_pct as number) >= 0 ? '+' : ''}${(perfSummary.avg_pnl_pct as number).toFixed(2)}%${
+          (perfSummary.pending_swaps_count as number) > 0
+            ? `\n⏳ Pending Liquidations: ${perfSummary.pending_swaps_count} (~$${((perfSummary.unrealized_residual_usd as number) || 0).toFixed(2)})`
+            : ''
+        }`
       : '',
     '────────────────',
   ]

--- a/packages/core/src/adapters/ToolExecutor.ts
+++ b/packages/core/src/adapters/ToolExecutor.ts
@@ -904,6 +904,7 @@ export async function swapBaseToSolWithRetry(
   label: string,
   minUsd: number = 0.05,
   poolAddress?: string | null,
+  position?: string | null,
 ): Promise<{
   swapped: boolean
   result: Record<string, unknown> | null
@@ -1007,6 +1008,7 @@ export async function swapBaseToSolWithRetry(
     amount: lastToken?.balance ?? 0,
     usd: tokenUsd,
     pool_address: poolAddress || null,
+    position: position || null,
     error: lastErr || `Failed after ${attempts} attempts`,
   }).catch((err: any) => {
     log('state_error', `Failed to enqueue pending liquidation: ${err?.message || err}`)
@@ -1079,9 +1081,13 @@ export async function sweepUnsoldTokensUnlocked(opts: { skipMints?: string[]; dr
   const skips = new Set([SOL_MINT_1, SOL_MINT_2, USDC_MINT, ...skipMints])
 
   // Reconcile wallet balances with persistent liquidation queue
+  const priceMap: Record<string, number> = {}
   for (const t of balances.tokens as any[]) {
     const symbolUpper = (t.symbol || '').toUpperCase()
     const isSolOrUsdc = symbolUpper === 'SOL' || symbolUpper === 'WSOL' || symbolUpper === 'USDC'
+    if (t.mint && typeof t.usd === 'number' && typeof t.balance === 'number' && t.balance > 0) {
+      priceMap[t.mint] = t.usd / t.balance
+    }
     if (skips.has(t.mint) || isSolOrUsdc || (t.balance ?? 0) <= 0) continue
 
     const existing = getPendingLiquidation(t.mint)
@@ -1092,6 +1098,15 @@ export async function sweepUnsoldTokensUnlocked(opts: { skipMints?: string[]; dr
         amount: t.balance,
         usd: t.usd,
       }).catch(() => {})
+    }
+  }
+
+  if (Object.keys(priceMap).length > 0) {
+    try {
+      const { updatePendingTradesMarkToMarket } = await import('../domain/lessons.js')
+      updatePendingTradesMarkToMarket(priceMap)
+    } catch {
+      // ignore
     }
   }
 
@@ -1460,13 +1475,6 @@ async function executeToolUnlocked(name: string, args: Record<string, unknown> =
             log('telegram_warn', `Failed to send close error notification: ${err?.message || err}`)
           })
         } else {
-          notifyClose({
-            pair: (result as any).pool_name || (args.position_address as string)?.slice(0, 8),
-            pnlUsd: (result as any).pnl_usd ?? 0,
-            pnlPct: (result as any).pnl_pct ?? 0,
-          }).catch((err: any) => {
-            log('telegram_warn', `Failed to send close notification: ${err?.message || err}`)
-          })
           // Note low-yield closes in pool memory so screener avoids redeploying
           if ((args.reason as string) && (args.reason as string).toLowerCase().includes('yield')) {
             const poolAddr = (result as any).pool || args.pool_address
@@ -1476,22 +1484,39 @@ async function executeToolUnlocked(name: string, args: Record<string, unknown> =
                 note: `Closed: low yield (fee/TVL below threshold) at ${new Date().toISOString().slice(0, 10)}`,
               })
           }
+
+          const baseMint = (result as any).base_mint
+          const hasBaseToken = baseMint && baseMint !== 'So11111111111111111111111111111111111111112'
+          const posAddr = (args.position_address as string) || (result as any).position
+
           // Auto-swap base token back to SOL unless user said to hold (retried).
-          if (!args.skip_swap && (result as any).base_mint) {
+          if (!args.skip_swap && hasBaseToken) {
             const poolAddress = (result as any).pool || (args.pool_address as string)
             const { swapped, result: swapResult } = await swapBaseToSolWithRetry(
-              (result as any).base_mint,
+              baseMint,
               'after close',
               0.05,
               poolAddress,
+              posAddr,
             )
             if (swapped) {
               ;(result as any).auto_swapped = true
               ;(result as any).auto_swap_note =
-                `Base token already auto-swapped back to SOL (${(result as any).base_mint.slice(0, 8)} → SOL). Do NOT call swap_token again.`
+                `Base token already auto-swapped back to SOL (${baseMint.slice(0, 8)} → SOL). Do NOT call swap_token again.`
               if ((swapResult as any)?.amount_out) (result as any).sol_received = (swapResult as any).amount_out
             }
           }
+
+          const isPending = hasBaseToken && !(result as any).auto_swapped
+          notifyClose({
+            pair: (result as any).pool_name || (args.position_address as string)?.slice(0, 8),
+            pnlUsd: (result as any).pnl_usd ?? 0,
+            pnlPct: (result as any).pnl_pct ?? 0,
+            status: isPending ? 'closed_pending_swap' : 'realized',
+            solReceived: (result as any).sol_received,
+          }).catch((err: any) => {
+            log('telegram_warn', `Failed to send close notification: ${err?.message || err}`)
+          })
         }
       } else if (name === 'claim_fees') {
         const isSuccess = (result as any)?.success !== false && !(result as any)?.error && !(result as any)?.blocked

--- a/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
+++ b/packages/core/src/adapters/blockchain/MeteoraAdapter.ts
@@ -1976,11 +1976,19 @@ export async function closePosition({ position_address, reason }: { position_add
             log('meteora_warn', `Failed to fetch pool exit metrics for ${poolAddress}: ${err?.message || err}`)
           }
 
+          const isBaseNonSol = closeBaseMint && closeBaseMint !== 'So11111111111111111111111111111111111111112'
+          const closeStatus = isBaseNonSol ? 'closed_pending_swap' : 'realized'
+
           await recordPerformance({
             position: position_address,
             pool: poolAddress,
             pool_name: tracked.pool_name || poolMeta.name || poolAddress.slice(0, 8),
             base_mint: closeBaseMint,
+            status: closeStatus,
+            liquidation_mint: isBaseNonSol ? closeBaseMint : undefined,
+            unrealized_residual_usd: isBaseNonSol ? finalValueUsd : 0,
+            cash_realized_sol: isBaseNonSol ? 0 : tracked.amount_sol,
+            cash_realized_usd: isBaseNonSol ? 0 : finalValueUsd,
             strategy: tracked.strategy,
             bin_range: tracked.bin_range,
             bin_step: tracked.bin_step || null,
@@ -2269,11 +2277,19 @@ export async function closePosition({ position_address, reason }: { position_add
         log('meteora_warn', `Failed to fetch pool exit metrics for ${poolAddress}: ${err?.message || err}`)
       }
 
+      const isBaseNonSol = closeBaseMint && closeBaseMint !== 'So11111111111111111111111111111111111111112'
+      const closeStatus = isBaseNonSol ? 'closed_pending_swap' : 'realized'
+
       await recordPerformance({
         position: position_address,
         pool: poolAddress,
         pool_name: tracked.pool_name || poolMeta.name || poolAddress.slice(0, 8),
         base_mint: closeBaseMint,
+        status: closeStatus,
+        liquidation_mint: isBaseNonSol ? closeBaseMint : undefined,
+        unrealized_residual_usd: isBaseNonSol ? finalValueUsd : 0,
+        cash_realized_sol: isBaseNonSol ? 0 : tracked.amount_sol,
+        cash_realized_usd: isBaseNonSol ? 0 : finalValueUsd,
         strategy: tracked.strategy,
         bin_range: tracked.bin_range,
         bin_step: tracked.bin_step || null,

--- a/packages/core/src/adapters/notifications/TelegramAdapter.ts
+++ b/packages/core/src/adapters/notifications/TelegramAdapter.ts
@@ -654,12 +654,20 @@ interface NotifyCloseArgs {
   pair: string
   pnlUsd: number
   pnlPct: number
+  status?: 'realized' | 'closed_pending_swap' | 'abandoned_loss'
+  solReceived?: number
 }
 
-export async function notifyClose({ pair, pnlUsd, pnlPct }: NotifyCloseArgs): Promise<void> {
+export async function notifyClose({ pair, pnlUsd, pnlPct, status, solReceived }: NotifyCloseArgs): Promise<void> {
   if (hasActiveLiveMessage()) return
   const sign = pnlUsd >= 0 ? '+' : ''
-  const body = `PnL: ${sign}$${(pnlUsd ?? 0).toFixed(2)} (${sign}${(pnlPct ?? 0).toFixed(2)}%)`
+  let body: string
+  if (status === 'closed_pending_swap') {
+    body = `PnL: ${sign}$${(pnlUsd ?? 0).toFixed(2)} (${sign}${(pnlPct ?? 0).toFixed(2)}% paper)\n⏳ Base tokens awaiting liquidation to SOL`
+  } else {
+    const solText = solReceived ? `\nCash: ${solReceived.toFixed(4)} SOL` : ''
+    body = `PnL: ${sign}$${(pnlUsd ?? 0).toFixed(2)} (${sign}${(pnlPct ?? 0).toFixed(2)}%)${solText}`
+  }
   notify('close', '🔒', `Closed ${pair}`, body)
   await sendPlain(`🔒 Closed ${pair}\n${body}`)
 }

--- a/packages/core/src/domain/lessons-realistic-pnl.test.ts
+++ b/packages/core/src/domain/lessons-realistic-pnl.test.ts
@@ -1,0 +1,366 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Redirect dataPath() to a temp directory for isolated test environment
+vi.mock('../shared/constants.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../shared/constants.js')>()
+  const nodeFs = await import('node:fs')
+  const nodeOs = await import('node:os')
+  const nodePath = await import('node:path')
+  const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'lessons-pnl-test-'))
+  return {
+    ...actual,
+    dataPath: (...segments: string[]) => nodePath.join(dir, ...segments),
+    __testDataDir: dir,
+  }
+})
+
+import {
+  abandonTradeLiquidation,
+  getPerformanceSummary,
+  recordPerformance,
+  settleTradeLiquidation,
+  updatePendingTradesMarkToMarket,
+} from './lessons.js'
+
+type MockedConstants = typeof import('../shared/constants.js') & { __testDataDir: string }
+const constants = (await import('../shared/constants.js')) as MockedConstants
+const tmpDir = constants.__testDataDir
+const lessonsFile = path.join(tmpDir, 'lessons.json')
+
+describe('TASK-03: Realistic PnL Accounting & Mark-to-Market', () => {
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true })
+    fs.writeFileSync(lessonsFile, JSON.stringify({ lessons: [], performance: [] }))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('AC1: Position closed with unsold tokens is marked closed_pending_swap and excluded from winning trade counts', async () => {
+    // Initial deposit: 1 SOL ($150)
+    // LP closed: 0.2 SOL cash withdrawn ($30) + 1,000,000 AKIRA tokens with theoretical instant value $130
+    // Theoretical total = $160 (+$10 / +6.67% paper win)
+    await recordPerformance({
+      position: 'pos-akira-1',
+      pool: 'pool-akira',
+      pool_name: 'AKIRA-SOL',
+      base_mint: 'mint-akira',
+      strategy: 'spot',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.5,
+      fee_tvl_ratio: 0.1,
+      organic_score: 50,
+      amount_sol: 1.0,
+      initial_value_usd: 150,
+      final_value_usd: 160, // Theoretical instant withdrawal
+      fees_earned_usd: 0,
+      minutes_in_range: 60,
+      minutes_held: 60,
+      close_reason: 'take profit (theoretical)',
+      status: 'closed_pending_swap',
+      cash_realized_sol: 0.2,
+      cash_realized_usd: 30,
+      unrealized_residual_usd: 130,
+      unrealized_tokens_amount: 1_000_000,
+      liquidation_mint: 'mint-akira',
+    })
+
+    const data = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'))
+    expect(data.performance).toHaveLength(1)
+    const rec = data.performance[0]
+    expect(rec.status).toBe('closed_pending_swap')
+    expect(rec.cash_realized_sol).toBe(0.2)
+    expect(rec.cash_realized_usd).toBe(30)
+    expect(rec.unrealized_residual_usd).toBe(130)
+
+    // Critical: NO positive ("WORKED" / "PREFER") lesson should be derived for pending unliquidated trades
+    expect(data.lessons).toHaveLength(0)
+
+    // Summary metrics:
+    const summary = getPerformanceSummary() as any
+    expect(summary).not.toBeNull()
+    expect(summary.total_positions_closed).toBe(1)
+    expect(summary.pending_swaps_count).toBe(1)
+    // Realized win rate must be 0 because 0 trades are fully realized as wins
+    expect(summary.win_rate_pct).toBe(0)
+    expect(summary.unrealized_residual_usd).toBe(130)
+    // Cash realized PnL = $30 (cash) - $150 (initial) = -$120
+    expect(summary.cash_realized_pnl_usd).toBe(-120)
+  })
+
+  it('AC2: Realized PnL is booked only upon conversion to SOL, tracking actual cash returned to wallet', async () => {
+    // Record pending trade
+    await recordPerformance({
+      position: 'pos-token-2',
+      pool: 'pool-token',
+      pool_name: 'TOKEN-SOL',
+      base_mint: 'mint-token-2',
+      strategy: 'spot',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.2,
+      fee_tvl_ratio: 0.1,
+      organic_score: 80,
+      amount_sol: 1.0,
+      initial_value_usd: 150,
+      final_value_usd: 160,
+      fees_earned_usd: 0,
+      minutes_in_range: 60,
+      minutes_held: 60,
+      close_reason: 'take profit',
+      status: 'closed_pending_swap',
+      cash_realized_sol: 0.2,
+      cash_realized_usd: 30,
+      unrealized_residual_usd: 130,
+      unrealized_tokens_amount: 500_000,
+      liquidation_mint: 'mint-token-2',
+    })
+
+    // Now liquidation succeeds: 500,000 tokens swapped for 0.88 SOL at SOL price $150 = $132 USD
+    const settled = await settleTradeLiquidation('mint-token-2', {
+      amountOutSol: 0.88,
+      solPrice: 150,
+      tx: 'tx-swap-success-1',
+      position: 'pos-token-2',
+    })
+    expect(settled).toBe(true)
+
+    const data = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'))
+    const rec = data.performance[0]
+    expect(rec.status).toBe('realized')
+    // Total cash realized SOL = 0.2 (from close) + 0.88 (from swap) = 1.08 SOL
+    expect(rec.cash_realized_sol).toBeCloseTo(1.08, 4)
+    // Total cash realized USD = 1.08 * 150 = $162
+    expect(rec.cash_realized_usd).toBeCloseTo(162, 2)
+    expect(rec.unrealized_residual_usd).toBe(0)
+    expect(rec.final_value_usd).toBeCloseTo(162, 2)
+    // Net PnL = $162 - $150 = +$12 (+8%)
+    expect(rec.net_pnl_usd).toBeCloseTo(12, 2)
+    expect(rec.pnl_usd).toBeCloseTo(12, 2)
+    expect(rec.pnl_pct).toBeCloseTo(8, 2)
+    expect(rec.liquidation_tx).toBe('tx-swap-success-1')
+
+    // Lesson should now be derived as a confirmed WORKED trade!
+    expect(data.lessons.length).toBeGreaterThanOrEqual(1)
+    expect(data.lessons[0].outcome).toBe('good')
+
+    // Summary now counts 100% win rate
+    const summary = getPerformanceSummary() as any
+    expect(summary.win_rate_pct).toBe(100)
+    expect(summary.pending_swaps_count).toBe(0)
+    expect(summary.cash_realized_pnl_usd).toBeCloseTo(12, 2)
+  })
+
+  it('AC3: Abandoned/unsellable inventory is formally recognized as abandoned_loss, converting paper wins into capital losses', async () => {
+    // Record pending trade that appeared profitable on paper
+    await recordPerformance({
+      position: 'pos-rug-3',
+      pool: 'pool-rug',
+      pool_name: 'RUG-SOL',
+      base_mint: 'mint-rug-3',
+      strategy: 'bid_ask',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.8,
+      fee_tvl_ratio: 0.1,
+      organic_score: 30,
+      amount_sol: 1.0,
+      initial_value_usd: 150,
+      final_value_usd: 170, // Paper value was +$20
+      fees_earned_usd: 5,
+      minutes_in_range: 10,
+      minutes_held: 20,
+      close_reason: 'stop loss',
+      status: 'closed_pending_swap',
+      cash_realized_sol: 0.1, // Only 0.1 SOL recovered
+      cash_realized_usd: 15,
+      unrealized_residual_usd: 155,
+      unrealized_tokens_amount: 10_000_000,
+      liquidation_mint: 'mint-rug-3',
+    })
+
+    // Token dump / zero liquidity -> sweeper abandons token
+    const abandoned = await abandonTradeLiquidation('mint-rug-3', {
+      reason: 'No route found / zero liquidity after 10 attempts',
+      position: 'pos-rug-3',
+    })
+    expect(abandoned).toBe(true)
+
+    const data = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'))
+    const rec = data.performance[0]
+    expect(rec.status).toBe('abandoned_loss')
+    expect(rec.unrealized_residual_usd).toBe(0)
+    // Final value is only the actual cash recovered: $15
+    expect(rec.final_value_usd).toBe(15)
+    // Net PnL = $15 (final) - $150 (initial) + $5 (fees) = -$130 (-86.67%)
+    expect(rec.net_pnl_usd).toBe(-130)
+    expect(rec.pnl_usd).toBe(-130)
+    expect(rec.pnl_pct).toBeCloseTo(-86.67, 1)
+
+    // Lesson must be derived as EXECUTION FAILURE / CAPITAL LOSS
+    expect(data.lessons.length).toBeGreaterThanOrEqual(1)
+    const failureLesson = data.lessons.find(
+      (l: any) => l.rule.includes('EXECUTION FAILURE') || l.tags.includes('capital_loss'),
+    )
+    expect(failureLesson).toBeDefined()
+    expect(failureLesson.outcome).toBe('bad')
+
+    // Summary must count this as a loss
+    const summary = getPerformanceSummary() as any
+    expect(summary.win_rate_pct).toBe(0)
+    expect(summary.total_pnl_usd).toBe(-130)
+  })
+
+  it('AC4: Mark-to-market updates residual valuation of unliquidated inventory', async () => {
+    await recordPerformance({
+      position: 'pos-mark-4',
+      pool: 'pool-mark',
+      pool_name: 'MEME-SOL',
+      base_mint: 'mint-meme-4',
+      strategy: 'spot',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.4,
+      fee_tvl_ratio: 0.1,
+      organic_score: 60,
+      amount_sol: 1.0,
+      initial_value_usd: 100,
+      final_value_usd: 110,
+      fees_earned_usd: 0,
+      minutes_in_range: 30,
+      minutes_held: 30,
+      close_reason: 'take profit',
+      status: 'closed_pending_swap',
+      cash_realized_sol: 0.1,
+      cash_realized_usd: 15,
+      unrealized_residual_usd: 95,
+      unrealized_tokens_amount: 1000, // $0.095 per token originally
+      liquidation_mint: 'mint-meme-4',
+    })
+
+    // Token drops 50% to $0.0475
+    const updatedCount = updatePendingTradesMarkToMarket({
+      'mint-meme-4': 0.0475,
+    })
+    expect(updatedCount).toBe(1)
+
+    const data = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'))
+    const rec = data.performance[0]
+    expect(rec.unrealized_residual_usd).toBeCloseTo(47.5, 2)
+    // finalValue = $15 (cash) + $47.5 (residual) = $62.5
+    expect(rec.final_value_usd).toBeCloseTo(62.5, 2)
+    // Net PnL = $62.5 - $100 = -$37.5 (-37.5%)
+    expect(rec.net_pnl_usd).toBeCloseTo(-37.5, 2)
+    expect(rec.pnl_pct).toBeCloseTo(-37.5, 2)
+  })
+
+  it('AC5: liquidation-queue markLiquidationSuccess automatically settles trade in lessons.json', async () => {
+    const { enqueuePendingLiquidation, markLiquidationSuccess } = await import('./liquidation-queue.js')
+
+    await recordPerformance({
+      position: 'pos-queue-5',
+      pool: 'pool-queue',
+      pool_name: 'QUEUE-SOL',
+      base_mint: 'mint-queue-5',
+      strategy: 'spot',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.3,
+      fee_tvl_ratio: 0.1,
+      organic_score: 75,
+      amount_sol: 1.0,
+      initial_value_usd: 150,
+      final_value_usd: 150,
+      fees_earned_usd: 0,
+      minutes_in_range: 30,
+      minutes_held: 30,
+      close_reason: 'take profit',
+      status: 'closed_pending_swap',
+      cash_realized_sol: 0.2,
+      cash_realized_usd: 30,
+      unrealized_residual_usd: 120,
+      unrealized_tokens_amount: 1000,
+      liquidation_mint: 'mint-queue-5',
+    })
+
+    await enqueuePendingLiquidation({
+      mint: 'mint-queue-5',
+      symbol: 'QUEUE',
+      amount: 1000,
+      usd: 120,
+      position: 'pos-queue-5',
+    })
+
+    // Now sweeper succeeds in swapping
+    await markLiquidationSuccess('mint-queue-5', {
+      amountOutSol: 0.9,
+      tx: 'tx-queue-success',
+    })
+
+    const data = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'))
+    const rec = data.performance[0]
+    expect(rec.status).toBe('realized')
+    // 0.2 + 0.9 = 1.1 SOL
+    expect(rec.cash_realized_sol).toBeCloseTo(1.1, 4)
+    expect(rec.unrealized_residual_usd).toBe(0)
+    expect(rec.liquidation_tx).toBe('tx-queue-success')
+  })
+
+  it('AC6: liquidation-queue markLiquidationAttempt abandonment automatically records abandoned_loss in lessons.json', async () => {
+    const { enqueuePendingLiquidation, markLiquidationAttempt } = await import('./liquidation-queue.js')
+
+    await recordPerformance({
+      position: 'pos-queue-6',
+      pool: 'pool-queue-6',
+      pool_name: 'DEAD-SOL',
+      base_mint: 'mint-dead-6',
+      strategy: 'bid_ask',
+      bin_range: 20,
+      bin_step: 10,
+      volatility: 0.9,
+      fee_tvl_ratio: 0.1,
+      organic_score: 20,
+      amount_sol: 1.0,
+      initial_value_usd: 150,
+      final_value_usd: 160,
+      fees_earned_usd: 0,
+      minutes_in_range: 10,
+      minutes_held: 15,
+      close_reason: 'stop loss',
+      status: 'closed_pending_swap',
+      cash_realized_sol: 0.05,
+      cash_realized_usd: 7.5,
+      unrealized_residual_usd: 152.5,
+      unrealized_tokens_amount: 5000,
+      liquidation_mint: 'mint-dead-6',
+    })
+
+    await enqueuePendingLiquidation({
+      mint: 'mint-dead-6',
+      symbol: 'DEAD',
+      amount: 5000,
+      usd: 152.5,
+      position: 'pos-queue-6',
+    })
+
+    // Attempt fails and hits maxAttempts (1)
+    await markLiquidationAttempt('mint-dead-6', {
+      error: 'zero liquidity pool drained',
+      maxAttempts: 1,
+    })
+
+    const data = JSON.parse(fs.readFileSync(lessonsFile, 'utf-8'))
+    const rec = data.performance[0]
+    expect(rec.status).toBe('abandoned_loss')
+    expect(rec.final_value_usd).toBe(7.5)
+    // Loss = 7.5 - 150 = -$142.5
+    expect(rec.net_pnl_usd).toBe(-142.5)
+
+    // Lesson should reflect failure
+    expect(data.lessons.some((l: any) => l.rule.includes('EXECUTION FAILURE') && l.outcome === 'bad')).toBe(true)
+  })
+})

--- a/packages/core/src/domain/lessons.ts
+++ b/packages/core/src/domain/lessons.ts
@@ -64,7 +64,9 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
     perf.final_value_usd > 0 &&
     perf.final_value_usd <= perf.amount_sol * 2
 
-  if (suspiciousUnitMix) {
+  const status = perf.status || 'realized'
+
+  if (suspiciousUnitMix && status === 'realized') {
     log(
       'lessons_warn',
       `Skipped suspicious performance record for ${perf.pool_name || perf.pool}: initial=${perf.initial_value_usd}, final=${perf.final_value_usd}, amount_sol=${perf.amount_sol}`,
@@ -81,7 +83,11 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
 
   const closeReasonText = String(perf.close_reason || '').toLowerCase()
   const suspiciousAbsurdClosedPnl =
-    Number.isFinite(pnl_pct) && perf.initial_value_usd >= 20 && pnl_pct <= -90 && !closeReasonText.includes('stop loss')
+    status === 'realized' &&
+    Number.isFinite(pnl_pct) &&
+    perf.initial_value_usd >= 20 &&
+    pnl_pct <= -90 &&
+    !closeReasonText.includes('stop loss')
 
   if (suspiciousAbsurdClosedPnl) {
     log(
@@ -92,8 +98,16 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
   }
 
   const signalSnapshot = buildSignalSnapshot(perf as unknown as Record<string, unknown>)
-  const entry = {
+  const entry: PerformanceRecord = {
     ...perf,
+    status,
+    cash_realized_sol:
+      perf.cash_realized_sol !== undefined ? perf.cash_realized_sol : status === 'realized' ? perf.amount_sol : 0,
+    cash_realized_usd:
+      perf.cash_realized_usd !== undefined ? perf.cash_realized_usd : status === 'realized' ? perf.final_value_usd : 0,
+    unrealized_residual_usd: perf.unrealized_residual_usd ?? 0,
+    unrealized_tokens_amount: perf.unrealized_tokens_amount ?? 0,
+    liquidation_mint: perf.liquidation_mint || perf.base_mint,
     signal_snapshot: signalSnapshot as SignalSnapshot | null as unknown as SignalSnapshot | undefined,
     price_pnl_usd: Math.round(price_pnl_usd * 100) / 100,
     price_pnl_pct: Math.round(price_pnl_pct * 100) / 100,
@@ -104,17 +118,20 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
     recorded_at: new Date().toISOString(),
   }
 
-  data.performance.push(entry as PerformanceRecord)
+  data.performance.push(entry)
 
-  // Derive and store a lesson
-  const lesson = derivLesson(entry as PerformanceRecord & { recorded_at?: string })
-  if (lesson) {
-    if (lesson.rule) {
-      const sanitized = sanitizeLessonText(lesson.rule)
-      if (sanitized) lesson.rule = sanitized
+  // Derive and store a lesson only if settled (never derive positive lessons for pending unliquidated trades)
+  let lesson: Lesson | null = null
+  if (entry.status !== 'closed_pending_swap') {
+    lesson = derivLesson(entry as PerformanceRecord & { recorded_at?: string })
+    if (lesson) {
+      if (lesson.rule) {
+        const sanitized = sanitizeLessonText(lesson.rule)
+        if (sanitized) lesson.rule = sanitized
+      }
+      data.lessons.push(lesson)
+      log('lessons', `New lesson: ${lesson.rule}`)
     }
-    data.lessons.push(lesson)
-    log('lessons', `New lesson: ${lesson.rule}`)
   }
 
   save(data)
@@ -122,8 +139,8 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
     void pushHiveLesson(lesson)
   }
 
-  // Update pool-level memory
-  if (perf.pool) {
+  // Update pool-level memory only for settled trades
+  if (perf.pool && entry.status !== 'closed_pending_swap') {
     const { recordPoolDeploy } = await import('./pool-memory.js')
     recordPoolDeploy(perf.pool, {
       pool_name: perf.pool_name,
@@ -184,6 +201,8 @@ export async function recordPerformance(perf: PerformanceRecord): Promise<void> 
  * Only generates a lesson if the outcome was clearly good or bad.
  */
 function derivLesson(perf: PerformanceRecord & { recorded_at?: string }): Lesson | null {
+  if (perf.status === 'closed_pending_swap') return null
+
   const tags: string[] = []
   const feeYieldPct = perf.initial_value_usd > 0 ? ((perf.fees_earned_usd || 0) / perf.initial_value_usd) * 100 : 0
 
@@ -664,6 +683,259 @@ interface GetPerformanceHistoryOpts {
 }
 
 /**
+ * Settle a pending trade liquidation with actual SOL cash received from swap.
+ * Finalizes the trade to 'realized', zeroes unliquidated residual, and derives lesson.
+ */
+export interface SettleTradeLiquidationOpts {
+  amountOutSol: number
+  solPrice?: number
+  tx?: string
+  position?: string
+}
+
+export async function settleTradeLiquidation(mint: string, opts: SettleTradeLiquidationOpts): Promise<boolean> {
+  const data = load()
+  let targetIndex = -1
+  if (opts.position) {
+    targetIndex = data.performance.findIndex((p) => p.position === opts.position && p.status === 'closed_pending_swap')
+  }
+  if (targetIndex === -1) {
+    for (let i = data.performance.length - 1; i >= 0; i--) {
+      const p = data.performance[i]
+      if (p && p.status === 'closed_pending_swap' && (p.liquidation_mint === mint || p.base_mint === mint)) {
+        targetIndex = i
+        break
+      }
+    }
+  }
+
+  if (targetIndex === -1) return false
+
+  const rec = data.performance[targetIndex]
+  if (!rec) return false
+  const now = new Date().toISOString()
+
+  const additionalSol = opts.amountOutSol || 0
+  const solPrice =
+    opts.solPrice || (rec.amount_sol > 0 && rec.initial_value_usd > 0 ? rec.initial_value_usd / rec.amount_sol : 150)
+  const newCashSol = (rec.cash_realized_sol || 0) + additionalSol
+  const additionalUsd = additionalSol * solPrice
+  const newCashUsd = Math.round(((rec.cash_realized_usd || 0) + additionalUsd) * 100) / 100
+
+  rec.cash_realized_sol = Math.round(newCashSol * 10000) / 10000
+  rec.cash_realized_usd = newCashUsd
+  rec.unrealized_residual_usd = 0
+  rec.unrealized_tokens_amount = 0
+  rec.final_value_usd = newCashUsd
+  rec.status = 'realized'
+  rec.settled_at = now
+  if (opts.tx) rec.liquidation_tx = opts.tx
+
+  const price_pnl_usd = rec.final_value_usd - rec.initial_value_usd
+  const price_pnl_pct = rec.initial_value_usd > 0 ? (price_pnl_usd / rec.initial_value_usd) * 100 : 0
+  const net_pnl_usd = price_pnl_usd + (rec.fees_earned_usd || 0)
+  const pnl_usd = net_pnl_usd
+  const pnl_pct = rec.initial_value_usd > 0 ? (pnl_usd / rec.initial_value_usd) * 100 : 0
+
+  rec.price_pnl_usd = Math.round(price_pnl_usd * 100) / 100
+  rec.price_pnl_pct = Math.round(price_pnl_pct * 100) / 100
+  rec.net_pnl_usd = Math.round(net_pnl_usd * 100) / 100
+  rec.pnl_usd = Math.round(pnl_usd * 100) / 100
+  rec.pnl_pct = Math.round(pnl_pct * 100) / 100
+
+  const lesson = derivLesson(rec as PerformanceRecord & { recorded_at?: string })
+  if (lesson) {
+    if (lesson.rule) {
+      const sanitized = sanitizeLessonText(lesson.rule)
+      if (sanitized) lesson.rule = sanitized
+    }
+    data.lessons.push(lesson)
+    log('lessons', `Settled trade lesson: ${lesson.rule}`)
+    void pushHiveLesson(lesson)
+  }
+
+  save(data)
+
+  if (rec.pool) {
+    try {
+      const { recordPoolDeploy } = await import('./pool-memory.js')
+      recordPoolDeploy(rec.pool, {
+        pool_name: rec.pool_name,
+        base_mint: rec.base_mint,
+        deployed_at: rec.deployed_at,
+        closed_at: now,
+        price_pnl_usd: rec.price_pnl_usd,
+        price_pnl_pct: rec.price_pnl_pct,
+        net_pnl_usd: rec.net_pnl_usd,
+        pnl_pct: rec.pnl_pct,
+        pnl_usd: rec.pnl_usd,
+        range_efficiency: rec.range_efficiency,
+        minutes_held: rec.minutes_held,
+        fees_earned_usd: rec.fees_earned_usd,
+        fees_earned_sol: rec.fees_earned_sol,
+        fee_earned_pct: rec.initial_value_usd > 0 ? ((rec.fees_earned_usd || 0) / rec.initial_value_usd) * 100 : null,
+        close_reason: rec.close_reason,
+        strategy: rec.strategy,
+        volatility: rec.volatility,
+        entry_mcap: rec.entry_mcap,
+        entry_tvl: rec.entry_tvl,
+        entry_volume: rec.entry_volume,
+        exit_mcap: rec.exit_mcap,
+        exit_tvl: rec.exit_tvl,
+        exit_volume: rec.exit_volume,
+      })
+    } catch {
+      // ignore
+    }
+  }
+
+  return true
+}
+
+/**
+ * Recognize an unliquidated token as abandoned / dead / rugged.
+ * Writes down unrealized residual to 0, recognizes full capital loss, and derives failure lesson.
+ */
+export interface AbandonTradeLiquidationOpts {
+  reason?: string
+  position?: string
+}
+
+export async function abandonTradeLiquidation(mint: string, opts: AbandonTradeLiquidationOpts = {}): Promise<boolean> {
+  const data = load()
+  let targetIndex = -1
+  if (opts.position) {
+    targetIndex = data.performance.findIndex((p) => p.position === opts.position && p.status === 'closed_pending_swap')
+  }
+  if (targetIndex === -1) {
+    for (let i = data.performance.length - 1; i >= 0; i--) {
+      const p = data.performance[i]
+      if (p && p.status === 'closed_pending_swap' && (p.liquidation_mint === mint || p.base_mint === mint)) {
+        targetIndex = i
+        break
+      }
+    }
+  }
+
+  if (targetIndex === -1) return false
+
+  const rec = data.performance[targetIndex]
+  if (!rec) return false
+  const now = new Date().toISOString()
+
+  rec.status = 'abandoned_loss'
+  rec.settled_at = now
+  rec.unrealized_residual_usd = 0
+  rec.unrealized_tokens_amount = 0
+  rec.final_value_usd = rec.cash_realized_usd || 0
+
+  const price_pnl_usd = rec.final_value_usd - rec.initial_value_usd
+  const price_pnl_pct = rec.initial_value_usd > 0 ? (price_pnl_usd / rec.initial_value_usd) * 100 : 0
+  const net_pnl_usd = price_pnl_usd + (rec.fees_earned_usd || 0)
+  const pnl_usd = net_pnl_usd
+  const pnl_pct = rec.initial_value_usd > 0 ? (pnl_usd / rec.initial_value_usd) * 100 : 0
+
+  rec.price_pnl_usd = Math.round(price_pnl_usd * 100) / 100
+  rec.price_pnl_pct = Math.round(price_pnl_pct * 100) / 100
+  rec.net_pnl_usd = Math.round(net_pnl_usd * 100) / 100
+  rec.pnl_usd = Math.round(pnl_usd * 100) / 100
+  rec.pnl_pct = Math.round(pnl_pct * 100) / 100
+
+  const tokenLabel = rec.pool_name?.split(/[-/]/)[0] || mint.slice(0, 8)
+  const reasonText = opts.reason || 'Unsold tokens abandoned / unsellable'
+  const lessonRule = `EXECUTION FAILURE / CAPITAL LOSS: Unsold ${tokenLabel} (${mint.slice(0, 8)}) could not be liquidated (${reasonText}). Realized loss: -$${Math.abs(pnl_usd).toFixed(2)} (${pnl_pct.toFixed(1)}%). Strategy: ${rec.strategy}.`
+
+  const lesson: Lesson = {
+    id: Date.now(),
+    rule: lessonRule,
+    tags: ['execution_failure', 'liquidation_failure', 'capital_loss', rec.strategy],
+    outcome: 'bad',
+    sourceType: 'performance',
+    confidence: 0.95,
+    context: `${rec.pool_name}, strategy=${rec.strategy}, liquidation_failed`,
+    pnl_pct: rec.pnl_pct,
+    fees_earned_usd: rec.fees_earned_usd,
+    initial_value_usd: rec.initial_value_usd,
+    range_efficiency: rec.range_efficiency,
+    close_reason: `abandoned_liquidation: ${reasonText}`,
+    pool: rec.pool,
+    created_at: now,
+  }
+
+  data.lessons.push(lesson)
+  log('lessons_warn', `Recognized abandoned liquidation loss: ${lessonRule}`)
+  save(data)
+  void pushHiveLesson(lesson)
+
+  if (rec.pool) {
+    try {
+      const { recordPoolDeploy } = await import('./pool-memory.js')
+      recordPoolDeploy(rec.pool, {
+        pool_name: rec.pool_name,
+        base_mint: rec.base_mint,
+        deployed_at: rec.deployed_at,
+        closed_at: now,
+        price_pnl_usd: rec.price_pnl_usd,
+        price_pnl_pct: rec.price_pnl_pct,
+        net_pnl_usd: rec.net_pnl_usd,
+        pnl_pct: rec.pnl_pct,
+        pnl_usd: rec.pnl_usd,
+        range_efficiency: rec.range_efficiency,
+        minutes_held: rec.minutes_held,
+        fees_earned_usd: rec.fees_earned_usd,
+        fees_earned_sol: rec.fees_earned_sol,
+        fee_earned_pct: rec.initial_value_usd > 0 ? ((rec.fees_earned_usd || 0) / rec.initial_value_usd) * 100 : null,
+        close_reason: `abandoned_liquidation: ${reasonText}`,
+        strategy: rec.strategy,
+        volatility: rec.volatility,
+      })
+    } catch {
+      // ignore
+    }
+  }
+
+  return true
+}
+
+/**
+ * Continuously mark unswapped token inventory to market spot prices.
+ */
+export function updatePendingTradesMarkToMarket(priceMap: Record<string, number>): number {
+  const data = load()
+  let updated = 0
+
+  for (const rec of data.performance) {
+    if (rec.status !== 'closed_pending_swap') continue
+    const mint = rec.liquidation_mint || rec.base_mint
+    if (!mint) continue
+
+    const price = priceMap[mint]
+    if (typeof price === 'number' && Number.isFinite(price) && price >= 0) {
+      const amount = rec.unrealized_tokens_amount || 0
+      const newResidual = Math.round(amount * price * 100) / 100
+      rec.unrealized_residual_usd = newResidual
+      const newFinal = Math.round(((rec.cash_realized_usd || 0) + newResidual) * 100) / 100
+      rec.final_value_usd = newFinal
+      const price_pnl_usd = rec.final_value_usd - rec.initial_value_usd
+      const price_pnl_pct = rec.initial_value_usd > 0 ? (price_pnl_usd / rec.initial_value_usd) * 100 : 0
+      const net_pnl_usd = price_pnl_usd + (rec.fees_earned_usd || 0)
+      rec.price_pnl_usd = Math.round(price_pnl_usd * 100) / 100
+      rec.price_pnl_pct = Math.round(price_pnl_pct * 100) / 100
+      rec.net_pnl_usd = Math.round(net_pnl_usd * 100) / 100
+      rec.pnl_usd = rec.net_pnl_usd
+      rec.pnl_pct = Math.round((rec.net_pnl_usd / (rec.initial_value_usd || 1)) * 10000) / 100
+      updated++
+    }
+  }
+
+  if (updated > 0) {
+    save(data)
+    log('lessons', `Marked ${updated} pending trade(s) to market`)
+  }
+  return updated
+}
+
+/**
  * Get individual performance records filtered by time window.
  * Tool handler: get_performance_history
  */
@@ -685,6 +957,10 @@ export function getPerformanceHistory({
       pool_name: r.pool_name,
       pool: r.pool,
       strategy: r.strategy,
+      status: r.status || 'realized',
+      cash_realized_sol: r.cash_realized_sol,
+      cash_realized_usd: r.cash_realized_usd,
+      unrealized_residual_usd: r.unrealized_residual_usd ?? 0,
       price_pnl_usd:
         r.price_pnl_usd ??
         (r.pnl_usd != null && r.fees_earned_usd != null
@@ -707,7 +983,8 @@ export function getPerformanceHistory({
     0,
   )
   const totalFees = filtered.reduce((s, r) => s + (r.fees_earned_usd ?? 0), 0)
-  const wins = filtered.filter((r) => (r.pnl_pct ?? 0) >= 0).length
+  const settled = filtered.filter((r) => r.status !== 'closed_pending_swap')
+  const wins = settled.filter((r) => (r.pnl_pct ?? 0) >= 0).length
 
   return {
     hours,
@@ -715,7 +992,7 @@ export function getPerformanceHistory({
     total_pnl_usd: Math.round(totalPnl * 100) / 100,
     total_price_pnl_usd: Math.round(totalPricePnl * 100) / 100,
     total_fees_earned_usd: Math.round(totalFees * 100) / 100,
-    win_rate_pct: filtered.length > 0 ? Math.round((wins / filtered.length) * 100) : null,
+    win_rate_pct: settled.length > 0 ? Math.round((wins / settled.length) * 100) : null,
     positions: filtered,
   }
 }
@@ -729,23 +1006,44 @@ export function getPerformanceSummary(): Record<string, unknown> | null {
 
   if (p.length === 0) return null
 
+  const realizedRecords = p.filter((x) => x.status !== 'closed_pending_swap')
+  const pendingRecords = p.filter((x) => x.status === 'closed_pending_swap')
+
   const totalPnl = p.reduce((s, x) => s + (x.net_pnl_usd ?? x.pnl_usd ?? 0), 0)
   const totalPricePnl = p.reduce((s, x) => s + (x.price_pnl_usd ?? (x.pnl_usd ?? 0) - (x.fees_earned_usd ?? 0)), 0)
   const totalFees = p.reduce((s, x) => s + (x.fees_earned_usd ?? 0), 0)
   const avgPnlPct = p.reduce((s, x) => s + (x.pnl_pct ?? 0), 0) / p.length
   const avgPricePnlPct = p.reduce((s, x) => s + (x.price_pnl_pct ?? 0), 0) / p.length
   const avgRangeEfficiency = p.reduce((s, x) => s + (x.range_efficiency ?? 0), 0) / p.length
-  const wins = p.filter((x) => (x.pnl_pct ?? 0) >= 0).length
+
+  const realizedWins = realizedRecords.filter((x) => (x.pnl_pct ?? 0) >= 0).length
+
+  const cashRealizedPnlUsd = p.reduce((s, x) => {
+    const cash =
+      x.cash_realized_usd !== undefined
+        ? x.cash_realized_usd
+        : x.status !== 'closed_pending_swap'
+          ? x.final_value_usd || 0
+          : 0
+    return s + (cash - (x.initial_value_usd || 0) + (x.fees_earned_usd || 0))
+  }, 0)
+
+  const unrealizedResidualUsd = pendingRecords.reduce((s, x) => s + (x.unrealized_residual_usd ?? 0), 0)
 
   return {
     total_positions_closed: p.length,
+    pending_swaps_count: pendingRecords.length,
+    realized_positions_count: realizedRecords.length,
     total_pnl_usd: Math.round(totalPnl * 100) / 100,
+    cash_realized_pnl_usd: Math.round(cashRealizedPnlUsd * 100) / 100,
+    unrealized_residual_usd: Math.round(unrealizedResidualUsd * 100) / 100,
     total_price_pnl_usd: Math.round(totalPricePnl * 100) / 100,
     total_fees_earned_usd: Math.round(totalFees * 100) / 100,
     avg_pnl_pct: Math.round(avgPnlPct * 100) / 100,
     avg_price_pnl_pct: Math.round(avgPricePnlPct * 100) / 100,
     avg_range_efficiency_pct: Math.round(avgRangeEfficiency * 10) / 10,
-    win_rate_pct: Math.round((wins / p.length) * 100),
+    win_rate_pct: realizedRecords.length > 0 ? Math.round((realizedWins / realizedRecords.length) * 100) : 0,
+    realized_win_rate_pct: realizedRecords.length > 0 ? Math.round((realizedWins / realizedRecords.length) * 100) : 0,
     total_lessons: data.lessons.length,
   }
 }

--- a/packages/core/src/domain/liquidation-queue.ts
+++ b/packages/core/src/domain/liquidation-queue.ts
@@ -21,6 +21,7 @@ export interface EnqueueLiquidationOpts {
   amount: number
   usd?: number | null
   pool_address?: string | null
+  position?: string | null
   error?: string
 }
 
@@ -63,6 +64,7 @@ export async function enqueuePendingLiquidation(opts: EnqueueLiquidationOpts): P
         amount: opts.amount > 0 ? opts.amount : existing.amount,
         usd: opts.usd !== undefined ? opts.usd : existing.usd,
         pool_address: opts.pool_address || existing.pool_address,
+        position: opts.position || existing.position || null,
         last_attempt_at: now,
         status: 'pending',
         last_error: opts.error || existing.last_error,
@@ -74,6 +76,7 @@ export async function enqueuePendingLiquidation(opts: EnqueueLiquidationOpts): P
         amount: opts.amount,
         usd: opts.usd ?? null,
         pool_address: opts.pool_address || null,
+        position: opts.position || null,
         added_at: now,
         last_attempt_at: now,
         attempts: 0,
@@ -101,11 +104,13 @@ export async function markLiquidationSuccess(
   mint: string,
   opts: { tx?: string; amountOutSol?: number } = {},
 ): Promise<boolean> {
-  return withStateLock(() => {
+  let position: string | null = null
+  const success = await withStateLock(() => {
     const state = loadState()
     const item = state.pendingLiquidations?.[mint]
     if (!item) return false
 
+    position = item.position || null
     item.status = 'liquidated'
     item.last_attempt_at = new Date().toISOString()
     item.last_error = null
@@ -117,6 +122,21 @@ export async function markLiquidationSuccess(
     )
     return true
   })
+
+  if (success) {
+    try {
+      const { settleTradeLiquidation } = await import('./lessons.js')
+      await settleTradeLiquidation(mint, {
+        amountOutSol: opts.amountOutSol || 0,
+        tx: opts.tx,
+        position: position || undefined,
+      })
+    } catch (e: any) {
+      log('state_warn', `Failed to settle trade liquidation in lessons for ${mint}: ${e?.message || e}`)
+    }
+  }
+
+  return success
 }
 
 /**
@@ -131,26 +151,31 @@ export async function markLiquidationAttempt(
     abandonWindowHours?: number
   } = {},
 ): Promise<{ status: 'pending' | 'abandoned'; attempts: number }> {
-  return withStateLock(() => {
+  let abandonedPosition: string | null = null
+  let lastError: string | null = null
+
+  const result = await withStateLock(() => {
     const state = loadState()
     const item = state.pendingLiquidations?.[mint]
     const maxAttempts = opts.maxAttempts ?? 10
     const abandonWindowHours = opts.abandonWindowHours ?? 2
 
     if (!item) {
-      return { status: 'abandoned', attempts: 0 }
+      return { status: 'abandoned' as const, attempts: 0 }
     }
 
     const now = new Date()
     item.attempts = (item.attempts || 0) + 1
     item.last_attempt_at = now.toISOString()
     item.last_error = opts.error || 'Liquidation attempt failed'
+    lastError = item.last_error
 
     const addedMs = item.added_at ? new Date(item.added_at).getTime() : now.getTime()
     const ageHours = (now.getTime() - addedMs) / (1000 * 60 * 60)
 
     if (item.attempts >= maxAttempts || ageHours >= abandonWindowHours) {
       item.status = 'abandoned'
+      abandonedPosition = item.position || null
       log(
         'state_warn',
         `Liquidation abandoned for ${item.symbol || mint.slice(0, 8)} after ${item.attempts} attempts (${ageHours.toFixed(1)}h). Token marked dead/rugged to halt RPC quote spam.`,
@@ -160,6 +185,20 @@ export async function markLiquidationAttempt(
     saveState(state)
     return { status: item.status as 'pending' | 'abandoned', attempts: item.attempts }
   })
+
+  if (result.status === 'abandoned') {
+    try {
+      const { abandonTradeLiquidation } = await import('./lessons.js')
+      await abandonTradeLiquidation(mint, {
+        reason: lastError || 'Liquidation attempts exhausted',
+        position: abandonedPosition || undefined,
+      })
+    } catch (e: any) {
+      log('state_warn', `Failed to record abandoned liquidation loss for ${mint}: ${e?.message || e}`)
+    }
+  }
+
+  return result
 }
 
 /**

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -247,11 +247,16 @@ export interface Lesson {
 
 export type LessonOutcome = 'good' | 'bad' | 'poor' | 'neutral' | 'manual' | 'evolution' | 'failed' | 'worked'
 
+export type PerformanceStatus = 'realized' | 'closed_pending_swap' | 'abandoned_loss'
+
 export interface PerformanceRecord {
   position: string
   pool: string
   pool_name: string
   base_mint?: string
+  /** Trade settlement status: realized (cash SOL received), closed_pending_swap, or abandoned_loss */
+  status?: PerformanceStatus
+  settled_at?: string
   strategy: string
   bin_range: number | BinRange
   bin_step: number
@@ -268,6 +273,18 @@ export interface PerformanceRecord {
   close_reason: string
   deployed_at?: string
   signal_snapshot?: SignalSnapshot
+  /** Actual net SOL returned to the wallet (including post-close swap) */
+  cash_realized_sol?: number
+  /** USD valuation of cash SOL returned to the wallet */
+  cash_realized_usd?: number
+  /** Marked-to-market USD value of unswapped base tokens awaiting liquidation */
+  unrealized_residual_usd?: number
+  /** Number of unsold base tokens awaiting liquidation */
+  unrealized_tokens_amount?: number
+  /** Base token mint awaiting liquidation */
+  liquidation_mint?: string
+  /** Transaction hash of successful liquidation swap */
+  liquidation_tx?: string
   /** Price-only PnL in USD (final_value_usd - initial_value_usd), excluding fees */
   price_pnl_usd?: number
   /** Percentage price-only PnL */
@@ -690,6 +707,7 @@ export interface PendingLiquidation {
   amount: number
   usd?: number | null
   pool_address?: string | null
+  position?: string | null
   added_at: string
   last_attempt_at: string | null
   attempts: number


### PR DESCRIPTION
Closes #267

### Summary & Root Cause
Prior to this change, when an LP position was closed, its PnL was immediately recorded based on the simulated or spot balance of returned base tokens at the moment of close. If the subsequent swap failed or the token dumped to 0, the trade remained permanently logged as a profitable win, producing 'Phantom PnL'.

This PR implements realistic PnL accounting, lifecycle separation, and mark-to-market:
1. **Realized Cash vs Pending Residual**:
   - Closed positions with unswapped base tokens are marked as `status: 'closed_pending_swap'`.
   - `cash_realized_sol` and `cash_realized_usd` only count actual cash SOL received in wallet.
   - `unrealized_residual_usd` tracks unswapped base token inventory marked to market.
2. **Mark-to-Market**:
   - `updatePendingTradesMarkToMarket(priceMap)` regularly updates unsold residual inventory values across the queue and performance history.
3. **Settlement on Liquidation**:
   - When the sweeper or auto-swap liquidates remaining tokens, `settleTradeLiquidation` transitions the trade to `status: 'realized'`, locks final cash SOL/USD, updates pool stats, and derives finalized lessons.
4. **100% Capital Loss on Abandonment**:
   - When liquidations are exhausted / abandoned, `abandonTradeLiquidation` writes residual value down to zsh, marks `status: 'abandoned_loss'`, and logs an `EXECUTION FAILURE / CAPITAL LOSS` lesson with `outcome: 'bad'`.
5. **Accurate Metrics & Alerts**:
   - Win rates in `getPerformanceSummary`, `getPerformanceHistory`, and `BriefingAdapter` exclude `closed_pending_swap` positions.
   - Telegram close notifications clearly distinguish between cash-settled closes and pending liquidations.

### Acceptance Criteria Verification
- [x] Unswapped closed trades are marked `closed_pending_swap`
- [x] Cash realized SOL/USD only accounts for actual SOL received in wallet
- [x] Residual unsold tokens marked to market spot prices
- [x] Full capital loss recognized upon sweeper abandonment (`abandoned_loss`)
- [x] Win rate excludes pending trades awaiting liquidation
- [x] Closes #267

### Test Plan
- Ran comprehensive domain tests: `packages/core/src/domain/lessons-realistic-pnl.test.ts`
- Ran full workspace test suite (35 test files, 402 tests passed)
- Built all packages cleanly with zero TypeScript errors
- Verified Biome lint passes with 0 errors