### PR TITLE
fix(core): persist evolved screening thresholds into screening namespace (#273)

### DIFF
--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod'
 import { DEFAULT_PNL_SOURCE } from '../shared/constants.js'
-import { resolveEnvString } from '../shared/utils.js'
+
+export function resolveEnvString(val: string): string | null {
+  if (!val.startsWith('env.')) return val
+  const envVar = val.slice(4)
+  const resolved = typeof process !== 'undefined' ? process.env?.[envVar] : undefined
+  return resolved !== undefined && resolved.trim() !== '' ? resolved.trim() : null
+}
 
 // Helper to handle process.env references for strings
 const envString = z.string().transform((val, ctx) => {
@@ -95,6 +101,9 @@ export const UserConfigSchema = z
     name: z.string().optional(),
     description: z.string().optional(),
     agentId: envStringNullable.optional(),
+    _lastEvolved: z.string().optional(),
+    _positionsAtEvolution: z.number().optional(),
+    _lastAgentTune: z.string().optional(),
     connection: z
       .object({
         description: z.string().optional(),

--- a/packages/core/src/domain/lessons.test.ts
+++ b/packages/core/src/domain/lessons.test.ts
@@ -16,12 +16,16 @@ vi.mock('../shared/constants.js', async (importOriginal) => {
   }
 })
 
-import { getPerformanceHistory, getPerformanceSummary, recordPerformance } from './lessons.js'
+import { DEFAULT_USER_CONFIG } from '../config/defaultUserConfig.js'
+import { UserConfigSchema } from '../config/schema.js'
+import type { AppConfig, PerformanceRecord } from '../shared/types.js'
+import { evolveThresholds, getPerformanceHistory, getPerformanceSummary, recordPerformance } from './lessons.js'
 
 type MockedConstants = typeof import('../shared/constants.js') & { __testDataDir: string }
 const constants = (await import('../shared/constants.js')) as MockedConstants
 const tmpDir = constants.__testDataDir
 const lessonsFile = path.join(tmpDir, 'lessons.json')
+const configFile = path.join(tmpDir, 'user-config.json')
 
 describe('lessons domain — Price PnL vs Net PnL disambiguation', () => {
   beforeEach(() => {
@@ -130,5 +134,164 @@ describe('lessons domain — Price PnL vs Net PnL disambiguation', () => {
     expect(pos.price_pnl_usd).toBe(10)
     expect(pos.net_pnl_usd).toBe(15)
     expect(pos.pnl_usd).toBe(15)
+  })
+})
+
+describe('evolveThresholds — config persistence & schema validity', () => {
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true })
+    fs.writeFileSync(lessonsFile, JSON.stringify({ lessons: [], performance: [] }))
+    fs.writeFileSync(configFile, JSON.stringify(DEFAULT_USER_CONFIG, null, 2))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes evolved thresholds to screening object, cleans up legacy root keys, and passes UserConfigSchema', () => {
+    // Seed config with legacy corrupted root keys
+    const initialConfig = JSON.parse(JSON.stringify(DEFAULT_USER_CONFIG))
+    initialConfig.minFeeActiveTvlRatio = 0.01 // legacy corrupted root key
+    initialConfig.minOrganic = 50 // legacy corrupted root key
+    fs.writeFileSync(configFile, JSON.stringify(initialConfig, null, 2))
+
+    const mockAppConfig = {
+      screening: {
+        minFeeActiveTvlRatio: 0.02,
+        minOrganic: 60,
+      },
+    } as unknown as AppConfig
+
+    // Create 5 performance records: 2 winners with high fee_tvl_ratio & organic, 3 losers with low fee_tvl & organic
+    const perfData: PerformanceRecord[] = [
+      {
+        position: 'p1',
+        pool: 'pool1',
+        pool_name: 'WIN1-SOL',
+        strategy: 'classic',
+        bin_range: 20,
+        bin_step: 10,
+        volatility: 0.2,
+        fee_tvl_ratio: 0.15,
+        organic_score: 85,
+        amount_sol: 1.0,
+        initial_value_usd: 100,
+        final_value_usd: 120,
+        fees_earned_usd: 10,
+        pnl_usd: 20,
+        pnl_pct: 10,
+        minutes_in_range: 60,
+        minutes_held: 60,
+        close_reason: 'take profit',
+        settled_at: new Date().toISOString(),
+      },
+      {
+        position: 'p2',
+        pool: 'pool2',
+        pool_name: 'WIN2-SOL',
+        strategy: 'classic',
+        bin_range: 20,
+        bin_step: 10,
+        volatility: 0.2,
+        fee_tvl_ratio: 0.2,
+        organic_score: 90,
+        amount_sol: 1.0,
+        initial_value_usd: 100,
+        final_value_usd: 130,
+        fees_earned_usd: 15,
+        pnl_usd: 30,
+        pnl_pct: 15,
+        minutes_in_range: 60,
+        minutes_held: 60,
+        close_reason: 'take profit',
+        settled_at: new Date().toISOString(),
+      },
+      {
+        position: 'p3',
+        pool: 'pool3',
+        pool_name: 'LOSE1-SOL',
+        strategy: 'classic',
+        bin_range: 20,
+        bin_step: 10,
+        volatility: 0.2,
+        fee_tvl_ratio: 0.01,
+        organic_score: 40,
+        amount_sol: 1.0,
+        initial_value_usd: 100,
+        final_value_usd: 80,
+        fees_earned_usd: 1,
+        pnl_usd: -20,
+        pnl_pct: -10,
+        minutes_in_range: 60,
+        minutes_held: 60,
+        close_reason: 'stop loss',
+        settled_at: new Date().toISOString(),
+      },
+      {
+        position: 'p4',
+        pool: 'pool4',
+        pool_name: 'LOSE2-SOL',
+        strategy: 'classic',
+        bin_range: 20,
+        bin_step: 10,
+        volatility: 0.2,
+        fee_tvl_ratio: 0.02,
+        organic_score: 45,
+        amount_sol: 1.0,
+        initial_value_usd: 100,
+        final_value_usd: 85,
+        fees_earned_usd: 2,
+        pnl_usd: -15,
+        pnl_pct: -8,
+        minutes_in_range: 60,
+        minutes_held: 60,
+        close_reason: 'stop loss',
+        settled_at: new Date().toISOString(),
+      },
+      {
+        position: 'p5',
+        pool: 'pool5',
+        pool_name: 'LOSE3-SOL',
+        strategy: 'classic',
+        bin_range: 20,
+        bin_step: 10,
+        volatility: 0.2,
+        fee_tvl_ratio: 0.01,
+        organic_score: 42,
+        amount_sol: 1.0,
+        initial_value_usd: 100,
+        final_value_usd: 75,
+        fees_earned_usd: 1,
+        pnl_usd: -25,
+        pnl_pct: -12,
+        minutes_in_range: 60,
+        minutes_held: 60,
+        close_reason: 'stop loss',
+        settled_at: new Date().toISOString(),
+      },
+    ]
+
+    const result = evolveThresholds(perfData, mockAppConfig, configFile)
+    expect(result).not.toBeNull()
+    expect(result?.changes).toBeDefined()
+    expect(Object.keys(result?.changes ?? {}).length).toBeGreaterThan(0)
+
+    // Read the persisted config from disk
+    const savedConfig = JSON.parse(fs.readFileSync(configFile, 'utf-8'))
+
+    // 1. Root level MUST NOT have screening fields
+    expect(savedConfig.minFeeActiveTvlRatio).toBeUndefined()
+    expect(savedConfig.minOrganic).toBeUndefined()
+
+    // 2. Screening object MUST have the evolved value
+    expect(savedConfig.screening.minFeeActiveTvlRatio).toBe(result?.changes.minFeeActiveTvlRatio)
+
+    // 3. Root metadata fields MUST be present
+    expect(typeof savedConfig._lastEvolved).toBe('string')
+    expect(savedConfig._positionsAtEvolution).toBe(5)
+
+    // 4. Saved config MUST pass strict UserConfigSchema validation
+    const parseResult = UserConfigSchema.safeParse(savedConfig)
+    expect(parseResult.success).toBe(true)
   })
 })

--- a/packages/core/src/domain/lessons.ts
+++ b/packages/core/src/domain/lessons.ts
@@ -331,7 +331,11 @@ interface EvolutionResult {
  * Analyze closed position performance and evolve screening thresholds.
  * Writes changes to user-config.json and returns a summary.
  */
-export function evolveThresholds(perfData: PerformanceRecord[], cfg: AppConfig): EvolutionResult | null {
+export function evolveThresholds(
+  perfData: PerformanceRecord[],
+  cfg: AppConfig,
+  targetConfigPath: string = USER_CONFIG_PATH,
+): EvolutionResult | null {
   if (!perfData || perfData.length < MIN_EVOLVE_POSITIONS) return null
 
   const winners = perfData.filter((p) => p.pnl_pct! > 0)
@@ -411,12 +415,18 @@ export function evolveThresholds(perfData: PerformanceRecord[], cfg: AppConfig):
   if (Object.keys(changes).length === 0) return { changes: {}, rationale: {} }
 
   // ── Persist changes to user-config.json ───────────────────────
-  const userConfig = loadJsonFile<Record<string, unknown>>(USER_CONFIG_PATH, {})
-  Object.assign(userConfig, changes)
+  const userConfig = loadJsonFile<Record<string, unknown>>(targetConfigPath, {})
+  if (!userConfig.screening || typeof userConfig.screening !== 'object' || Array.isArray(userConfig.screening)) {
+    userConfig.screening = {}
+  }
+  Object.assign(userConfig.screening as Record<string, unknown>, changes)
+  // Clean up legacy root-level keys if present from previous versions
+  delete (userConfig as Record<string, unknown>).minFeeActiveTvlRatio
+  delete (userConfig as Record<string, unknown>).minOrganic
   userConfig._lastEvolved = new Date().toISOString()
   userConfig._positionsAtEvolution = perfData.length
 
-  saveJsonFile(USER_CONFIG_PATH, userConfig)
+  saveJsonFile(targetConfigPath, userConfig)
 
   // Apply to live config object immediately
   const s = cfg.screening

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -84,12 +84,9 @@ export function formatNumber(n: number | null | undefined): string {
   return String(Math.round(n))
 }
 
-export function resolveEnvString(val: string): string | null {
-  if (!val.startsWith('env.')) return val
-  const envVar = val.slice(4)
-  const resolved = typeof process !== 'undefined' ? process.env?.[envVar] : undefined
-  return resolved !== undefined && resolved.trim() !== '' ? resolved.trim() : null
-}
+import { resolveEnvString } from '../config/schema.js'
+
+export { resolveEnvString }
 
 /**
  * Recursively resolves any string value starting with "env.VAR_NAME"


### PR DESCRIPTION
## Summary
Closes #273

Fixes a configuration corruption bug where `evolveThresholds` wrote screening parameter adjustments directly to the root of `user-config.json` instead of under `screening: { ... }`, causing strict Zod schema validation to fail on restart with `Unrecognized keys: "minFeeActiveTvlRatio", "_lastEvolved", "_positionsAtEvolution"`.

## Root Cause & Gap Analysis
1. `evolveThresholds` executed `Object.assign(userConfig, changes)` directly on `userConfig` root, placing screening fields (`minFeeActiveTvlRatio`, `minOrganic`) at the root level.
2. `UserConfigSchema` strictly rejects unrecognized keys (`.strict()`) but did not include runtime metadata keys `_lastEvolved`, `_positionsAtEvolution`, and `_lastAgentTune`.
3. `schema.ts` imported `resolveEnvString` from `utils.ts`, while `utils.ts` imported `logger.ts` -> `Config.ts` -> `ConfigValidator.ts` -> `schema.ts`, creating a circular dependency during early module evaluation.

## Key Changes
1. **`lessons.ts`**:
   - Write evolved thresholds to `userConfig.screening` (`Object.assign(userConfig.screening, changes)`).
   - Clean up legacy root-level keys (`minFeeActiveTvlRatio`, `minOrganic`) from the config file if present.
   - Accept optional `targetConfigPath: string = USER_CONFIG_PATH` for dependency injection and safe unit testing without mutating production configs.
2. **`schema.ts`**:
   - Add optional metadata fields `_lastEvolved?: z.string().optional()`, `_positionsAtEvolution?: z.number().optional()`, and `_lastAgentTune?: z.string().optional()` to `UserConfigSchema`.
   - Implement `resolveEnvString` directly in `schema.ts` and re-export from `utils.ts` to break circular dependency.
3. **`lessons.test.ts`**:
   - Added integration regression tests verifying that `evolveThresholds` updates `screening` fields on disk, purges legacy corrupted root keys, and produces a configuration that passes `UserConfigSchema.safeParse()`.

## Verification
- `npx vitest run packages/core/src/domain/lessons.test.ts`: passed (4/4 tests).
- `npx vitest run`: passed (35 test files, 424 tests).
- `pnpm run typecheck`: passed across all workspace projects.
