### PR TITLE
[Fix] portfolio intent: add get_position_pnl to tool set

### DIFF
--- a/packages/core/src/application/agent-loop.test.ts
+++ b/packages/core/src/application/agent-loop.test.ts
@@ -467,4 +467,35 @@ describe('agent-loop — portfolio intent routing & tools', () => {
     expect(tools?.has('get_meteora_positions')).toBe(true)
     expect(tools?.has('get_my_positions')).toBe(true)
   })
+
+  // Regression: issue #265 — portfolio-only query must include get_position_pnl
+  it('includes get_position_pnl in portfolio intent tools (issue #265)', () => {
+    const tools = INTENT_TOOLS.portfolio
+    expect(tools?.has('get_position_pnl')).toBe(true)
+  })
+
+  // Regression: issue #265 — set_position_note is a write tool and must NOT be in portfolio intent
+  it('excludes set_position_note from portfolio intent tools (issue #265)', () => {
+    const tools = INTENT_TOOLS.portfolio
+    expect(tools?.has('set_position_note')).toBe(false)
+  })
+
+  // Regression: issue #265 — union of portfolio + positions intents still works
+  it('portfolio+positions union query includes get_position_pnl via intent union', () => {
+    // "check my portfolio PnL" hits both portfolio (via "portfolio") and positions (via "pnl")
+    const goal = 'check my portfolio PnL'
+    const portfolioPattern = INTENT_PATTERNS.find((p) => p.intent === 'portfolio')
+    const positionsPattern = INTENT_PATTERNS.find((p) => p.intent === 'positions')
+    expect(portfolioPattern?.re.test(goal)).toBe(true)
+    expect(positionsPattern?.re.test(goal)).toBe(true)
+    // Both intents matched — union includes get_position_pnl from positions set
+    const matched = new Set<string>()
+    for (const { intent, re } of INTENT_PATTERNS) {
+      if (re.test(goal)) {
+        const tools = INTENT_TOOLS[intent]
+        if (tools) for (const t of tools) matched.add(t)
+      }
+    }
+    expect(matched.has('get_position_pnl')).toBe(true)
+  })
 })

--- a/packages/core/src/application/agent-loop.ts
+++ b/packages/core/src/application/agent-loop.ts
@@ -137,6 +137,7 @@ export const INTENT_TOOLS: Record<string, Set<string>> = {
     'get_wallet_balance',
     'get_meteora_positions',
     'get_my_positions',
+    'get_position_pnl',
     'get_pending_liquidations',
   ]),
   balance: new Set([


### PR DESCRIPTION
## Summary

Portfolio-only queries (e.g. `show my portfolio`, `what's in my portfolio`) lost access to `get_position_pnl` after PR #263 split `portfolio` from the `positions` intent regex. P&L data is fundamental to any meaningful portfolio view, so `get_position_pnl` should be in the `portfolio` tool set.

Closes #265

## Root Cause & Gap Analysis
- **Why/When it happened**: PR #263 added a dedicated `portfolio` intent (correct separation of concerns) but did not carry `get_position_pnl` across from the old `positions` set. A query hitting only `portfolio` intent (no positions keyword) no longer received `get_position_pnl`.
- **Why we missed it**: The existing portfolio-intent test only checked `get_portfolio_summary`, `get_wallet_balance`, `get_meteora_positions`, `get_my_positions` — it did not assert on `get_position_pnl`.

## Decision
- ✅ `get_position_pnl` added to `portfolio` — P&L is essential for any portfolio view
- ❌ `set_position_note` NOT added — write tool, no justification for a read-style query

## Acceptance Criteria Checklist
- [x] AC1: `show my portfolio` → `get_position_pnl` included
- [x] AC2: `show my portfolio` → `set_position_note` NOT included
- [x] AC3: Union query `check my portfolio PnL` still works
- [x] AC4: Regression tests added (3 new tests in `agent-loop.test.ts`)
- [x] AC5: All 427 tests pass, no new lint/type errors

## Testing Plan
- [x] **Unit: INTENT_TOOLS.portfolio has get_position_pnl** — ✅ new regression test
- [x] **Unit: INTENT_TOOLS.portfolio lacks set_position_note** — ✅ new regression test
- [x] **Unit: portfolio+positions union** — ✅ new regression test
- [x] **CI: Full test suite** — 427/427 green