### PR TITLE
[core] capital starvation prevention & adaptive deployment sizing

### DIFF
--- a/packages/core/src/config/Config.test.ts
+++ b/packages/core/src/config/Config.test.ts
@@ -474,7 +474,6 @@ describe('DEFAULT_USER_CONFIG template parity and validation', () => {
           {
             path: ['llm', 'defaultModel'],
             message: 'Environment variable LLM_MODEL is not set',
-            params: { envVar: 'LLM_MODEL', ref: 'env.LLM_MODEL' },
           },
         ],
       }
@@ -485,6 +484,43 @@ describe('DEFAULT_USER_CONFIG template parity and validation', () => {
       expect(output).toContain('LLM_MODEL=<value>')
       expect(output).toContain('OR update the value directly in your configuration file:')
       expect(output).toContain('/Users/r/test/user-config.json')
+    })
+  })
+
+  describe('computeDeployAmount', () => {
+    it('returns standard deploy floor when wallet has sufficient balance', async () => {
+      const { computeDeployAmount, config } = await import('./Config.js')
+      const floor = config.management.deployAmountSol
+      const reserve = config.management.gasReserve
+
+      // With wallet having enough for reserve + floor, should return at least floor
+      const result = computeDeployAmount(floor + reserve + 0.01)
+      expect(result).toBeGreaterThanOrEqual(floor)
+    })
+
+    it('scales down to minViableDeploy when wallet balance is near threshold and minViableDeploy provided', async () => {
+      const { computeDeployAmount, config } = await import('./Config.js')
+      const floor = config.management.deployAmountSol
+      const reserve = config.management.gasReserve
+      const minViable = Math.max(0.05, floor * 0.8)
+
+      // Wallet has less than reserve + floor, but enough for reserve + minViable
+      const walletSol = reserve + minViable + 0.001
+      const withoutAdaptive = computeDeployAmount(walletSol)
+      const withAdaptive = computeDeployAmount(walletSol, minViable)
+
+      expect(withoutAdaptive).toBe(floor)
+      expect(withAdaptive).toBe(parseFloat(minViable.toFixed(2)))
+    })
+
+    it('does not scale below minViableDeploy if wallet is near threshold', async () => {
+      const { computeDeployAmount, config } = await import('./Config.js')
+      const floor = config.management.deployAmountSol
+      const reserve = config.management.gasReserve
+      const minViable = Math.max(0.05, floor * 0.8)
+
+      const result = computeDeployAmount(reserve + minViable, minViable)
+      expect(result).toBe(parseFloat(minViable.toFixed(2)))
     })
   })
 })

--- a/packages/core/src/config/Config.ts
+++ b/packages/core/src/config/Config.ts
@@ -282,14 +282,15 @@ setDryRun(config.connection.dryRun ?? false)
 // Initialize the minSafeBinsBelow override from config
 setMinSafeBinsBelowOverride(config.strategy.minSafeBinsBelow)
 
-export function computeDeployAmount(walletSol: number): number {
+export function computeDeployAmount(walletSol: number, minViableDeploy?: number): number {
   const reserve = config.management.gasReserve
   const pct = config.management.positionSizePct
   const floor = config.management.deployAmountSol
   const ceil = config.risk.maxDeployAmount
   const deployable = Math.max(0, walletSol - reserve)
   const dynamic = deployable * pct
-  const result = Math.min(ceil, Math.max(floor, dynamic))
+  const effectiveFloor = minViableDeploy !== undefined && deployable < floor ? Math.min(floor, minViableDeploy) : floor
+  const result = Math.min(ceil, Math.max(effectiveFloor, dynamic))
   return parseFloat(result.toFixed(2))
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,4 +28,5 @@ export * from './shared/logger.js'
 export * from './shared/mutex.js'
 export * from './shared/types.js'
 export * from './shared/utils.js'
+export * from './utils/time.js'
 export { briefing, desktop, domain, hivemind, meteora, price, screening, study, telegram, token, toolExecutor, wallet }

--- a/packages/daemon/src/Daemon.test.ts
+++ b/packages/daemon/src/Daemon.test.ts
@@ -820,4 +820,160 @@ describe('Telegram Queue Persistence & Safety Guards (#237 / #244)', () => {
     expect(loadJsonFile<any[]>(queuePath, ['not_empty'])).toEqual([])
     exitSpy.mockRestore()
   })
+
+  describe('Capital Starvation Prevention & Adaptive Sizing', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      adapters = createMockAdapters()
+      daemon = new Daemon(adapters)
+    })
+
+    afterEach(async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = true
+    })
+
+    it('allows screening when SOL is near threshold but above adaptive minimum', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({
+        sol: 0.19,
+        tokens: [],
+      })
+      adapters.screening.getTopCandidates = vi.fn().mockResolvedValue({ candidates: [] })
+
+      const res = await daemon.runScreeningCycle({ silent: true })
+      expect(res).not.toBeNull()
+      expect(adapters.screening.getTopCandidates).toHaveBeenCalled()
+    })
+
+    it('triggers auto-sweep when SOL is below threshold and wallet has swappable tokens', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi
+        .fn()
+        .mockResolvedValueOnce({
+          sol: 0.12,
+          tokens: [{ mint: 'mint_abc', symbol: 'DUST', balance: 100, usd: 5 }],
+        })
+        .mockResolvedValueOnce({
+          sol: 0.22,
+          tokens: [],
+        })
+      adapters.screening.getTopCandidates = vi.fn().mockResolvedValue({ candidates: [] })
+
+      const res = await daemon.runScreeningCycle({ silent: true })
+      expect(res).not.toBeNull()
+      expect(adapters.toolExecutor.executeTool).toHaveBeenCalledWith('swap_all_tokens_to_sol', {})
+      expect(adapters.wallet.getWalletBalances).toHaveBeenCalledTimes(2)
+    })
+
+    it('alerts and suppresses screening when SOL is genuinely starved after auto-sweep failure', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({
+        sol: 0.12,
+        tokens: [{ mint: 'mint_abc', symbol: 'DUST', balance: 100, usd: 5 }],
+      })
+      adapters.telegram.isEnabled = vi.fn().mockReturnValue(true)
+      adapters.toolExecutor.executeTool = vi.fn().mockRejectedValue(new Error('swap failed'))
+
+      const res = await daemon.runScreeningCycle({ silent: true })
+      expect(res).toContain('insufficient SOL')
+      expect(adapters.telegram.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Trading paused'))
+      expect((daemon as any).screeningStarvedUntil).toBeGreaterThan(Date.now())
+    })
+
+    it('suppresses subsequent screening cycles during starvation cooldown', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      ;(daemon as any).screeningStarvedUntil = Date.now() + 10 * 60 * 1000
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+
+      const res = await daemon.runScreeningCycle({ silent: true })
+      expect(res).toBeNull()
+      expect(adapters.screening.getTopCandidates).not.toHaveBeenCalled()
+    })
+
+    it('skips auto-sweep when no swappable tokens are available', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({
+        sol: 0.12,
+        tokens: [
+          { mint: 'So11111111111111111111111111111111111111111', symbol: 'SOL', balance: 0, usd: 0 },
+          { mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', symbol: 'USDC', balance: 0, usd: 0 },
+        ],
+      })
+
+      const res = await daemon.runScreeningCycle({ silent: true })
+      expect(res).toContain('insufficient SOL')
+      expect(adapters.toolExecutor.executeTool).not.toHaveBeenCalled()
+    })
+
+    it('allows manual screening (silent: false) to bypass starvation cooldown and clears cooldown on sufficient balance', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      ;(daemon as any).screeningStarvedUntil = Date.now() + 10 * 60 * 1000
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({
+        sol: 0.25,
+        tokens: [],
+      })
+      adapters.screening.getTopCandidates = vi.fn().mockResolvedValue({ candidates: [] })
+
+      const res = await daemon.runScreeningCycle({ silent: false })
+      expect(res).not.toBeNull()
+      expect(adapters.screening.getTopCandidates).toHaveBeenCalled()
+      expect((daemon as any).screeningStarvedUntil).toBe(0)
+    })
+
+    it('passes adaptive deploy amount to smart wallet screening when balance is near threshold', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+      const origSource = config.screening.entrySource
+      config.screening.entrySource = 'smart_wallets'
+
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({
+        sol: 0.19,
+        tokens: [],
+      })
+      const smartSpy = vi.spyOn(daemon, 'runSmartWalletScreening').mockResolvedValue('OK')
+
+      try {
+        await daemon.runScreeningCycle({ silent: true })
+        expect(smartSpy).toHaveBeenCalled()
+        const callArgs = smartSpy.mock.calls[0]?.[0] as any
+        expect(callArgs?.deployAmount).toBeLessThan(config.management.deployAmountSol)
+      } finally {
+        config.screening.entrySource = origSource
+      }
+    })
+
+    it('skips auto-sweep when token has 0 USD value (treated as dust)', async () => {
+      const { config } = await import('@etemaro/core')
+      config.connection.dryRun = false
+
+      adapters.meteora.getMyPositions = vi.fn().mockResolvedValue({ positions: [], total_positions: 0 })
+      adapters.wallet.getWalletBalances = vi.fn().mockResolvedValue({
+        sol: 0.12,
+        tokens: [{ mint: 'dead_token_mint', symbol: 'SCAM', balance: 1000, usd: 0 }],
+      })
+
+      const res = await daemon.runScreeningCycle({ silent: true })
+      expect(res).toContain('insufficient SOL')
+      expect(adapters.toolExecutor.executeTool).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/daemon/src/Daemon.ts
+++ b/packages/daemon/src/Daemon.ts
@@ -55,6 +55,7 @@ import {
   setPositionInstruction,
   sharedConfigPath,
   sharedDataPath,
+  sleep,
   strategyLibraryPath,
   TELEGRAM_QUEUE_FILENAME,
   TOKEN_BLACKLIST_FILENAME,
@@ -296,6 +297,7 @@ export class Daemon {
   // Cycle timers
   private managementLastRun: number | null = null
   private screeningLastRun: number | null = null
+  private screeningStarvedUntil = 0 // Epoch timestamp (ms); suppresses screening during capital-starvation cooldown
 
   // Telegram queue
   private telegramQueue: any[] = []
@@ -793,6 +795,7 @@ Summarize the current portfolio health, total fees earned, and performance of al
         if (!this.acquireLock('opportunityPoll')) return
         try {
           if (Date.now() - this.screeningLastTriggered < oppCooldownMs) return
+          if (this.screeningStarvedUntil > Date.now()) return
           const positions = await this.adapters.meteora.getMyPositions({ silent: true }).catch((err: any) => {
             log('cron_error', `Opportunity poller failed to fetch positions: ${err?.message || err}`)
             return null
@@ -846,7 +849,12 @@ Summarize the current portfolio health, total fees earned, and performance of al
               log('cron_error', `Opportunity poller failed to fetch wallet balances: ${err?.message || err}`)
               return null
             })
-            const minRequired = config.management.deployAmountSol + config.management.gasReserve
+            const deployFloor = config.management.deployAmountSol
+            const gasReserve = config.management.gasReserve
+            const minViableDeploy = Math.max(0.05, deployFloor * 0.8)
+            const needsAdaptive = (balance?.sol ?? 0) < deployFloor + gasReserve
+            const adaptiveDeploy = computeDeployAmount(balance?.sol ?? 0, needsAdaptive ? minViableDeploy : undefined)
+            const minRequired = gasReserve + adaptiveDeploy
             if (!balance || balance.sol < minRequired) {
               log(
                 'cron',
@@ -1271,6 +1279,10 @@ After evaluating, write a brief one-line result per position.
       log('cron', 'Screening skipped — previous cycle still running')
       return null
     }
+    if (this.screeningStarvedUntil > Date.now() && silent) {
+      log('cron', 'Screening suppressed — capital starvation cooldown active')
+      return null
+    }
     this.screeningLastTriggered = Date.now()
 
     let prePositions: any, preBalance: any
@@ -1292,26 +1304,69 @@ After evaluating, write a brief one-line result per position.
         })
         return screenReport
       }
-      const minRequired = config.management.deployAmountSol + config.management.gasReserve
+      const deployFloor = config.management.deployAmountSol
+      const gasReserve = config.management.gasReserve
+      const minViableDeploy = Math.max(0.05, deployFloor * 0.8)
       const isDryRun = config.connection.dryRun
+      let adaptiveDeploy = deployFloor
       if (!isDryRun) {
         preBalance = await this.adapters.wallet.getWalletBalances()
+        const needsAdaptive = preBalance.sol < deployFloor + gasReserve
+        adaptiveDeploy = computeDeployAmount(preBalance.sol, needsAdaptive ? minViableDeploy : undefined)
+        const minRequired = gasReserve + adaptiveDeploy
+
         if (preBalance.sol < minRequired) {
-          log(
-            'cron',
-            `Screening skipped — insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)} needed for deploy + gas)`,
-          )
-          screenReport = `Screening skipped — insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)} needed for deploy + gas).`
-          this.adapters.domain.appendDecision({
-            type: 'skip',
-            actor: 'SCREENER',
-            summary: 'Screening skipped',
-            reason: `Insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)})`,
+          const hasSwappableTokens = (preBalance.tokens || []).some((t: any) => {
+            const hasBalance = (t.balance ?? 0) > 0
+            const isSolOrUsdc =
+              t.mint === 'So11111111111111111111111111111111111111111' ||
+              t.mint === 'So11111111111111111111111111111111111111112' ||
+              t.mint === 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+            const isDust = typeof t.usd === 'number' && t.usd >= 0 && t.usd < 0.02
+            return hasBalance && !isSolOrUsdc && !isDust
           })
-          return screenReport
+
+          if (hasSwappableTokens) {
+            log(
+              'cron',
+              `SOL ${preBalance.sol.toFixed(3)} below adaptive min ${minRequired.toFixed(3)} — attempting auto-sweep`,
+            )
+            try {
+              await this.adapters.toolExecutor.executeTool('swap_all_tokens_to_sol', {})
+              await sleep(5000)
+              preBalance = await this.adapters.wallet.getWalletBalances()
+              const recheckAdaptive = computeDeployAmount(
+                preBalance.sol,
+                preBalance.sol < deployFloor + gasReserve ? minViableDeploy : undefined,
+              )
+              const recheckMin = gasReserve + recheckAdaptive
+
+              if (preBalance.sol >= recheckMin) {
+                log('cron', `Auto-sweep succeeded — SOL balance: ${preBalance.sol.toFixed(3)}`)
+                adaptiveDeploy = recheckAdaptive
+                this.screeningStarvedUntil = 0
+              } else {
+                this.handleScreeningStarvation(preBalance, gasReserve, minViableDeploy)
+                screenReport = `Screening skipped — insufficient SOL (${preBalance.sol.toFixed(3)} < ${recheckMin.toFixed(3)}) after auto-sweep.`
+                return screenReport
+              }
+            } catch (e: any) {
+              log('cron_error', `Auto-sweep failed: ${e.message}`)
+              this.handleScreeningStarvation(preBalance, gasReserve, minViableDeploy)
+              screenReport = `Screening skipped — insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)}); auto-sweep failed.`
+              return screenReport
+            }
+          } else {
+            this.handleScreeningStarvation(preBalance, gasReserve, minViableDeploy)
+            screenReport = `Screening skipped — insufficient SOL (${preBalance.sol.toFixed(3)} < ${minRequired.toFixed(3)}).`
+            return screenReport
+          }
+        } else {
+          this.screeningStarvedUntil = 0
         }
       } else {
         preBalance = { sol: Math.max(config.management.deployAmountSol, 1), tokens: [] }
+        adaptiveDeploy = computeDeployAmount(preBalance.sol)
       }
 
       if (!silent && this.adapters.telegram.isEnabled()) {
@@ -1323,7 +1378,7 @@ After evaluating, write a brief one-line result per position.
         try {
           screenReport = await this.runSmartWalletScreening({
             liveMessage,
-            deployAmount: computeDeployAmount(preBalance.sol),
+            deployAmount: adaptiveDeploy,
           })
         } catch (e: any) {
           log('cron_error', `Smart wallet screening failed: ${e.message}`)
@@ -1334,7 +1389,7 @@ After evaluating, write a brief one-line result per position.
 
       log('cron', `Starting screening cycle [model: ${config.llm.screeningModel}]`)
       const currentBalance = preBalance
-      const deployAmount = computeDeployAmount(currentBalance.sol)
+      const deployAmount = adaptiveDeploy
       log('cron', `Computed deploy amount: ${deployAmount} SOL (wallet: ${currentBalance.sol} SOL)`)
 
       const activeStrategy = this.adapters.domain.getActiveStrategy()
@@ -1663,6 +1718,31 @@ IMPORTANT:
       }
     }
     return screenReport
+  }
+
+  private handleScreeningStarvation(preBalance: any, gasReserve: number, minViableDeploy: number): void {
+    const minThreshold = gasReserve + minViableDeploy
+    this.screeningStarvedUntil = Date.now() + 15 * 60 * 1000
+
+    log(
+      'cron',
+      `Screening skipped — insufficient SOL (${preBalance.sol.toFixed(3)} < ${minThreshold.toFixed(3)}) after auto-sweep attempt`,
+    )
+
+    const alertMsg = `Trading paused: wallet balance (${preBalance.sol.toFixed(4)} SOL) below minimum threshold (${minThreshold.toFixed(3)} SOL). Deposit SOL or approve token liquidation to resume.`
+
+    if (this.adapters.telegram.isEnabled()) {
+      this.adapters.telegram.sendMessage(alertMsg).catch((err: any) => {
+        log('telegram_error', `Failed to send starvation alert: ${err?.message || err}`)
+      })
+    }
+
+    this.adapters.domain.appendDecision({
+      type: 'skip',
+      actor: 'SCREENER',
+      summary: 'Screening skipped — capital starvation',
+      reason: `Insufficient SOL (${preBalance.sol.toFixed(3)} < ${minThreshold.toFixed(3)}) after auto-sweep attempt`,
+    })
   }
 
   // ─── Deterministic Screen (for /screen command) ────────────────


### PR DESCRIPTION
## Summary

Fixes the 9.5-hour operational deadlock caused by a rigid `deployAmountSol + gasReserve` screening gate. When the wallet was deficient by $0.005 USD, every screening cycle aborted silently for hours despite holding swappable tokens worth ~$28 USD.

Closes #268

## Root Cause & Gap Analysis

- **Why/Whent it happened**: `Daemon.ts:1295` used a hard `config.management.deployAmountSol + config.management.gasReserve` floor. A microscopic deficit of 0.000047 SOL blocked all screening.
- **Why we missed it**: No adaptive sizing, no pre-flight auto-sweep, and no operator alerting on capital starvation.

## Acceptance Criteria Checklist

- [x] AC1: A deficit of <1% of `deployAmountSol` does not freeze screening
- [x] AC2: Near-threshold wallets scale down to a viable deploy amount (min 0.05 SOL or 80% of configured floor)
- [x] AC3: `swap_all_tokens_to_sol` is invoked automatically when tokens are available and SOL is below threshold
- [x] AC4: Operator receives Telegram alert within 15 minutes of genuine starvation
- [x] AC5: Screening cycles are suppressed for 15 minutes after starvation alert to prevent log spam
- [x] AC6: No new typecheck or lint errors introduced

## Testing Plan

- [x] **Unit: `computeDeployAmount` with optional `minViableDeploy` parameter**
- [x] **Unit: Daemon adaptive sizing when SOL is near threshold** — 0.19 SOL proceeds with scaled-down deploy
- [x] **Unit: Daemon auto-sweep path triggers `swap_all_tokens_to_sol` and re-checks balance**
- [x] **Unit: Daemon starvation alert and 15-minute suppression cooldown**
- [x] **Unit: Daemon skips auto-sweep when only SOL/USDC/dust tokens are present**
- [x] **CI: Typecheck & Lint** — clean in changed files
- [x] **CI: Automated Tests** — daemon + config + ToolExecutor suites green (40/40 daemon, 27/27 config, 34/34 ToolExecutor)